### PR TITLE
Set initial window size to screen's visual bounds

### DIFF
--- a/src/main/java/edu/wpi/first/shuffleboard/Shuffleboard.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/Shuffleboard.java
@@ -8,9 +8,11 @@ import java.io.IOException;
 
 import javafx.application.Application;
 import javafx.fxml.FXMLLoader;
+import javafx.geometry.Rectangle2D;
 import javafx.scene.Scene;
 import javafx.scene.layout.Pane;
 import javafx.scene.text.Font;
+import javafx.stage.Screen;
 import javafx.stage.Stage;
 
 @SuppressWarnings("JavadocMethod")
@@ -40,6 +42,11 @@ public class Shuffleboard extends Application {
   @Override
   public void start(Stage primaryStage) throws IOException {
     primaryStage.setScene(new Scene(mainPane));
+    Rectangle2D primaryScreenBounds = Screen.getPrimary().getVisualBounds();
+    primaryStage.setX(primaryScreenBounds.getMinX());
+    primaryStage.setY(primaryScreenBounds.getMinY());
+    primaryStage.setWidth(primaryScreenBounds.getWidth());
+    primaryStage.setHeight(primaryScreenBounds.getHeight());
     primaryStage.show();
   }
 

--- a/src/main/resources/edu/wpi/first/shuffleboard/MainWindow.fxml
+++ b/src/main/resources/edu/wpi/first/shuffleboard/MainWindow.fxml
@@ -9,7 +9,7 @@
 <?import javafx.scene.control.TabPane?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.control.SeparatorMenuItem?>
-<BorderPane fx:id="root" maxHeight="Infinity" maxWidth="Infinity"
+<BorderPane fx:id="root"
             xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1"
             fx:controller="edu.wpi.first.shuffleboard.MainWindowController">
 


### PR DESCRIPTION
This prevents my computer's task bar from covering the window decorations and
tab list.