### PR TITLE
Refactor Widget class tree, add VoltageView Widget

### DIFF
--- a/src/main/java/edu/wpi/first/shuffleboard/DummySource.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/DummySource.java
@@ -43,6 +43,9 @@ public class DummySource<T> extends AbstractDataSource<T> {
     } else if (types.contains(DataTypes.SendableChooser)) {
       final SendableChooserData data = new SendableChooserData(new String[]{"A", "B", "C"}, "A", "A");
       return Optional.of(new DummySource(DataTypes.SendableChooser, data));
+    } else if (types.stream().anyMatch(DataType::isComplex)) {
+      DataType type = types.stream().filter(DataType::isComplex).findFirst().get();
+      return Optional.of(new DummySource(type, type.getDefaultValue()));
     } else {
       return Optional.empty();
     }

--- a/src/main/java/edu/wpi/first/shuffleboard/WidgetTileController.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/WidgetTileController.java
@@ -2,14 +2,12 @@ package edu.wpi.first.shuffleboard;
 
 import edu.wpi.first.shuffleboard.components.WidgetTile;
 import edu.wpi.first.shuffleboard.sources.DataSource;
-import edu.wpi.first.shuffleboard.util.PropertyUtils;
 import edu.wpi.first.shuffleboard.widget.Widget;
 import edu.wpi.first.shuffleboard.widget.WidgetPropertySheet;
 
 import org.fxmisc.easybind.EasyBind;
 
 import javafx.beans.binding.Bindings;
-import javafx.beans.property.Property;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.Label;

--- a/src/main/java/edu/wpi/first/shuffleboard/WidgetTileController.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/WidgetTileController.java
@@ -1,11 +1,15 @@
 package edu.wpi.first.shuffleboard;
 
 import edu.wpi.first.shuffleboard.components.WidgetTile;
+import edu.wpi.first.shuffleboard.sources.DataSource;
 import edu.wpi.first.shuffleboard.util.PropertyUtils;
 import edu.wpi.first.shuffleboard.widget.Widget;
 import edu.wpi.first.shuffleboard.widget.WidgetPropertySheet;
 
+import org.fxmisc.easybind.EasyBind;
+
 import javafx.beans.binding.Bindings;
+import javafx.beans.property.Property;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
@@ -21,10 +25,10 @@ public class WidgetTileController {
   @FXML
   private void initialize() {
     tile.addEventHandler(MouseEvent.MOUSE_CLICKED, this::changeView);
-    PropertyUtils.bindWithConverter(
-        titleLabel.textProperty(),
-        tile.widgetProperty(),
-        w -> w.getSource().getName());
+    titleLabel.textProperty().bind(
+        EasyBind.monadic(tile.widgetProperty())
+            .selectProperty(Widget::sourceProperty)
+            .selectProperty(DataSource::nameProperty));
     tile.centerProperty().bind(
         Bindings.createObjectBinding(
             this::createCenter, tile.widgetProperty(), tile.showWidgetProperty()));

--- a/src/main/java/edu/wpi/first/shuffleboard/components/LinearIndicator.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/components/LinearIndicator.java
@@ -1,0 +1,40 @@
+package edu.wpi.first.shuffleboard.components;
+
+import org.controlsfx.control.RangeSlider;
+
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.css.PseudoClass;
+
+public class LinearIndicator extends RangeSlider {
+
+  private final DoubleProperty value = new SimpleDoubleProperty(this, "value", 0);
+
+  public LinearIndicator() {
+    getStyleClass().add("linear-indicator");
+    value.addListener((__, prev, cur) -> {
+      double v = cur.doubleValue();
+      if (v < 0) {
+        setLowValue(v);
+        setHighValue(0);
+      } else {
+        setLowValue(0);
+        setHighValue(v);
+      }
+    });
+    setDisable(true);
+    pseudoClassStateChanged(PseudoClass.getPseudoClass("disabled"), false);
+  }
+
+  public double getValue() {
+    return value.get();
+  }
+
+  public DoubleProperty valueProperty() {
+    return value;
+  }
+
+  public void setValue(double value) {
+    this.value.set(value);
+  }
+}

--- a/src/main/java/edu/wpi/first/shuffleboard/components/LinearIndicator.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/components/LinearIndicator.java
@@ -10,16 +10,17 @@ public class LinearIndicator extends RangeSlider {
 
   private final DoubleProperty value = new SimpleDoubleProperty(this, "value", 0);
 
+  @SuppressWarnings("JavadocMethod")
   public LinearIndicator() {
     getStyleClass().add("linear-indicator");
     value.addListener((__, prev, cur) -> {
-      double v = cur.doubleValue();
-      if (v < 0) {
-        setLowValue(v);
+      double currentValue = cur.doubleValue();
+      if (currentValue < 0) {
+        setLowValue(currentValue);
         setHighValue(0);
       } else {
         setLowValue(0);
-        setHighValue(v);
+        setHighValue(currentValue);
       }
     });
     setDisable(true);

--- a/src/main/java/edu/wpi/first/shuffleboard/components/LinearIndicator.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/components/LinearIndicator.java
@@ -9,22 +9,30 @@ import javafx.css.PseudoClass;
 public class LinearIndicator extends RangeSlider {
 
   private final DoubleProperty value = new SimpleDoubleProperty(this, "value", 0);
+  private final DoubleProperty center = new SimpleDoubleProperty(this, "center", 0);
 
   @SuppressWarnings("JavadocMethod")
   public LinearIndicator() {
     getStyleClass().add("linear-indicator");
-    value.addListener((__, prev, cur) -> {
-      double currentValue = cur.doubleValue();
-      if (currentValue < 0) {
-        setLowValue(currentValue);
-        setHighValue(0);
-      } else {
-        setLowValue(0);
-        setHighValue(currentValue);
-      }
-    });
+    value.addListener(__ -> setRangeBounds());
+    center.addListener(__ -> setRangeBounds());
     setDisable(true);
     pseudoClassStateChanged(PseudoClass.getPseudoClass("disabled"), false);
+  }
+
+  /**
+   * Sets the low and high values as necessary based on changes to the current value or center properties.
+   */
+  private void setRangeBounds() {
+    double currentValue = getValue();
+    double center = getCenter();
+    if (currentValue < center) {
+      setLowValue(currentValue);
+      setHighValue(center);
+    } else {
+      setLowValue(center);
+      setHighValue(currentValue);
+    }
   }
 
   public double getValue() {
@@ -37,5 +45,17 @@ public class LinearIndicator extends RangeSlider {
 
   public void setValue(double value) {
     this.value.set(value);
+  }
+
+  public double getCenter() {
+    return center.get();
+  }
+
+  public DoubleProperty centerProperty() {
+    return center;
+  }
+
+  public void setCenter(double center) {
+    this.center.set(center);
   }
 }

--- a/src/main/java/edu/wpi/first/shuffleboard/components/WidgetTile.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/components/WidgetTile.java
@@ -34,7 +34,7 @@ public class WidgetTile extends BorderPane {
       FXMLLoader loader = new FXMLLoader(WidgetTile.class.getResource("WidgetTile.fxml"));
       loader.setRoot(this);
       loader.load();
-      getStyleClass().add("tile");
+      getStyleClass().addAll("tile", "card");
       PropertyUtils.bindWithConverter(idProperty(), widget, w -> "widget-tile[" + w + "]");
     } catch (IOException e) {
       throw new RuntimeException("Could not load the widget tile FXML", e);

--- a/src/main/java/edu/wpi/first/shuffleboard/data/AnalogInputData.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/data/AnalogInputData.java
@@ -1,0 +1,15 @@
+package edu.wpi.first.shuffleboard.data;
+
+import java.util.Map;
+
+public class AnalogInputData extends NamedData<Double> {
+
+  public AnalogInputData(String name, double value) {
+    super(name, value);
+  }
+
+  public AnalogInputData(Map<String, Object> map) {
+    this((String) map.getOrDefault("Name", "?"), (double) map.getOrDefault("Value", 0.0));
+  }
+
+}

--- a/src/main/java/edu/wpi/first/shuffleboard/data/DataTypes.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/data/DataTypes.java
@@ -1,6 +1,7 @@
 package edu.wpi.first.shuffleboard.data;
 
 import edu.wpi.first.shuffleboard.data.types.AllType;
+import edu.wpi.first.shuffleboard.data.types.AnalogInputType;
 import edu.wpi.first.shuffleboard.data.types.BooleanArrayType;
 import edu.wpi.first.shuffleboard.data.types.BooleanType;
 import edu.wpi.first.shuffleboard.data.types.MapType;
@@ -39,6 +40,7 @@ public final class DataTypes {
   // Complex types
   public static final ComplexDataType<MapData> Map = new MapType();
   public static final ComplexDataType<SendableChooserData> SendableChooser = new SendableChooserType();
+  public static final ComplexDataType<AnalogInputData> AnalogInput = new AnalogInputType();
 
   private static final Map<String, DataType> dataTypes = new TreeMap<>();
 
@@ -55,6 +57,7 @@ public final class DataTypes {
     register(BooleanArray);
     register(Map);
     register(SendableChooser);
+    register(AnalogInput);
   }
 
   private DataTypes() {

--- a/src/main/java/edu/wpi/first/shuffleboard/data/NamedData.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/data/NamedData.java
@@ -1,0 +1,34 @@
+package edu.wpi.first.shuffleboard.data;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Map;
+
+public abstract class NamedData<T> extends ComplexData<NamedData<T>> {
+
+  private final String name;
+  private final T value;
+
+  protected NamedData(String name, T value) {
+    this.name = name;
+    this.value = value;
+  }
+
+  @Override
+  public Map<String, Object> asMap() {
+    return ImmutableMap.of("Name", name, "Value", value);
+  }
+
+  public final String getName() {
+    return name;
+  }
+
+  public final T getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s(name=%s, value=%s)", getClass().getSimpleName(), name, value);
+  }
+}

--- a/src/main/java/edu/wpi/first/shuffleboard/data/types/AnalogInputType.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/data/types/AnalogInputType.java
@@ -1,0 +1,26 @@
+package edu.wpi.first.shuffleboard.data.types;
+
+import edu.wpi.first.shuffleboard.data.AnalogInputData;
+import edu.wpi.first.shuffleboard.data.ComplexDataType;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public class AnalogInputType implements ComplexDataType<AnalogInputData> {
+
+  @Override
+  public Function<Map<String, Object>, AnalogInputData> fromMap() {
+    return AnalogInputData::new;
+  }
+
+  @Override
+  public String getName() {
+    return "Analog Input";
+  }
+
+  @Override
+  public AnalogInputData getDefaultValue() {
+    return new AnalogInputData("example", 0);
+  }
+
+}

--- a/src/main/java/edu/wpi/first/shuffleboard/sources/AbstractDataSource.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/sources/AbstractDataSource.java
@@ -7,6 +7,7 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 import javafx.beans.value.ObservableValue;
 
 import static java.util.Objects.requireNonNull;
@@ -19,7 +20,7 @@ import static java.util.Objects.requireNonNull;
  */
 public abstract class AbstractDataSource<T> implements DataSource<T> {
 
-  protected final Property<String> name = new SimpleStringProperty(this, "name", "");
+  protected final StringProperty name = new SimpleStringProperty(this, "name", "");
   protected final Property<Boolean> active = new SimpleBooleanProperty(this, "active", false);
   protected final Property<T> data = new AsyncProperty<>(this, "data", null);
   protected final BooleanProperty connected = new SimpleBooleanProperty(this, "connected", false);
@@ -30,7 +31,7 @@ public abstract class AbstractDataSource<T> implements DataSource<T> {
   }
 
   @Override
-  public ObservableValue<String> nameProperty() {
+  public StringProperty nameProperty() {
     return name;
   }
 

--- a/src/main/java/edu/wpi/first/shuffleboard/sources/DataSource.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/sources/DataSource.java
@@ -2,6 +2,7 @@ package edu.wpi.first.shuffleboard.sources;
 
 import edu.wpi.first.shuffleboard.data.DataType;
 import javafx.beans.property.Property;
+import javafx.beans.property.StringProperty;
 import javafx.beans.value.ObservableValue;
 
 /**
@@ -35,7 +36,7 @@ public interface DataSource<T> {
     return activeProperty().getValue();
   }
 
-  ObservableValue<String> nameProperty();
+  StringProperty nameProperty();
 
   /**
    * Gets the name of this data source. This is typically a unique identifier for the data

--- a/src/main/java/edu/wpi/first/shuffleboard/util/UnitStringConverter.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/util/UnitStringConverter.java
@@ -1,0 +1,37 @@
+package edu.wpi.first.shuffleboard.util;
+
+import javafx.util.StringConverter;
+
+/**
+ * A string converter that converts numbers to formatted unit strings. The unit strings are appended to the number
+ * text; for example, "12 Meters" or "-23.25 Volts". There is always a space between the number and the unit, and
+ * either 2 decimal points ("X.XX") or none, if the number is an integer value.
+ */
+public class UnitStringConverter extends StringConverter<Number> {
+
+  private final String unit;
+
+  /**
+   * Creates a new converter that uses the given unit string.
+   *
+   * @param unit the unit string to use, such as "Volts" or "Feet"
+   */
+  public UnitStringConverter(String unit) {
+    this.unit = unit;
+  }
+
+  @Override
+  public String toString(Number number) {
+    if ((double) number.longValue() == number.doubleValue()) {
+      // It's an integer value, don't show decimal point
+      return String.format("%d %s", number.longValue(), unit);
+    }
+    return String.format("%.2f %s", number.doubleValue(), unit);
+  }
+
+  @Override
+  public Double fromString(String string) {
+    return Double.valueOf(string.substring(0, string.length() - (unit.length() + 1)));
+  }
+
+}

--- a/src/main/java/edu/wpi/first/shuffleboard/widget/AbstractWidget.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/widget/AbstractWidget.java
@@ -1,0 +1,62 @@
+package edu.wpi.first.shuffleboard.widget;
+
+import edu.wpi.first.shuffleboard.sources.DataSource;
+import edu.wpi.first.shuffleboard.sources.IncompatibleSourceException;
+
+import javafx.beans.property.Property;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+
+/**
+ * A partial implementation of {@link Widget} that implements the source and property methods. This also has a method
+ * {@link #exportProperties(Property[]) exportProperties} that allows subclasses to easily add properties.
+ */
+public abstract class AbstractWidget implements Widget {
+
+  protected final Property<DataSource> source
+      = new SimpleObjectProperty<>(this, "source", DataSource.none());
+  private final ObservableList<Property<?>> properties = FXCollections.observableArrayList();
+
+  /**
+   * Exports the given properties so other parts of the app can see the properties of this widget.
+   * Not all properties need to (or should be) exported; it should only properties that can be
+   * user-configurable. If possible, the view for this widget will allow users to modify the value
+   * of each property. For example, a "Number Slider" widget with a slider could have the minimum
+   * and maximum values of that slider be configurable by the user.
+   *
+   * @param properties the properties to export
+   */
+  protected final void exportProperties(Property<?>... properties) {
+    for (Property<?> property : properties) {
+      if (!this.properties.contains(property)) {
+        this.properties.add(property);
+      }
+    }
+  }
+
+  @Override
+  public final ObservableList<Property<?>> getProperties() {
+    return properties;
+  }
+
+  @Override
+  public Property<DataSource> sourceProperty() {
+    return source;
+  }
+
+  @Override
+  public final DataSource getSource() {
+    return source.getValue();
+  }
+
+  @Override
+  public final void setSource(DataSource source) throws IncompatibleSourceException {
+    if (getDataTypes().contains(source.getDataType())) {
+      this.source.setValue(source);
+    } else {
+      throw new IncompatibleSourceException(getDataTypes(), source.getDataType());
+    }
+  }
+
+}

--- a/src/main/java/edu/wpi/first/shuffleboard/widget/AnnotatedWidget.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/widget/AnnotatedWidget.java
@@ -1,0 +1,33 @@
+package edu.wpi.first.shuffleboard.widget;
+
+import edu.wpi.first.shuffleboard.data.DataType;
+import edu.wpi.first.shuffleboard.data.DataTypes;
+
+import java.util.Set;
+
+/**
+ * A type of widget that has its name and data types set with a {@link Description} annotation on the class. Widget
+ * classes that are also FXML controllers should specify the FXML file with a {@link ParametrizedController} annotation.
+ */
+public abstract class AnnotatedWidget extends AbstractWidget {
+
+  private Description description = getClass().getAnnotation(Description.class);
+
+  @Override
+  public final String getName() {
+    return getDescription().name();
+  }
+
+  @Override
+  public final Set<DataType> getDataTypes() {
+    return DataTypes.forTypes(getDescription().dataTypes());
+  }
+
+  private Description getDescription() {
+    if (description == null) {
+      description = getClass().getAnnotation(Description.class);
+    }
+    return description;
+  }
+
+}

--- a/src/main/java/edu/wpi/first/shuffleboard/widget/SimpleAnnotatedWidget.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/widget/SimpleAnnotatedWidget.java
@@ -1,28 +1,15 @@
 package edu.wpi.first.shuffleboard.widget;
 
-import com.google.common.collect.ImmutableList;
-
-import edu.wpi.first.shuffleboard.data.DataType;
-import edu.wpi.first.shuffleboard.data.DataTypes;
 import edu.wpi.first.shuffleboard.sources.DataSource;
-import edu.wpi.first.shuffleboard.sources.IncompatibleSourceException;
 
 import org.fxmisc.easybind.EasyBind;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-
 import javafx.beans.property.Property;
-import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
-public abstract class SimpleAnnotatedWidget<T> implements Widget {
-
-  protected final SimpleObjectProperty<DataSource<T>> source
-      = new SimpleObjectProperty<>(DataSource.none());
+public abstract class SimpleAnnotatedWidget<T> extends AnnotatedWidget implements SingleTypeWidget<T> {
 
   /**
    * The property for this widgets data. This is the preferred way to get the current value of the
@@ -33,55 +20,15 @@ public abstract class SimpleAnnotatedWidget<T> implements Widget {
 
   private final Property<String> sourceName = new SimpleStringProperty(this, "sourceName", "");
   private final ObservableList<Property<?>> properties = FXCollections.observableArrayList();
-  protected final Description description = getClass().getAnnotation(Description.class);
 
   // Getters and setters
 
-  @Override
-  public final String getName() {
-    return description.name();
+  public Property<DataSource> sourceProperty() {
+    return (Property) source;
   }
 
-  @Override
-  public final Set<DataType> getDataTypes() {
-    return DataTypes.forTypes(description.dataTypes());
-  }
-
-  /**
-   * Gets the data source that this widget backs. The source is automatically set when the
-   * widget is created.
-   */
-  @Override
-  public final DataSource<T> getSource() {
-    return source.get();
-  }
-
-  /**
-   * Bind a source to a widget.
-   */
-  public final void setSource(DataSource source) throws IncompatibleSourceException {
-    Objects.requireNonNull(source, "A widget must have a source");
-    if (!getDataTypes().contains(source.getDataType())) {
-      throw new IncompatibleSourceException(getDataTypes(), source.getDataType());
-    }
-    this.source.set(source);
-    sourceName.setValue(source.getName());
-  }
-
-  public Property<DataSource<T>> sourceProperty() {
-    return source;
-  }
-
-  protected final Property<T> dataProperty() {
+  public final Property<T> dataProperty() {
     return data;
-  }
-
-  protected final T getData() {
-    return data.getValue();
-  }
-
-  protected final void setData(T data) {
-    this.data.setValue(data);
   }
 
   public final String getSourceName() {
@@ -90,22 +37,6 @@ public abstract class SimpleAnnotatedWidget<T> implements Widget {
 
   public final Property<String> sourceNameProperty() {
     return sourceName;
-  }
-
-  /**
-   * Exports the given properties so other parts of the app can see the properties of this widget.
-   * Not all properties need to (or should be) exported; it should only properties that can be
-   * user-configurable. If possible, the view for this widget will allow users to modify the value
-   * of each property. For example, a "Number Slider" widget with a slider could have the minimum
-   * and maximum values of that slider be configurable by the user.
-   */
-  protected void exportProperties(Property<?>... properties) {
-    this.properties.setAll(properties);
-  }
-
-  @Override
-  public List<Property<?>> getProperties() {
-    return ImmutableList.copyOf(properties);
   }
 
 }

--- a/src/main/java/edu/wpi/first/shuffleboard/widget/SingleTypeWidget.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/widget/SingleTypeWidget.java
@@ -1,0 +1,34 @@
+package edu.wpi.first.shuffleboard.widget;
+
+import edu.wpi.first.shuffleboard.sources.DataSource;
+
+import javafx.beans.property.Property;
+
+public interface SingleTypeWidget<T> extends Widget {
+
+  /**
+   * Gets a property containing the value of the source. This is used for brevity and is a shortcut for
+   * {@code EasyBind.monadic(sourceProperty()).selectProperty(DataSource::dataProperty)}
+   */
+  Property<T> dataProperty();
+
+  /**
+   * Gets the current value of the data source.
+   */
+  default T getData() {
+    return dataProperty().getValue();
+  }
+
+  /**
+   * Sets the current value of the data source.
+   */
+  default void setData(T data) {
+    dataProperty().setValue(data);
+  }
+
+  @Override
+  default DataSource<T> getSource() {
+    return sourceProperty().getValue();
+  }
+
+}

--- a/src/main/java/edu/wpi/first/shuffleboard/widget/StockWidgets.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/widget/StockWidgets.java
@@ -23,7 +23,7 @@ public final class StockWidgets {
                .stream()
                .filter(ci -> ci.getPackageName().startsWith("edu.wpi.first.shuffleboard"))
                .map(ClassPath.ClassInfo::load)
-               .filter(SimpleAnnotatedWidget.class::isAssignableFrom)
+               .filter(AnnotatedWidget.class::isAssignableFrom)
                .map(c -> (Class<Widget>) c)
                .filter(c -> c.isAnnotationPresent(Description.class))
                .forEach(Widgets::register);

--- a/src/main/java/edu/wpi/first/shuffleboard/widget/VoltageViewWidget.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/widget/VoltageViewWidget.java
@@ -5,6 +5,7 @@ import edu.wpi.first.shuffleboard.data.AnalogInputData;
 import edu.wpi.first.shuffleboard.data.types.AnalogInputType;
 import edu.wpi.first.shuffleboard.data.types.NumberType;
 import edu.wpi.first.shuffleboard.sources.DataSource;
+import edu.wpi.first.shuffleboard.util.UnitStringConverter;
 
 import org.fxmisc.easybind.EasyBind;
 
@@ -58,6 +59,7 @@ public class VoltageViewWidget extends AnnotatedWidget {
                 return max.doubleValue() - min.doubleValue();
               }
             }));
+    indicator.setLabelFormatter(new UnitStringConverter("V")); // "Volts" is too long and causes clipping issues
     exportProperties(indicator.minProperty(), indicator.maxProperty(), indicator.centerProperty(),
         indicator.orientationProperty(), numTicks);
   }
@@ -66,4 +68,5 @@ public class VoltageViewWidget extends AnnotatedWidget {
   public Pane getView() {
     return root;
   }
+
 }

--- a/src/main/java/edu/wpi/first/shuffleboard/widget/VoltageViewWidget.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/widget/VoltageViewWidget.java
@@ -45,7 +45,7 @@ public class VoltageViewWidget extends AnnotatedWidget {
           }
           return value;
         }));
-    exportProperties(indicator.minProperty(), indicator.maxProperty());
+    exportProperties(indicator.minProperty(), indicator.maxProperty(), indicator.orientationProperty());
   }
 
   @Override

--- a/src/main/java/edu/wpi/first/shuffleboard/widget/VoltageViewWidget.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/widget/VoltageViewWidget.java
@@ -10,6 +10,8 @@ import org.fxmisc.easybind.EasyBind;
 
 import java.util.logging.Logger;
 
+import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.SimpleDoubleProperty;
 import javafx.fxml.FXML;
 import javafx.scene.layout.Pane;
 
@@ -23,6 +25,8 @@ public class VoltageViewWidget extends AnnotatedWidget {
   private Pane root;
   @FXML
   private LinearIndicator indicator;
+
+  private final DoubleProperty numTicks = new SimpleDoubleProperty(this, "numTickMarks", 5);
 
   @FXML
   private void initialize() {
@@ -45,7 +49,17 @@ public class VoltageViewWidget extends AnnotatedWidget {
           }
           return value;
         }));
-    exportProperties(indicator.minProperty(), indicator.maxProperty(), indicator.orientationProperty());
+    indicator.majorTickUnitProperty().bind(
+        EasyBind.combine(indicator.minProperty(), indicator.maxProperty(), numTicks,
+            (min, max, numTicks) -> {
+              if (numTicks.intValue() > 1) {
+                return (max.doubleValue() - min.doubleValue()) / (numTicks.intValue() - 1);
+              } else {
+                return max.doubleValue() - min.doubleValue();
+              }
+            }));
+    exportProperties(indicator.minProperty(), indicator.maxProperty(), indicator.centerProperty(),
+        indicator.orientationProperty(), numTicks);
   }
 
   @Override

--- a/src/main/java/edu/wpi/first/shuffleboard/widget/VoltageViewWidget.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/widget/VoltageViewWidget.java
@@ -1,0 +1,54 @@
+package edu.wpi.first.shuffleboard.widget;
+
+import edu.wpi.first.shuffleboard.components.LinearIndicator;
+import edu.wpi.first.shuffleboard.data.AnalogInputData;
+import edu.wpi.first.shuffleboard.data.types.AnalogInputType;
+import edu.wpi.first.shuffleboard.data.types.NumberType;
+import edu.wpi.first.shuffleboard.sources.DataSource;
+
+import org.fxmisc.easybind.EasyBind;
+import org.fxmisc.easybind.monadic.MonadicBinding;
+
+import javafx.fxml.FXML;
+import javafx.scene.layout.Pane;
+
+@Description(name = "Voltage View", dataTypes = {NumberType.class, AnalogInputType.class})
+@ParametrizedController("VoltageView.fxml")
+public class VoltageViewWidget extends AnnotatedWidget {
+
+  @FXML
+  private Pane root;
+  @FXML
+  private LinearIndicator indicator;
+
+  @FXML
+  private void initialize() {
+    MonadicBinding<Double> v = EasyBind.combine(
+        EasyBind.monadic(sourceProperty()).selectProperty(DataSource::dataProperty),
+        indicator.minProperty(),
+        indicator.maxProperty(),
+        (data, min, max) -> {
+          if (!getSource().isActive()) {
+            return min.doubleValue();
+          }
+          double value;
+          if (data instanceof Number) {
+            value = ((Number) data).doubleValue();
+          } else if (data instanceof AnalogInputData) {
+            value = ((AnalogInputData) data).getValue();
+          } else {
+            value = 0;
+            System.err.println("Unexpected data: " + data + " (Source: " + getSource() + ")");
+          }
+          return value;
+        });
+
+    indicator.valueProperty().bind(v);
+    exportProperties(indicator.minProperty(), indicator.maxProperty());
+  }
+
+  @Override
+  public Pane getView() {
+    return root;
+  }
+}

--- a/src/main/java/edu/wpi/first/shuffleboard/widget/VoltageViewWidget.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/widget/VoltageViewWidget.java
@@ -7,7 +7,8 @@ import edu.wpi.first.shuffleboard.data.types.NumberType;
 import edu.wpi.first.shuffleboard.sources.DataSource;
 
 import org.fxmisc.easybind.EasyBind;
-import org.fxmisc.easybind.monadic.MonadicBinding;
+
+import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
 import javafx.scene.layout.Pane;
@@ -16,6 +17,8 @@ import javafx.scene.layout.Pane;
 @ParametrizedController("VoltageView.fxml")
 public class VoltageViewWidget extends AnnotatedWidget {
 
+  private static final Logger log = Logger.getLogger(VoltageViewWidget.class.getName());
+
   @FXML
   private Pane root;
   @FXML
@@ -23,7 +26,7 @@ public class VoltageViewWidget extends AnnotatedWidget {
 
   @FXML
   private void initialize() {
-    MonadicBinding<Double> v = EasyBind.combine(
+    indicator.valueProperty().bind(EasyBind.combine(
         EasyBind.monadic(sourceProperty()).selectProperty(DataSource::dataProperty),
         indicator.minProperty(),
         indicator.maxProperty(),
@@ -38,12 +41,10 @@ public class VoltageViewWidget extends AnnotatedWidget {
             value = ((AnalogInputData) data).getValue();
           } else {
             value = 0;
-            System.err.println("Unexpected data: " + data + " (Source: " + getSource() + ")");
+            log.warning("Unexpected data: " + data + " (Source: " + getSource() + ")"); // NOPMD
           }
           return value;
-        });
-
-    indicator.valueProperty().bind(v);
+        }));
     exportProperties(indicator.minProperty(), indicator.maxProperty());
   }
 

--- a/src/main/java/edu/wpi/first/shuffleboard/widget/Widget.java
+++ b/src/main/java/edu/wpi/first/shuffleboard/widget/Widget.java
@@ -3,12 +3,13 @@ package edu.wpi.first.shuffleboard.widget;
 import edu.wpi.first.shuffleboard.data.DataType;
 import edu.wpi.first.shuffleboard.sources.DataSource;
 import edu.wpi.first.shuffleboard.sources.IncompatibleSourceException;
-import javafx.beans.property.Property;
-import javafx.collections.ObservableMap;
-import javafx.scene.layout.Pane;
 
 import java.util.List;
 import java.util.Set;
+
+import javafx.beans.property.Property;
+import javafx.collections.ObservableMap;
+import javafx.scene.layout.Pane;
 
 /**
  * A widget is a UI element that displays data from a {@link DataSource} and has the ability to
@@ -63,10 +64,25 @@ public interface Widget {
    */
   Set<DataType> getDataTypes();
 
+  /**
+   * Sets the source for this widget.
+   *
+   * @param source the new source
+   *
+   * @throws IncompatibleSourceException if the source is for a data type this widget does not support
+   */
   void setSource(DataSource source) throws IncompatibleSourceException;
 
+  /**
+   * Gets the source for this widget.
+   */
   DataSource<?> getSource();
 
+  Property<DataSource> sourceProperty();
+
+  /**
+   * Gets the user-configurable properties for this widget.
+   */
   List<Property<?>> getProperties();
 
 }

--- a/src/main/resources/edu/wpi/first/shuffleboard/base.css
+++ b/src/main/resources/edu/wpi/first/shuffleboard/base.css
@@ -150,12 +150,12 @@
  *                                                                             *
  ******************************************************************************/
 .linear-indicator .track {
-    -fx-pref-height: 4em;
+    -fx-pref-height: 1em;
     -fx-background-color: -swatch-light-gray;
 }
 
 .linear-indicator:vertical .track {
-    -fx-pref-width: 4em;
+    -fx-pref-width: 1em;
 }
 
 .linear-indicator .low-thumb, .linear-indicator .high-thumb {
@@ -169,5 +169,9 @@
 }
 
 .voltage-view .range-bar {
-    -fx-background-color: gold;
+    -fx-background-color: linear-gradient(to bottom, gold, derive(gold, -10%));
+}
+
+.voltage-view:vertical .range-bar {
+    -fx-background-color: linear-gradient(to right, gold, derive(gold, -10%));
 }

--- a/src/main/resources/edu/wpi/first/shuffleboard/base.css
+++ b/src/main/resources/edu/wpi/first/shuffleboard/base.css
@@ -149,12 +149,13 @@
  * Linear indicator                                                            *
  *                                                                             *
  ******************************************************************************/
-.linear-indicator-control {
-}
-
 .linear-indicator .track {
     -fx-pref-height: 4em;
     -fx-background-color: -swatch-light-gray;
+}
+
+.linear-indicator:vertical .track {
+    -fx-pref-width: 4em;
 }
 
 .linear-indicator .low-thumb, .linear-indicator .high-thumb {
@@ -166,5 +167,5 @@
 }
 
 .voltage-view .range-bar {
-    -fx-background-color: linear-gradient(to bottom, gold, goldenrod);
+    -fx-background-color: gold;
 }

--- a/src/main/resources/edu/wpi/first/shuffleboard/base.css
+++ b/src/main/resources/edu/wpi/first/shuffleboard/base.css
@@ -5,7 +5,6 @@
  * through all themes (like the tile highlight) or use CSS variables to make   *
  * them easy to reskin.                                                        *
  ******************************************************************************/
-
 @import "material.css";
 
 /*******************************************************************************
@@ -143,4 +142,29 @@
  ******************************************************************************/
 .slider .track, .range-slider .track {
     -fx-background-color: -swatch-300;
+}
+
+/*******************************************************************************
+ *                                                                             *
+ * Linear indicator                                                            *
+ *                                                                             *
+ ******************************************************************************/
+.linear-indicator-control {
+}
+
+.linear-indicator .track {
+    -fx-pref-height: 4em;
+    -fx-background-color: -swatch-light-gray;
+}
+
+.linear-indicator .low-thumb, .linear-indicator .high-thumb {
+    -fx-background-radius: 0;
+    -fx-border-radius: 0;
+    -fx-border-width: 0;
+    -fx-border-color: transparent;
+    -fx-background-color: transparent;
+}
+
+.voltage-view .range-bar {
+    -fx-background-color: linear-gradient(to bottom, gold, goldenrod);
 }

--- a/src/main/resources/edu/wpi/first/shuffleboard/base.css
+++ b/src/main/resources/edu/wpi/first/shuffleboard/base.css
@@ -163,6 +163,8 @@
     -fx-border-radius: 0;
     -fx-border-width: 0;
     -fx-border-color: transparent;
+    -fx-pref-width: 0;
+    -fx-pref-height: 0;
     -fx-background-color: transparent;
 }
 

--- a/src/main/resources/edu/wpi/first/shuffleboard/light.css
+++ b/src/main/resources/edu/wpi/first/shuffleboard/light.css
@@ -41,10 +41,6 @@
  * Tiles                                                                       *
  *                                                                             *
  ******************************************************************************/
-.tile {
-    -fx-background-color: -swatch-100;
-}
-
 .tile:selected {
     -fx-effect: dropshadow(gaussian, -swatch-500, 6, 0.1, 0, 4);
 }

--- a/src/main/resources/edu/wpi/first/shuffleboard/widget/VoltageView.fxml
+++ b/src/main/resources/edu/wpi/first/shuffleboard/widget/VoltageView.fxml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.layout.StackPane?>
+<?import edu.wpi.first.shuffleboard.components.LinearIndicator?>
+<StackPane xmlns="http://javafx.com/javafx"
+           xmlns:fx="http://javafx.com/fxml"
+           fx:controller="edu.wpi.first.shuffleboard.widget.VoltageViewWidget"
+           fx:id="root">
+    <padding>
+        <Insets topRightBottomLeft="8"/>
+    </padding>
+    <LinearIndicator fx:id="indicator" styleClass="voltage-view" min="0" max="12" showTickLabels="true" showTickMarks="true"/>
+</StackPane>

--- a/src/main/resources/edu/wpi/first/shuffleboard/widget/VoltageView.fxml
+++ b/src/main/resources/edu/wpi/first/shuffleboard/widget/VoltageView.fxml
@@ -6,9 +6,9 @@
 <StackPane xmlns="http://javafx.com/javafx"
            xmlns:fx="http://javafx.com/fxml"
            fx:controller="edu.wpi.first.shuffleboard.widget.VoltageViewWidget"
-           fx:id="root">
+           fx:id="root" prefWidth="256">
     <padding>
         <Insets top="8" right="16" bottom="8" left="16"/>
     </padding>
-    <LinearIndicator fx:id="indicator" styleClass="voltage-view" min="0" max="12" showTickLabels="true" showTickMarks="true"/>
+    <LinearIndicator fx:id="indicator" styleClass="voltage-view" min="-12" max="12" showTickLabels="true" showTickMarks="true"/>
 </StackPane>

--- a/src/main/resources/edu/wpi/first/shuffleboard/widget/VoltageView.fxml
+++ b/src/main/resources/edu/wpi/first/shuffleboard/widget/VoltageView.fxml
@@ -8,7 +8,7 @@
            fx:controller="edu.wpi.first.shuffleboard.widget.VoltageViewWidget"
            fx:id="root">
     <padding>
-        <Insets topRightBottomLeft="8"/>
+        <Insets top="8" right="16" bottom="8" left="16"/>
     </padding>
     <LinearIndicator fx:id="indicator" styleClass="voltage-view" min="0" max="12" showTickLabels="true" showTickMarks="true"/>
 </StackPane>


### PR DESCRIPTION

Adds a `LinearIndicator` component that looks like a progress bar, but doesn't have to start at the left edge.

Refactor the Widget class tree to allow annotated widgets with more than one type of data

Fix tiles not having their titles set when changing the source

Tiles now use the `card` CSS class; this closes #72

Screenshot of the new widget:

![screenshot from 2017-08-04 13-37-42](https://user-images.githubusercontent.com/6320992/28979997-1e27eda0-791a-11e7-88a8-656dbe2d8265.png)