### PR TITLE
Switches shuffleboard to new ntcore artifact locations

### DIFF
--- a/api/api.gradle.kts
+++ b/api/api.gradle.kts
@@ -10,5 +10,6 @@ dependencies {
     api(group = "com.google.guava", name = "guava", version = "21.0")
     api(group = "org.fxmisc.easybind", name = "easybind", version = "1.0.3")
     api(group = "org.controlsfx", name = "controlsfx", version = "8.40.11")
-    api(group = "edu.wpi.first.wpilib.networktables.java", name = "NetworkTables", version = "+", classifier = "desktop")
+    api(group = "edu.wpi.first.ntcore", name = "ntcore-java", version = "3.1.7-20170808143930-12-gccfeab5")
+    implementation(group = "edu.wpi.first.wpiutil", name = "wpiutil-java", version = "2.0.0-20170808143537-16-gf0cc5d9")
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/NetworkTableUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/NetworkTableUtils.java
@@ -132,7 +132,7 @@ public final class NetworkTableUtils {
       return DataTypes.Map;
     }
     if (rootTable.containsKey(normalKey)) {
-      return DataType.forJavaType(rootTable.getValue(normalKey).getClass());
+      return DataType.forJavaType(rootTable.getValue(normalKey, null).getClass());
     }
     if (rootTable.containsSubTable(normalKey)) {
       ITable table = rootTable.getSubTable(normalKey);

--- a/app/app.gradle.kts
+++ b/app/app.gradle.kts
@@ -18,6 +18,7 @@ dependencies {
     compile(group = "com.google.code.gson", name = "gson", version = "2.8.1")
     fun testFx(name: String, version: String = "4.0.+") =
         create(group = "org.testfx", name = name, version = version)
+    runtime(group = "edu.wpi.first.ntcore", name = "ntcore-jni", version = "3.1.7-20170808143930-12-gccfeab5", classifier = "all")
     testCompile(testFx(name = "testfx-core"))
     testCompile(testFx(name = "testfx-junit"))
     testRuntime(testFx(name = "openjfx-monocle", version = "8u76-b04"))


### PR DESCRIPTION
Required fixing NetworkTableUtils, as the exception throwing functions
were removed.

closes #112 