### PR TITLE
pin ntcore to the 3.1.7 release

### DIFF
--- a/api/api.gradle.kts
+++ b/api/api.gradle.kts
@@ -10,5 +10,5 @@ dependencies {
     api(group = "com.google.guava", name = "guava", version = "21.0")
     api(group = "org.fxmisc.easybind", name = "easybind", version = "1.0.3")
     api(group = "org.controlsfx", name = "controlsfx", version = "8.40.11")
-    api(group = "edu.wpi.first.wpilib.networktables.java", name = "NetworkTables", version = "+", classifier = "desktop")
+    api(group = "edu.wpi.first.wpilib.networktables.java", name = "NetworkTables", version = "3.1.7", classifier = "desktop")
 }


### PR DESCRIPTION
this was done originally when we were in early, early development. Also, it's not actually very easy to figure out what the latest release of ntcore is—jenkins doesn't advertise it in any way I can find.