### PR TITLE
Reduce Comment Size from codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,4 +12,7 @@ coverage:
     patch: yes
     changes: no
 
-comment: false
+comment:
+  layout: "diff"
+  behavior: new
+  require_changes: yes


### PR DESCRIPTION
Depends on #118 

I do not know why disabling codecov is not working right now.  This PR will reduce the size of codecov comments to make them less obtrusive.  

Please wait to merge until codecov comments on this PR so we can confirm that we like it.