### PR TITLE
Disable mac builds on Travis due to instability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ matrix:
   include:
     - os: linux
       jdk: oraclejdk8
-    - os: osx
-      osx_image: xcode8
+#    - os: osx
+#      osx_image: xcode8
 
 addons:
   apt:


### PR DESCRIPTION
Currently, waiting for travis builds on mac is a huge time-sink. Until Travis has better-provisioned or more reliable mac infrastructure, we should disable this step of the matrix (alternatively, we can mark it as allowed_failure, but it wasn't obvious how to go about that)