### PR TITLE
Honor the minimum widget size for widgets in tiles

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
@@ -347,16 +347,18 @@ public class WidgetPaneController {
                                       Function<TileLayout, TileLayout> targetLayoutFunction,
                                       Function<TileSize, TileSize> shrink,
                                       boolean left) {
+    TileSize minSize = pane.round(tile.getWidget().getView().getMinWidth(), tile.getWidget().getView().getMinHeight());
     TileLayout layout = pane.getTileLayout(tile);
     TileLayout targetLayout = targetLayoutFunction.apply(layout);
     int importantDim = left ? layout.size.getWidth() : layout.size.getHeight();
+    int minDim = left ? minSize.getWidth() : minSize.getHeight();
     if (!pane.isOverlapping(targetLayout, n -> n == tile) && !targetLayout.origin.equals(layout.origin)) { // NOPMD
       // Great, we can move it
       return Optional.of(() -> {
         GridPane.setColumnIndex(tile, targetLayout.origin.col);
         GridPane.setRowIndex(tile, targetLayout.origin.row);
       });
-    } else if (importantDim > 1) {
+    } else if (importantDim > minDim) {
       // Shrink the tile
       return Optional.of(() -> tile.setSize(shrink.apply(tile.getSize())));
     } else if (!targetLayout.origin.equals(layout.origin)) { // NOPMD

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/dnd/TileDragResizer.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/dnd/TileDragResizer.java
@@ -1,8 +1,8 @@
 package edu.wpi.first.shuffleboard.app.dnd;
 
+import edu.wpi.first.shuffleboard.api.widget.TileSize;
 import edu.wpi.first.shuffleboard.app.components.TilePane;
 import edu.wpi.first.shuffleboard.app.components.WidgetTile;
-import edu.wpi.first.shuffleboard.api.widget.TileSize;
 
 import java.util.Map;
 import java.util.WeakHashMap;
@@ -106,14 +106,14 @@ public final class TileDragResizer {
     resizeLocation = ResizeLocation.NONE;
 
     // round size to nearest tile size
-    final int tileWidth = tilePane.roundWidthToNearestTile(tile.getMinWidth());
-    final int tileHeight = tilePane.roundHeightToNearestTile(tile.getMinHeight());
+    final int tileWidth = tilePane.roundWidthToNearestTile(tile.getWidth());
+    final int tileHeight = tilePane.roundHeightToNearestTile(tile.getHeight());
 
     // limit size to prevent exceeding the bounds of the grid
     final int boundedWidth = Math.min(tilePane.getNumColumns() - GridPane.getColumnIndex(tile),
-                                      tileWidth);
+        tileWidth);
     final int boundedHeight = Math.min(tilePane.getNumRows() - GridPane.getRowIndex(tile),
-                                       tileHeight);
+        tileHeight);
 
     tile.setSize(new TileSize(boundedWidth, boundedHeight));
     GridPane.setColumnSpan(tile, boundedWidth);
@@ -190,11 +190,15 @@ public final class TileDragResizer {
     final double newHeight = tile.getMinHeight() + (mouseY - lastY);
 
     if (resizeLocation.isHorizontal && newWidth >= tilePane.getTileSize()) {
-      tile.setMinWidth(newWidth);
+      if (tile.getWidget().getView().getMinWidth() < newWidth) {
+        tile.setMinWidth(newWidth);
+      }
       tile.setMaxWidth(newWidth);
     }
     if (resizeLocation.isVertical && newHeight >= tilePane.getTileSize()) {
-      tile.setMinHeight(newHeight);
+      if (tile.getWidget().getView().getMinHeight() < newHeight) {
+        tile.setMinHeight(newHeight);
+      }
       tile.setMaxHeight(newHeight);
     }
 


### PR DESCRIPTION
This lets us specify the minimum widget size (like 256x128 for encoders) have prevent tiles containing those widgets to be smaller than that minimum size.

Closes #136