### PR TITLE
Change recording file format to {date}/{time}.frc

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recorder.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recorder.java
@@ -26,8 +26,9 @@ public final class Recorder {
 
   private static final Logger log = Logger.getLogger(Recorder.class.getName());
 
-  private static final DateTimeFormatter timeFormatter =
-      DateTimeFormatter.ofPattern("uuuu-MM-dd_HH:mm:ss", Locale.getDefault());
+  private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ISO_DATE;
+  private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH.mm.ss", Locale.getDefault());
+
   private static final Recorder instance = new Recorder();
 
   private final BooleanProperty running = new SimpleBooleanProperty(this, "running", false);
@@ -54,7 +55,9 @@ public final class Recorder {
       return;
     }
     try {
-      String file = String.format(Storage.RECORDING_FILE_FORMAT, createTimestamp());
+      String date = dateFormatter.format(LocalDateTime.ofInstant(startTime, ZoneId.systemDefault()));
+      String time = timeFormatter.format(LocalDateTime.ofInstant(startTime, ZoneId.systemDefault()));
+      String file = Storage.RECORDING_FILE_FORMAT.replace("${date}", date).replace("${time}", time);
       Serialization.saveRecording(recording, file);
       log.fine("Saved recording to " + file);
     } catch (IOException e) {

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recorder.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recorder.java
@@ -7,10 +7,6 @@ import edu.wpi.first.shuffleboard.api.util.ThreadUtils;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.util.Locale;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -25,9 +21,6 @@ import javafx.beans.property.SimpleBooleanProperty;
 public final class Recorder {
 
   private static final Logger log = Logger.getLogger(Recorder.class.getName());
-
-  private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ISO_DATE;
-  private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH.mm.ss", Locale.getDefault());
 
   private static final Recorder instance = new Recorder();
 
@@ -55,18 +48,12 @@ public final class Recorder {
       return;
     }
     try {
-      String date = dateFormatter.format(LocalDateTime.ofInstant(startTime, ZoneId.systemDefault()));
-      String time = timeFormatter.format(LocalDateTime.ofInstant(startTime, ZoneId.systemDefault()));
-      String file = Storage.RECORDING_FILE_FORMAT.replace("${date}", date).replace("${time}", time);
+      String file = Storage.createRecordingFilePath(startTime);
       Serialization.saveRecording(recording, file);
       log.fine("Saved recording to " + file);
     } catch (IOException e) {
       throw new RuntimeException("Could not save the recording", e);
     }
-  }
-
-  private String createTimestamp() {
-    return timeFormatter.format(LocalDateTime.ofInstant(startTime, ZoneId.systemDefault()));
   }
 
   /**

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -10,6 +10,7 @@ import edu.wpi.first.shuffleboard.api.sources.recording.serialization.Serializer
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -83,7 +84,10 @@ public final class Serialization {
       i += next.length;
       j++;
     }
-    Files.createDirectories(Paths.get(file).getParent());
+    Path saveDir = Paths.get(file).getParent();
+    if (saveDir != null) {
+      Files.createDirectories(saveDir);
+    }
     Files.write(Paths.get(file), all);
   }
 

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -6,7 +6,6 @@ import edu.wpi.first.shuffleboard.api.data.DataType;
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
 import edu.wpi.first.shuffleboard.api.sources.recording.serialization.TypeAdapter;
 import edu.wpi.first.shuffleboard.api.sources.recording.serialization.Serializers;
-import edu.wpi.first.shuffleboard.api.util.Storage;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -37,10 +36,6 @@ public final class Serialization {
   public static final int SIZE_OF_DOUBLE = 8;
 
   private Serialization() {
-  }
-
-  public static void saveToDefaultLocation(Recording recording) throws IOException {
-    saveRecording(recording, Storage.DEFAULT_RECORDING_FILE);
   }
 
   /**
@@ -88,6 +83,7 @@ public final class Serialization {
       i += next.length;
       j++;
     }
+    Files.createDirectories(Paths.get(file).getParent());
     Files.write(Paths.get(file), all);
   }
 
@@ -113,15 +109,6 @@ public final class Serialization {
    */
   public static <T> T decode(byte[] buffer, int bufferPosition, DataType<T> type) {
     return Serializers.get(type).deserialize(buffer, bufferPosition);
-  }
-
-  /**
-   * Loads the default recording file at {@link Storage#DEFAULT_RECORDING_FILE}.
-   *
-   * @throws IOException if the file could not be read
-   */
-  public static Recording loadDefaultRecording() throws IOException {
-    return loadRecording(Storage.DEFAULT_RECORDING_FILE);
   }
 
   /**

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/Storage.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/Storage.java
@@ -1,5 +1,11 @@
 package edu.wpi.first.shuffleboard.api.util;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+
 /**
  * Utilities for local file storage.
  */
@@ -19,12 +25,31 @@ public final class Storage {
 
   public static final String RECORDING_FILE_FORMAT = RECORDING_DIR + "/${date}/recording-${time}.frc";
 
+  private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ISO_DATE;
+  private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH.mm.ss", Locale.getDefault());
+
   /**
    * The path to the plugins directory. This directory is scanned once at startup for plugin jars to load.
    */
   public static final String PLUGINS_DIR = STORAGE_DIR + "/plugins";
 
   private Storage() {
+  }
+
+  /**
+   * Generates the path to a recording file based on when a recording started. The generated path is in the format
+   * {@code /SmartDashboard/recordings/<date>/recording-<time>.frc}, where {@code date} is the date formatted by the
+   * ISO-8601 format, and {@code time} is a modified version that uses periods ({@code "."}) instead of colons because
+   * Windows does not allow colon characters in file names.
+   *
+   * @param startTime the time the recording started
+   */
+  public static String createRecordingFilePath(Instant startTime) {
+    String date = dateFormatter.format(LocalDateTime.ofInstant(startTime, ZoneId.systemDefault()));
+    String time = timeFormatter.format(LocalDateTime.ofInstant(startTime, ZoneId.systemDefault()));
+    return RECORDING_FILE_FORMAT
+        .replace("${date}", date)
+        .replace("${time}", time);
   }
 
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/Storage.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/Storage.java
@@ -15,9 +15,9 @@ public final class Storage {
    */
   public static final String STORAGE_DIR = USER_HOME + "/SmartDashboard";
 
-  public static final String RECORDING_FILE_FORMAT = STORAGE_DIR + "/dashboard_recording_%s.frc";
+  public static final String RECORDING_DIR = STORAGE_DIR + "/recordings";
 
-  public static final String DEFAULT_RECORDING_FILE = STORAGE_DIR + "/default_dashboard_recording.frc";
+  public static final String RECORDING_FILE_FORMAT = RECORDING_DIR + "/${date}/recording-${time}.frc";
 
   /**
    * The path to the plugins directory. This directory is scanned once at startup for plugin jars to load.

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -407,7 +407,7 @@ public class MainWindowController {
   @FXML
   private void loadPlayback() throws IOException {
     FileChooser chooser = new FileChooser();
-    chooser.setInitialDirectory(new File(Storage.STORAGE_DIR));
+    chooser.setInitialDirectory(new File(Storage.RECORDING_DIR));
     chooser.getExtensionFilters().setAll(
         new FileChooser.ExtensionFilter("FRC Data Recording", "*.frc"));
     final File selected = chooser.showOpenDialog(root.getScene().getWindow());


### PR DESCRIPTION
Fix #50
Remove unused serialization methods

Recording files are now saved to `~/SmartDashboard/recordings/<date>/recording-<time>.frc`, where
`date`  is formatted in `YYYY-MM-DD` (eg `2017-01-01`) and `time` is formatted in `HH.mm.ss` (eg `12.34.56` for 12:34:56). Periods are used instead of colons because Windows doesn't allow colons in file names

Sample file structure:

```
SmartDashboard
  recordings
    2017-08-24
      recording-12.15.20.frc
      recording-13.41.51.frc
    2017-08-25
      recording-09.31.45.frc
      recording-10.12.33.frc
```