### PR TITLE
Supress unchecked warnings

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/SourceTreeTable.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/SourceTreeTable.java
@@ -9,6 +9,7 @@ import edu.wpi.first.shuffleboard.api.util.NetworkTableUtils;
 import java.util.Comparator;
 import java.util.List;
 
+import edu.wpi.first.shuffleboard.api.util.TypeUtils;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.ReadOnlyStringWrapper;
@@ -21,9 +22,8 @@ import javafx.scene.control.TreeTableView;
  * A tree table view or displaying hierarchical sources.
  *
  * @param <S> the type of the source entries in the tree
- * @param <V> the type of the values of the sources
  */
-public class SourceTreeTable<S extends SourceEntry, V> extends TreeTableView<S> {
+public class SourceTreeTable<S extends SourceEntry> extends TreeTableView<S> {
 
   /**
    * Compares tree items, branches first.
@@ -40,7 +40,7 @@ public class SourceTreeTable<S extends SourceEntry, V> extends TreeTableView<S> 
   private final ObjectProperty<SourceType> sourceType = new SimpleObjectProperty<>(this, "sourceType", null);
 
   private final TreeTableColumn<S, String> keyColumn = new TreeTableColumn<>("Name");
-  private final TreeTableColumn<S, V> valueColumn = new TreeTableColumn<>("Value");
+  private final TreeTableColumn<S, Object> valueColumn = new TreeTableColumn<>("Value");
 
   /**
    * Creates a new source tree table. It comes pre-populated with a key and a value column.
@@ -52,9 +52,10 @@ public class SourceTreeTable<S extends SourceEntry, V> extends TreeTableView<S> 
     keyColumn.setCellValueFactory(
         f -> new ReadOnlyStringWrapper(getEntryForCellData(f).getViewName()));
     valueColumn.setCellValueFactory(
-        f -> new ReadOnlyObjectWrapper(getEntryForCellData(f).getValueView()));
+        f -> new ReadOnlyObjectWrapper<>(getEntryForCellData(f).getValueView()));
 
-    getColumns().addAll(keyColumn, valueColumn);
+    getColumns().add(keyColumn);
+    getColumns().add(valueColumn);
   }
 
   /**
@@ -81,6 +82,7 @@ public class SourceTreeTable<S extends SourceEntry, V> extends TreeTableView<S> 
    * @param entry   the entry that should be updated
    * @param deleted {@code true} if the entry was deleted, {@code false} otherwise
    */
+  @SuppressWarnings("unchecked")
   private void makeBranches(S entry, boolean deleted) {
     final SourceType sourceType = getSourceType();
     String name = entry.getName();

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/data/DataTypes.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/data/DataTypes.java
@@ -235,7 +235,8 @@ public class DataTypes extends Registry<DataType> {
   /**
    * Gets the registered data types of the given types.
    */
-  public Set<DataType> forTypes(Class<? extends DataType>... types) {
+  @SafeVarargs
+  public final Set<DataType> forTypes(Class<? extends DataType>... types) {
     return Arrays.stream(types)
         .map(this::forType)
         .filter(Optional::isPresent)

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/data/types/NoneType.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/data/types/NoneType.java
@@ -2,7 +2,7 @@ package edu.wpi.first.shuffleboard.api.data.types;
 
 import edu.wpi.first.shuffleboard.api.data.SimpleDataType;
 
-public class NoneType extends SimpleDataType {
+public class NoneType extends SimpleDataType<Object> {
 
   public NoneType() {
     super("None", null);

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/SourceType.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/SourceType.java
@@ -13,7 +13,7 @@ public class SourceType {
   private final String name;
   private final boolean isRecordable;
   private final String protocol;
-  private final Function<String, DataSource> sourceSupplier;
+  private final Function<String, DataSource<?>> sourceSupplier;
 
   /**
    * Creates a new source type.
@@ -26,7 +26,7 @@ public class SourceType {
   public SourceType(String name,
                     boolean isRecordable,
                     String protocol,
-                    Function<String, DataSource> sourceSupplier) {
+                    Function<String, DataSource<?>> sourceSupplier) {
     this.name = name;
     this.isRecordable = isRecordable;
     this.protocol = protocol;

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -22,7 +22,7 @@ import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-@SuppressWarnings("PMD.GodClass")
+@SuppressWarnings({"unchecked", "PMD.GodClass"})
 public final class Serialization {
 
   private static final Logger log = Logger.getLogger(Serialization.class.getName());
@@ -47,6 +47,7 @@ public final class Serialization {
    *
    * @throws IOException if the recording could not be saved to the given file
    */
+  @SuppressWarnings("unchecked")
   public static void saveRecording(Recording recording, String file) throws IOException {
     // work on a copy of the data so changes to the recording don't mess this up
     final List<TimestampedData> dataCopy = new ArrayList<>(recording.getData());

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/Registry.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/Registry.java
@@ -68,6 +68,7 @@ public abstract class Registry<T> {
    *
    * @param items the items to register
    */
+  @SafeVarargs
   public final void registerAll(T... items) {
     Objects.requireNonNull(items, "items");
     for (T item : items) {

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/SimpleAnnotatedWidget.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/SimpleAnnotatedWidget.java
@@ -24,7 +24,7 @@ public abstract class SimpleAnnotatedWidget<T> extends AnnotatedWidget implement
   // Getters and setters
 
   public Property<DataSource> sourceProperty() {
-    return (Property) source;
+    return source;
   }
 
   public final Property<T> dataProperty() {

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/SingleTypeWidget.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/SingleTypeWidget.java
@@ -27,6 +27,7 @@ public interface SingleTypeWidget<T> extends Widget {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   default DataSource<T> getSource() {
     return sourceProperty().getValue();
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,6 +69,12 @@ subprojects {
         "testRuntime"(testFx(name = "openjfx-monocle", version = "8u76-b04"))
     }
 
+    tasks.withType<JavaCompile> {
+        options.compilerArgs.add("-Xlint:unchecked")
+        options.compilerArgs.add("-Xlint:deprecation")
+        options.compilerArgs.add("-Werror")
+    }
+
     checkstyle {
         configFile = file("$rootDir/checkstyle.xml")
         toolVersion = "8.1"


### PR DESCRIPTION
@SamCarlberg What do you think about these warnings.  They are complaining because there are 2 interface methods with the same name:

>/Users/austinshalit/Documents/git/shuffleboard/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/SimpleAnnotatedWidget.java:12: warning: [unchecked] getSource() in AbstractWidget implements getSource() in SingleTypeWidget
public abstract class SimpleAnnotatedWidget<T> extends AnnotatedWidget implements SingleTypeWidget<T> {
                ^
  return type requires unchecked conversion from DataSource to DataSource<T#2>
  where T#1,T#2 are type-variables:
    T#1 extends Object declared in interface SingleTypeWidget
    T#2 extends Object declared in class SimpleAnnotatedWidget
/Users/austinshalit/Documents/git/shuffleboard/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/ComplexAnnotatedWidget.java:9: warning: [unchecked] getSource() in AbstractWidget implements getSource() in SingleTypeWidget
public abstract class ComplexAnnotatedWidget<D extends ComplexData>
                ^
  return type requires unchecked conversion from DataSource to DataSource<D>
  where T,D are type-variables:
    T extends Object declared in interface SingleTypeWidget
    D extends ComplexData declared in class ComplexAnnotatedWidget
error: warnings found and -Werror specified
