### PR TITLE
Make text field widgets editable

### DIFF
--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/TextView.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/TextView.java
@@ -6,7 +6,6 @@ import edu.wpi.first.shuffleboard.api.widget.ParametrizedController;
 import edu.wpi.first.shuffleboard.api.widget.SimpleAnnotatedWidget;
 
 import org.fxmisc.easybind.EasyBind;
-import org.fxmisc.easybind.monadic.MonadicBinding;
 
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
@@ -38,8 +37,7 @@ public class TextView extends SimpleAnnotatedWidget<Object> {
   @FXML
   private void initialize() {
     text.bind(EasyBind.map(dataProperty(), this::simpleToString));
-    MonadicBinding<Boolean> isNumber = EasyBind.map(dataProperty(), d -> d instanceof Number).orElse(false);
-    numberField.visibleProperty().bind(isNumber);
+    numberField.visibleProperty().bind(EasyBind.map(dataProperty(), d -> d instanceof Number).orElse(false));
     textField.visibleProperty().bind(numberField.visibleProperty().not());
 
     text.addListener((__, oldText, newText) -> {

--- a/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/TextView.fxml
+++ b/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/TextView.fxml
@@ -4,6 +4,7 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.StackPane?>
+<?import edu.wpi.first.shuffleboard.api.components.NumberField?>
 <BorderPane xmlns="http://javafx.com/javafx"
             xmlns:fx="http://javafx.com/fxml"
             fx:controller="edu.wpi.first.shuffleboard.plugin.base.widget.TextView"
@@ -13,7 +14,8 @@
             <padding>
                 <Insets topRightBottomLeft="8"/>
             </padding>
-            <TextField text="${controller.text}"/>
+            <TextField fx:id="textField"/>
+            <NumberField fx:id="numberField"/>
         </StackPane>
     </center>
 </BorderPane>


### PR DESCRIPTION
Fixes #47

ATM allows for boolean text entries (`"true"` is the `true` value, anything else becomes `false`). I think that's acceptable since checkboxes/toggle buttons/toggle switches all exist and are incredibly easier to use