### PR TITLE
Fix publishing bug

### DIFF
--- a/app/app.gradle.kts
+++ b/app/app.gradle.kts
@@ -1,4 +1,4 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 import org.gradle.jvm.tasks.Jar
 
 plugins {
@@ -36,12 +36,6 @@ tasks.withType<Jar> {
             "Implementation-Version" to getWPILibVersion(),
             "Main-Class" to theMainClassName
         ).filterValues { it != null })
-    }
-}
-
-tasks {
-    "shadowJar"(ShadowJar::class) {
-        classifier = null
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+
 import edu.wpi.first.wpilib.versioning.ReleaseType
 import org.gradle.api.Project
 import org.gradle.api.plugins.quality.FindBugs
@@ -154,7 +155,7 @@ subprojects {
 
 }
 
-configure(setOf(project(":app"))) {
+project(":app") {
     apply {
         plugin("com.github.johnrengelman.shadow")
     }
@@ -165,7 +166,7 @@ configure(setOf(project(":app"))) {
     }
     publishing {
         publications {
-            create<MavenPublication>("shadow") {
+            create<MavenPublication>("app") {
                 groupId = "edu.wpi.first.shuffleboard"
                 artifactId = "Shuffleboard"
                 getWPILibVersion()?.let { version = it }


### PR DESCRIPTION
The `app-all.jar` file wasn't getting generated by the shadow plugin, instead `app.jar` was being generated. Now shadow will generate the `app-all.jar` file so that the jar can be correctly published.

You can test this by running `./gradlew publishToMavenLocal`. We may want to have travis do that as one of it's steps just to make sure that this doesn't break in the future.