### PR TITLE
Change the default number widget type from NumberSlider to TextView

### DIFF
--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -104,7 +104,7 @@ public class BasePlugin extends Plugin {
   public Map<DataType, Class<? extends Widget>> getDefaultWidgets() {
     return ImmutableMap.<DataType, Class<? extends Widget>>builder()
         .put(new BooleanType(), BooleanBox.class)
-        .put(new NumberType(), NumberSlider.class)
+        .put(new NumberType(), TextView.class)
         .put(new StringType(), TextView.class)
         .put(new AnalogInputType(), VoltageViewWidget.class)
         .put(new PowerDistributionType(), PowerDistributionPanelWidget.class)


### PR DESCRIPTION
Resolves #188 
Not totally sure if TextView is acceptable or if a new widget is needed; the javadoc for TextView claims it is for text, numbers, and booleans.