### PR TITLE
Fix subsystem population

### DIFF
--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/SubsystemLayout.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/SubsystemLayout.java
@@ -116,7 +116,7 @@ public class SubsystemLayout implements Layout, Populatable, Sourced {
         .flatMap(TypeUtils.castStream(Sourced.class))
         .map(Sourced::getSource)
         .map(DataSource::getId)
-        .anyMatch(uri -> uri.startsWith(source.getId()));
+        .anyMatch(source.getId()::startsWith);
   }
 
   @Override

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/SubsystemLayout.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/SubsystemLayout.java
@@ -107,7 +107,9 @@ public class SubsystemLayout implements Layout, Populatable, Sourced {
 
   @Override
   public boolean supports(DataSource<?> source) {
-    return this.source != null && source.getName().startsWith(getSource().getName());
+    return this.source != null
+        && this.source != source
+        && source.getName().startsWith(getSource().getName());
   }
 
   @Override


### PR DESCRIPTION
- Fixes subsystems adding widgets for data that already has a widget for a higher-level structure (eg `Sensor/Value` when there's already a widget for `Sensor`)
- Fixes empty space at the top of subsystem layouts. This was caused by adding an empty subsystem layout for the same source as the parent, which took up space without actually containing any widgets.