### PR TITLE
Removes java components from publish

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -203,7 +203,6 @@ project(":app") {
                 artifact (shadowJar) {
                     classifier = null
                 }
-                from(components["java"])
                 artifact(sourceJar)
             }
         }


### PR DESCRIPTION
Not required when publishing shadowjar without all classifier