### PR TITLE
Make buttons and toggle buttons look more like raised buttons

### DIFF
--- a/api/src/main/resources/edu/wpi/first/shuffleboard/api/material.css
+++ b/api/src/main/resources/edu/wpi/first/shuffleboard/api/material.css
@@ -119,11 +119,17 @@
 
 .toggle-button, .button {
     -fx-text-fill: -fx-text-button-normal;
-    -fx-font-family: 'Roboto';
     -fx-font-weight: bold;
     -fx-background-insets: 0.0;
-    -fx-background-radius: 4.0;
+    -fx-background-radius: 0.0;
     -fx-alignment: CENTER;
+    -fx-background-color: rgba(250, 250, 250);
+    -fx-effect: dropshadow(gaussian, rgba(0.0, 0.0, 0.0, 0.30), 6.0, 0.3, 0, 2);
+}
+
+.toggle-button:selected, .button:selected {
+    -fx-background-color: -swatch-500;
+    -fx-text-fill: white;
 }
 
 .button-raised .button .text, .button-flat .button .text {
@@ -132,23 +138,22 @@
 
 .button:default {
     -fx-background-color: -swatch-500;
-    -fx-text-fill: -fx-text-button-colored;
+    -fx-text-fill: white;
 }
 
 .toggle-button:focused, .button:focused, .button:default:focused {
-    -fx-background-color: -swatch-light-gray;
+    -fx-background-color: rgb(240, 240, 240);
+    -fx-text-fill: -swatch-500;
 }
 
 .toggle-button:focused:selected {
-    -fx-background-color: derive(-swatch-500, 50.0%),
-    derive(-swatch-500, -20.0%);
-    -fx-background-insets: 0.0, 0.2em;
-    -fx-text-fill: -fx-text-button-colored;
+    -fx-background-color: derive(-swatch-500, -12%);
+    -fx-text-fill: white;
 }
 
 .toggle-button:armed, .toggle-button:selected, .button:armed, .button:default:armed {
-    -fx-background-color: -swatch-gray;
-    -fx-text-fill: -fx-text-button-colored;
+    -fx-background-color: -swatch-500;
+    -fx-text-fill: white;
 }
 
 .icon-button {

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/dark.css
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/dark.css
@@ -13,11 +13,13 @@
 .root {
     -fx-text-base-color: #fefefe;
     /* Swatch Colors - Red */
+
     -swatch-100: hsb(0, 80%, 98%);
     -swatch-200: hsb(0, 80%, 88%);
     -swatch-300: hsb(0, 80%, 78%);
     -swatch-400: hsb(0, 80%, 68%);
     -swatch-500: hsb(0, 80%, 58%);
+
     -swatch-dark-gray: #222;
     -swatch-gray: #333;
     -swatch-light-gray: #444;
@@ -64,21 +66,39 @@
  * Button, toggle button                                                       *
  *                                                                             *
  ******************************************************************************/
-.button, .toggle-button {
-    -fx-background-color: -swatch-light-gray;
-    -fx-background-radius: 0;
+.toggle-button, .button {
+    -fx-background-color: rgb(64, 64, 64);
+    -fx-text-fill: white;
+    -fx-effect: dropshadow(gaussian, rgba(0.0, 0.0, 0.0, 0.70), 6.0, 0.3, 0, 2);
 }
 
-.button:pressed {
+.toggle-button:selected, .button:selected {
     -fx-background-color: -swatch-500;
+    -fx-text-fill: white;
 }
 
-.toggle-button:pressed {
-    -fx-background-color: -swatch-300;
+.button-raised .button .text, .button-flat .button .text {
+    -fx-text-weight: Bold;
 }
 
-.toggle-button:selected {
+.button:default {
     -fx-background-color: -swatch-500;
+    -fx-text-fill: white;
+}
+
+.toggle-button:focused, .button:focused, .button:default:focused {
+    -fx-background-color: rgb(48, 48, 48);
+    -fx-text-fill: white;
+}
+
+.toggle-button:focused:selected {
+    -fx-background-color: derive(-swatch-500, -12%);
+    -fx-text-fill: white;
+}
+
+.toggle-button:armed, .toggle-button:selected, .button:armed, .button:default:armed {
+    -fx-background-color: -swatch-500;
+    -fx-text-fill: white;
 }
 
 /*******************************************************************************

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/ToggleButton.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/ToggleButton.java
@@ -1,8 +1,13 @@
 package edu.wpi.first.shuffleboard.plugin.base.widget;
 
+import edu.wpi.first.shuffleboard.api.sources.DataSource;
+import edu.wpi.first.shuffleboard.api.util.NetworkTableUtils;
 import edu.wpi.first.shuffleboard.api.widget.Description;
 import edu.wpi.first.shuffleboard.api.widget.ParametrizedController;
 import edu.wpi.first.shuffleboard.api.widget.SimpleAnnotatedWidget;
+
+import org.fxmisc.easybind.EasyBind;
+import org.fxmisc.easybind.monadic.MonadicBinding;
 
 import javafx.fxml.FXML;
 import javafx.scene.layout.Pane;
@@ -15,11 +20,16 @@ public class ToggleButton extends SimpleAnnotatedWidget<Boolean> {
   private Pane root;
   @FXML
   private javafx.scene.control.ToggleButton button;
+  private MonadicBinding<String> simpleSourceName; // NOPMD use a field to avoid GC
 
   @FXML
   private void initialize() {
+    simpleSourceName = EasyBind.monadic(sourceProperty())
+        .map(DataSource::getName)
+        .map(NetworkTableUtils::simpleKey)
+        .orElse("");
     button.selectedProperty().bindBidirectional(dataProperty());
-    button.textProperty().bind(sourceNameProperty());
+    button.textProperty().bind(simpleSourceName);
   }
 
   @Override

--- a/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/SpeedController.fxml
+++ b/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/SpeedController.fxml
@@ -24,8 +24,8 @@
             <Slider fx:id="control" min="-1" max="1" showTickLabels="true" showTickMarks="true" majorTickUnit="0.5"/>
         </center>
         <bottom>
-            <HBox alignment="CENTER">
-                <NumberField fx:id="valueField" number="0"/>
+            <HBox alignment="CENTER" spacing="8" maxWidth="Infinity">
+                <NumberField fx:id="valueField" HBox.hgrow="ALWAYS"/>
                 <Button text="Zero" onAction="#zero" minWidth="64"/>
             </HBox>
         </bottom>

--- a/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/ToggleButton.fxml
+++ b/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/ToggleButton.fxml
@@ -2,9 +2,14 @@
 
 <?import javafx.scene.control.ToggleButton?>
 <?import javafx.scene.layout.StackPane?>
+<?import javafx.geometry.Insets?>
 <StackPane xmlns="http://javafx.com/javafx"
            xmlns:fx="http://javafx.com/fxml"
            fx:controller="edu.wpi.first.shuffleboard.plugin.base.widget.ToggleButton"
+           minWidth="40" minHeight="40"
            fx:id="root">
-    <ToggleButton fx:id="button" alignment="CENTER" maxHeight="Infinity" maxWidth="Infinity"/>
+    <padding>
+        <Insets topRightBottomLeft="8"/>
+    </padding>
+    <ToggleButton fx:id="button" maxHeight="Infinity" maxWidth="Infinity"/>
 </StackPane>


### PR DESCRIPTION
Also fixes ToggleButton widgets not showing the source name in the button, along with adding some extra padding to make them easier to tell apart from parent tiles

Closes #186 

# Screenshots

## Light theme
![buttons-light](https://user-images.githubusercontent.com/6320992/31589368-5b9ec7c0-b1ce-11e7-9035-b5bd4346e3a7.PNG)

## Dark theme
![buttons-dark](https://user-images.githubusercontent.com/6320992/31589369-5ba8a9d4-b1ce-11e7-9d84-4fd45acd2a0e.PNG)
