### PR TITLE
Fix sizeOfWidget failing if preferred dimensions are not specified

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/WidgetPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/WidgetPane.java
@@ -220,8 +220,8 @@ public class WidgetPane extends TilePane implements ComponentContainer {
     Pane view = widget.getView();
 
     return new TileSize(
-        roundWidthToNearestTile(view.getPrefWidth(), RoundingMode.UP),
-        roundHeightToNearestTile(view.getPrefHeight(), RoundingMode.UP)
+        roundWidthToNearestTile(Math.max(view.getMinWidth(), view.getPrefWidth()), RoundingMode.UP),
+        roundHeightToNearestTile(Math.max(view.getMinHeight(), view.getPrefHeight()), RoundingMode.UP)
     );
   }
 


### PR DESCRIPTION
Uses `max(minDim, prefDim)`. This will only use the minimum dimension if the preferred one is not specified, or if the widget is misconfigured to have the minimum size greater than the preferred one