### PR TITLE
Add simple dial widget

### DIFF
--- a/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
+++ b/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
@@ -211,6 +211,8 @@
  ******************************************************************************/
 .gauge {
     -fx-needle-color: -swatch-500;
+    -fx-bar-color: -swatch-200;
+    -fx-bar-background-color: -swatch-light-gray;
     -fx-tick-label-color: -fx-text-base-color;
     -fx-tick-mark-color: black;
     -fx-major-tick-color: #333;

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -44,6 +44,7 @@ import edu.wpi.first.shuffleboard.plugin.base.widget.NumberBarWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.NumberSlider;
 import edu.wpi.first.shuffleboard.plugin.base.widget.PIDControllerWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.PowerDistributionPanelWidget;
+import edu.wpi.first.shuffleboard.plugin.base.widget.SimpleDialWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.SpeedController;
 import edu.wpi.first.shuffleboard.plugin.base.widget.TextView;
 import edu.wpi.first.shuffleboard.plugin.base.widget.ThreeAxisAccelerometerWidget;
@@ -93,6 +94,7 @@ public class BasePlugin extends Plugin {
         WidgetType.forAnnotatedWidget(ToggleSwitch.class),
         WidgetType.forAnnotatedWidget(NumberSlider.class),
         WidgetType.forAnnotatedWidget(NumberBarWidget.class),
+        WidgetType.forAnnotatedWidget(SimpleDialWidget.class),
         WidgetType.forAnnotatedWidget(TextView.class),
         WidgetType.forAnnotatedWidget(VoltageViewWidget.class),
         WidgetType.forAnnotatedWidget(PowerDistributionPanelWidget.class),

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/SimpleDialWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/SimpleDialWidget.java
@@ -1,0 +1,33 @@
+package edu.wpi.first.shuffleboard.plugin.base.widget;
+
+import edu.wpi.first.shuffleboard.api.widget.Description;
+import edu.wpi.first.shuffleboard.api.widget.ParametrizedController;
+import edu.wpi.first.shuffleboard.api.widget.SimpleAnnotatedWidget;
+
+import eu.hansolo.medusa.Gauge;
+
+import javafx.fxml.FXML;
+import javafx.scene.layout.Pane;
+
+@Description(name = "Simple Dial", dataTypes = Number.class)
+@ParametrizedController("SimpleDialWidget.fxml")
+public class SimpleDialWidget extends SimpleAnnotatedWidget<Number> {
+
+  @FXML
+  private Pane root;
+  @FXML
+  private Gauge dial;
+
+  @FXML
+  private void initialize() {
+    dial.valueProperty().bind(dataOrDefault);
+
+    exportProperties(dial.minValueProperty(), dial.maxValueProperty(), dial.valueVisibleProperty());
+  }
+
+  @Override
+  public Pane getView() {
+    return root;
+  }
+
+}

--- a/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/SimpleDialWidget.fxml
+++ b/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/SimpleDialWidget.fxml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import edu.wpi.first.shuffleboard.api.components.StyleableGauge?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.layout.StackPane?>
+<StackPane xmlns="http://javafx.com/javafx"
+           xmlns:fx="http://javafx.com/fxml"
+           fx:controller="edu.wpi.first.shuffleboard.plugin.base.widget.SimpleDialWidget"
+           fx:id="root"
+           minWidth="128" minHeight="128">
+    <padding>
+        <Insets topRightBottomLeft="4"/>
+    </padding>
+    <!-- Flat-style filled-arc gauge -->
+    <StyleableGauge fx:id="dial" skinType="DASHBOARD" minValue="0" maxValue="100" tickLabelsVisible="false"/>
+</StackPane>


### PR DESCRIPTION
Note that medusa gauges are a bit buggy. The text doesn't like to stay a consistent size, and may sometimes disappear entirely when toggling the "value visible" property. 

Uses the same color schemes as linear indicators for visual consistency.

# Screenshots

![dial-0](https://user-images.githubusercontent.com/6320992/32030872-da0addc4-b9cb-11e7-8335-6bea32269c4a.PNG)
![dial-1](https://user-images.githubusercontent.com/6320992/32030873-da154232-b9cb-11e7-962a-6c2697081c20.PNG)
![dial-2](https://user-images.githubusercontent.com/6320992/32030874-da1fc432-b9cb-11e7-9b98-ad0fb6d9ebe5.PNG)
![dial-3](https://user-images.githubusercontent.com/6320992/32030875-da2aec54-b9cb-11e7-808c-69ed97111227.PNG)
