### PR TITLE
Publish API and plugin jars and source and javadocs for all artifacts

### DIFF
--- a/app/app.gradle.kts
+++ b/app/app.gradle.kts
@@ -20,8 +20,6 @@ dependencies {
     compile(project(path = ":plugins:networktables"))
     compile(group = "com.google.code.gson", name = "gson", version = "2.8.2")
     compile(group = "de.huxhorn.lilith", name = "de.huxhorn.lilith.3rdparty.junique", version = "1.0.4")
-
-    runtime(group = "edu.wpi.first.ntcore", name = "ntcore-jni", version = "4.+", classifier = "all")
 }
 
 val theMainClassName = "edu.wpi.first.shuffleboard.app.Shuffleboard"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ buildscript {
 plugins {
     `maven-publish`
     jacoco
-    id("edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin") version "1.6"
+    id("edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin") version "2.0"
     id("com.github.johnrengelman.shadow") version "2.0.1"
     id("com.diffplug.gradle.spotless") version "3.5.1"
 }
@@ -52,7 +52,7 @@ allprojects {
     }
 }
 
-subprojects {
+allprojects {
     apply {
         plugin("java")
         plugin("checkstyle")
@@ -182,6 +182,10 @@ subprojects {
             }
         }
     }
+
+    tasks.withType<Javadoc> {
+        isFailOnError = false
+    }
 }
 
 project(":app") {
@@ -193,17 +197,56 @@ project(":app") {
         from(java.sourceSets["main"].allSource)
         classifier = "sources"
     }
+    val javadocJar = task<Jar>("javadocJar") {
+        dependsOn("javadoc")
+        description = "Creates a JAR that contains the javadocs."
+        from(java.docsDir)
+        classifier = "javadoc"
+    }
     publishing {
         publications {
             create<MavenPublication>("app") {
                 groupId = "edu.wpi.first.shuffleboard"
-                artifactId = "Shuffleboard"
+                artifactId = "app"
                 getWPILibVersion()?.let { version = it }
                 val shadowJar: ShadowJar by tasks
                 artifact (shadowJar) {
                     classifier = null
                 }
                 artifact(sourceJar)
+                artifact(javadocJar)
+            }
+        }
+    }
+}
+
+project(":api") {
+    apply {
+        plugin("com.github.johnrengelman.shadow")
+    }
+    val sourceJar = task<Jar>("sourceJar") {
+        description = "Creates a JAR that contains the source code."
+        from(java.sourceSets["main"].allSource)
+        classifier = "sources"
+    }
+    val javadocJar = task<Jar>("javadocJar") {
+        dependsOn("javadoc")
+        description = "Creates a JAR that contains the javadocs."
+        from(java.docsDir)
+        classifier = "javadoc"
+    }
+    publishing {
+        publications {
+            create<MavenPublication>("api") {
+                groupId = "edu.wpi.first.shuffleboard"
+                artifactId = "api"
+                getWPILibVersion()?.let { version = it }
+                val shadowJar: ShadowJar by tasks
+                artifact (shadowJar) {
+                    classifier = null
+                }
+                artifact(sourceJar)
+                artifact(javadocJar)
             }
         }
     }

--- a/plugins/base/base.gradle.kts
+++ b/plugins/base/base.gradle.kts
@@ -1,7 +1,3 @@
-plugins {
-    `java-library`
-}
-
 description = """
 Base shuffleboard plugin that provides the default data types and widgets.
 """.trimMargin()

--- a/plugins/cameraserver/cameraserver.gradle.kts
+++ b/plugins/cameraserver/cameraserver.gradle.kts
@@ -2,10 +2,6 @@ description = """
 The bundled CameraServer plugin. This plugin provides data sources and widgets for viewing MJPEG streams from the WPILib CameraServer.
 """.trimIndent().trim()
 
-plugins {
-    id("edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin") version "1.6"
-}
-
 dependencies {
     api(group = "edu.wpi.first.cscore", name = "cscore-java", version = "+")
     implementation(group = "edu.wpi.first.cscore", name = "cscore-jni", version = "+")

--- a/plugins/cameraserver/cameraserver.gradle.kts
+++ b/plugins/cameraserver/cameraserver.gradle.kts
@@ -3,7 +3,9 @@ The bundled CameraServer plugin. This plugin provides data sources and widgets f
 """.trimIndent().trim()
 
 dependencies {
-    api(group = "edu.wpi.first.cscore", name = "cscore-java", version = "+")
-    implementation(group = "edu.wpi.first.cscore", name = "cscore-jni", version = "+")
-    implementation(group = "edu.wpi.first.wpilib", name = "opencv", version = "3.2.0")
+    compile(group = "edu.wpi.first.cscore", name = "cscore-java", version = "+")
+    compile(group = "org.opencv", name = "opencv-java", version = "3.2.0")
+    compile(group = "org.jcodec", name = "jcodec-javase", version = "0.2.0")
+    compile(group = "edu.wpi.first.cscore", name = "cscore-jni", version = "+", classifier = "all")
+    compile(group = "org.opencv", name = "opencv-jni", version = "+", classifier = "all")
 }

--- a/plugins/plugins.gradle.kts
+++ b/plugins/plugins.gradle.kts
@@ -1,7 +1,18 @@
+import edu.wpi.first.wpilib.versioning.ReleaseType
+import org.gradle.jvm.tasks.Jar
+
+// Ensure that the WPILibVersioningPlugin is setup by setting the release type, if releaseType wasn't
+// already specified on the command line
+if (!hasProperty("releaseType")) {
+    WPILibVersion {
+        releaseType = ReleaseType.DEV
+    }
+}
+
 subprojects {
-    apply {
-        plugin("com.github.johnrengelman.shadow")
-        plugin("java-library")
+    plugins {
+        id("edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin") version "2.0"
+        `java-library`
     }
     dependencies {
         compile(group = "com.google.code.findbugs", name = "annotations", version = "+")
@@ -12,4 +23,32 @@ subprojects {
         implementation(group = "edu.wpi.first.cscore", name = "cscore-jni", version = "+", classifier = "all")
         implementation(group = "org.opencv", name = "opencv-jni", version = "+", classifier = "all")
     }
+    val sourceJar = task<Jar>("sourceJar") {
+        description = "Creates a JAR that contains the source code."
+        from(java.sourceSets["main"].allSource)
+        classifier = "sources"
+    }
+    val javadocJar = task<Jar>("javadocJar") {
+        dependsOn("javadoc")
+        description = "Creates a JAR that contains the javadocs."
+        from(java.docsDir)
+        classifier = "javadoc"
+    }
+    publishing.publications {
+        create<MavenPublication>("api") {
+            groupId = "edu.wpi.first.shuffleboard.plugin"
+            artifactId = project.name
+            getWPILibVersion()?.let { version = it }
+            val jar: Jar by tasks
+            artifact(jar)
+            artifact(javadocJar)
+            artifact(sourceJar)
+        }
+    }
 }
+
+/**
+ * @return [edu.wpi.first.wpilib.versioning.WPILibVersioningPluginExtension.version] value or null
+ * if that value is the empty string.
+ */
+fun getWPILibVersion(): String? = if (WPILibVersion.version != "") WPILibVersion.version else null

--- a/plugins/plugins.gradle.kts
+++ b/plugins/plugins.gradle.kts
@@ -1,48 +1,43 @@
 import edu.wpi.first.wpilib.versioning.ReleaseType
 import org.gradle.jvm.tasks.Jar
 
-// Ensure that the WPILibVersioningPlugin is setup by setting the release type, if releaseType wasn't
-// already specified on the command line
-if (!hasProperty("releaseType")) {
-    WPILibVersion {
-        releaseType = ReleaseType.DEV
-    }
-}
-
 subprojects {
-    plugins {
-        id("edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin") version "2.0"
-        `java-library`
-    }
-    dependencies {
-        compile(group = "com.google.code.findbugs", name = "annotations", version = "+")
-        compile(project(":api"))
-        compile(group = "edu.wpi.first.cscore", name = "cscore-java", version = "+")
-        compile(group = "org.opencv", name = "opencv-java", version = "3.2.0")
-        compile(group = "org.jcodec", name = "jcodec-javase", version = "0.2.0")
-        implementation(group = "edu.wpi.first.cscore", name = "cscore-jni", version = "+", classifier = "all")
-        implementation(group = "org.opencv", name = "opencv-jni", version = "+", classifier = "all")
-    }
-    val sourceJar = task<Jar>("sourceJar") {
-        description = "Creates a JAR that contains the source code."
-        from(java.sourceSets["main"].allSource)
-        classifier = "sources"
-    }
-    val javadocJar = task<Jar>("javadocJar") {
-        dependsOn("javadoc")
-        description = "Creates a JAR that contains the javadocs."
-        from(java.docsDir)
-        classifier = "javadoc"
-    }
-    publishing.publications {
-        create<MavenPublication>("api") {
-            groupId = "edu.wpi.first.shuffleboard.plugin"
-            artifactId = project.name
-            getWPILibVersion()?.let { version = it }
-            val jar: Jar by tasks
-            artifact(jar)
-            artifact(javadocJar)
-            artifact(sourceJar)
+    afterEvaluate {
+        // Ensure that the WPILibVersioningPlugin is setup by setting the release type, if releaseType wasn't
+        // already specified on the command line
+        if (!hasProperty("releaseType")) {
+            WPILibVersion {
+                releaseType = ReleaseType.DEV
+            }
+        }
+        plugins {
+            id("edu.wpi.first.wpilib.versioning.WPILibVersioningPlugin") version "2.0"
+            `java-library`
+        }
+        dependencies {
+            compileOnly(group = "com.google.code.findbugs", name = "annotations", version = "+")
+            compile(project(":api"))
+        }
+        val sourceJar = task<Jar>("sourceJar") {
+            description = "Creates a JAR that contains the source code."
+            from(java.sourceSets["main"].allSource)
+            classifier = "sources"
+        }
+        val javadocJar = task<Jar>("javadocJar") {
+            dependsOn("javadoc")
+            description = "Creates a JAR that contains the javadocs."
+            from(java.docsDir)
+            classifier = "javadoc"
+        }
+        publishing.publications {
+            create<MavenPublication>("plugin.${project.name}") {
+                groupId = "edu.wpi.first.shuffleboard.plugin"
+                artifactId = project.name
+                getWPILibVersion()?.let { version = it }
+                from(components["java"])
+                artifact(javadocJar)
+                artifact(sourceJar)
+            }
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,7 +5,11 @@ include ":plugins:base"
 include ":plugins:cameraserver"
 include ":plugins:networktables"
 
-rootProject.children.each { project ->
+rootProject.children.each {
+    setUpChildProject(it)
+}
+
+private void setUpChildProject(ProjectDescriptor project) {
     /*
      * Instead of every file being named build.gradle.kts we instead use the name ${project.name}.gradle.kts.
      * This is much nicer for searching for the file in your IDE.
@@ -16,5 +20,6 @@ rootProject.children.each { project ->
     if (!project.buildFile.isFile()) {
         project.buildFileName = kotlinName
     }
-    assert project.buildFile.isFile() : "File named $groovyName or $kotlinName must exist."
+    assert project.buildFile.isFile(): "File named $groovyName or $kotlinName must exist."
+    project.children.each { setUpChildProject(it) }
 }


### PR DESCRIPTION
Fixes #193
Fixes #265

Plugins are currently distributed as normal jars, (not as uberjars). A good improvement would be to bundle non-shuffleboard dependencies so third-party plugins dependent on the bulitin ones (see #263) are able to use their libraries, eg `ntcore` for a plugin that depends on the NetworkTables plugin. Unfortunately, it looks like it's difficult to exclude transitive dependencies so even if the API files are excluded, all of its dependent libraries (and their dependents, and so on) will be bundled in every plugin.

Since the builtin plugins are already distributed as part of the app, it's not as big a deal from our end. But third-party developers won't have access to `cscore` (and probably `ntcore` once that gets moved entirely to the nt plugin).

@JLLeitschuh Any thoughts on how we can bundle _only_ the dependencies declared in the plugin gradle files as part of a shadow jar?