### PR TITLE
Publish the API jar standalone, not as uberjar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -241,9 +241,8 @@ project(":api") {
                 groupId = "edu.wpi.first.shuffleboard"
                 artifactId = "api"
                 getWPILibVersion()?.let { version = it }
-                val shadowJar: ShadowJar by tasks
-                artifact (shadowJar) {
-                    classifier = null
+                afterEvaluate {
+                    from(components["java"])
                 }
                 artifact(sourceJar)
                 artifact(javadocJar)


### PR DESCRIPTION
This allows consumers to get sources and javadoc jars for libraries API depends on

Also cuts down the size of the jar from 25MB to 130KB