### PR TITLE
Add widget for editing robot preferences

### DIFF
--- a/api/api.gradle.kts
+++ b/api/api.gradle.kts
@@ -9,7 +9,7 @@ Public API for writing plugins for shuffleboard.
 dependencies {
     api(group = "com.google.guava", name = "guava", version = "21.0")
     api(group = "org.fxmisc.easybind", name = "easybind", version = "1.0.3")
-    api(group = "org.controlsfx", name = "controlsfx", version = "8.40.11")
+    api(group = "org.controlsfx", name = "controlsfx", version = "8.40.14")
     api(group = "de.codecentric.centerdevice", name = "javafxsvg", version = "1.2.1")
     api(group = "edu.wpi.first.ntcore", name = "ntcore-java", version = "4.+")
     api(group = "eu.hansolo", name = "Medusa", version = "7.9") // Note the capital 'M' -- lowercase is a much older version!

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/WidgetPropertySheet.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/WidgetPropertySheet.java
@@ -28,7 +28,7 @@ import javafx.util.StringConverter;
 public class WidgetPropertySheet extends PropertySheet {
 
   /**
-   * Creates an empry property sheet.
+   * Creates an empty property sheet.
    */
   public WidgetPropertySheet() {
     super();

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/WidgetPropertySheet.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/WidgetPropertySheet.java
@@ -1,7 +1,5 @@
-package edu.wpi.first.shuffleboard.app.components;
+package edu.wpi.first.shuffleboard.api.components;
 
-import edu.wpi.first.shuffleboard.api.components.IntegerField;
-import edu.wpi.first.shuffleboard.api.components.NumberField;
 import edu.wpi.first.shuffleboard.api.theme.Theme;
 import edu.wpi.first.shuffleboard.api.theme.Themes;
 
@@ -11,7 +9,7 @@ import org.controlsfx.property.editor.AbstractPropertyEditor;
 import org.controlsfx.property.editor.DefaultPropertyEditorFactory;
 import org.controlsfx.property.editor.PropertyEditor;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -19,7 +17,6 @@ import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.Property;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.value.ObservableValue;
-import javafx.collections.FXCollections;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Control;
 import javafx.scene.control.TextField;
@@ -31,12 +28,10 @@ import javafx.util.StringConverter;
 public class WidgetPropertySheet extends PropertySheet {
 
   /**
-   * Creates a new property sheet for the given widget.
+   * Creates an empry property sheet.
    */
-  public WidgetPropertySheet(List<Property<?>> properties) {
-    super(properties.stream()
-        .map(property -> new PropertyItem<>(property))
-        .collect(Collectors.toCollection(FXCollections::observableArrayList)));
+  public WidgetPropertySheet() {
+    super();
     setModeSwitcherVisible(false);
     setSearchBoxVisible(false);
     setPropertyEditorFactory(new DefaultPropertyEditorFactory() {
@@ -60,6 +55,16 @@ public class WidgetPropertySheet extends PropertySheet {
         return super.call(item);
       }
     });
+  }
+
+  /**
+   * Creates a new property sheet containing items for each of the given properties.
+   */
+  public WidgetPropertySheet(Collection<Property<?>> properties) {
+    this();
+    getItems().setAll(properties.stream()
+        .map(property -> new PropertyItem<>(property))
+        .collect(Collectors.toList()));
   }
 
   /**

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/data/MapData.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/data/MapData.java
@@ -2,6 +2,7 @@ package edu.wpi.first.shuffleboard.api.data;
 
 import com.google.common.collect.ImmutableMap;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class MapData extends ComplexData<MapData> {
@@ -31,6 +32,20 @@ public class MapData extends ComplexData<MapData> {
 
   public boolean containsValue(Object value) {
     return map.containsValue(value);
+  }
+
+  /**
+   * Creates a new MapData instance that is identical to this one, but with a new value for the given key.
+   *
+   * @param key   the key to set
+   * @param value the new value to put
+   *
+   * @return a new MapData instance containing the change
+   */
+  public MapData put(String key, Object value) {
+    HashMap<String, Object> map = new HashMap<>(this.map);
+    map.put(key, value);
+    return new MapData(map);
   }
 
   @Override

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/NetworkTableUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/NetworkTableUtils.java
@@ -23,8 +23,8 @@ public final class NetworkTableUtils {
   public static final NetworkTableInstance inst = NetworkTableInstance.getDefault();
   public static final NetworkTable rootTable = new NetworkTable(inst, "");
 
-  private static final Pattern oldMetadataPattern = Pattern.compile("/~\\w+~($|/)");
-  private static final Pattern newMetadataPattern = Pattern.compile("/\\.");
+  private static final Pattern oldMetadataPattern = Pattern.compile("(^|/)~\\w+~($|/)");
+  private static final Pattern newMetadataPattern = Pattern.compile("(^|/)\\.");
 
   private NetworkTableUtils() {
     throw new UnsupportedOperationException("This is a utility class!");

--- a/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
+++ b/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
@@ -87,10 +87,6 @@
     -fx-font-size: 11pt;
 }
 
-.tile .toggle-switch {
-    -fx-font-size: 12pt;
-}
-
 .tile:selected {
     -fx-effect: dropshadow(gaussian, -swatch-500, 6, 0.1, 0, 4);
 }
@@ -102,8 +98,8 @@
     -fx-font-size: 11pt;
 }
 
-.tile .property-sheet * {
-    /* TODO figure out exactly what needs to be set */
+.tile .scroll-pane, .tile .viewport,
+.tile .property-sheet .property-pane, .tile .property-sheet .tool-bar {
     -fx-background-color: transparent;
 }
 
@@ -112,13 +108,8 @@
     -fx-font-size: 12px;
 }
 
-
 .layout-label * {
     -fx-text-fill: #aaa;
-}
-
-.tile .scroll-pane, .tile .viewport {
-    -fx-background-color: transparent;
 }
 
 /*******************************************************************************

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -17,7 +17,7 @@ import edu.wpi.first.shuffleboard.api.util.TypeUtils;
 import edu.wpi.first.shuffleboard.api.widget.Components;
 import edu.wpi.first.shuffleboard.app.components.DashboardTabPane;
 import edu.wpi.first.shuffleboard.app.components.WidgetGallery;
-import edu.wpi.first.shuffleboard.app.components.WidgetPropertySheet;
+import edu.wpi.first.shuffleboard.api.components.WidgetPropertySheet;
 import edu.wpi.first.shuffleboard.app.json.JsonBuilder;
 import edu.wpi.first.shuffleboard.app.plugin.PluginLoader;
 import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
@@ -18,7 +18,7 @@ import edu.wpi.first.shuffleboard.app.components.LayoutTile;
 import edu.wpi.first.shuffleboard.app.components.Tile;
 import edu.wpi.first.shuffleboard.app.components.TileLayout;
 import edu.wpi.first.shuffleboard.app.components.WidgetPane;
-import edu.wpi.first.shuffleboard.app.components.WidgetPropertySheet;
+import edu.wpi.first.shuffleboard.api.components.WidgetPropertySheet;
 import edu.wpi.first.shuffleboard.app.components.WidgetTile;
 import edu.wpi.first.shuffleboard.app.dnd.TileDragResizer;
 import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
@@ -1,6 +1,7 @@
 package edu.wpi.first.shuffleboard.app.components;
 
 import edu.wpi.first.shuffleboard.api.Populatable;
+import edu.wpi.first.shuffleboard.api.components.WidgetPropertySheet;
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
 import edu.wpi.first.shuffleboard.api.sources.DataSource;
 import edu.wpi.first.shuffleboard.api.util.Debouncer;

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/dark.css
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/dark.css
@@ -68,6 +68,11 @@
  ******************************************************************************/
 .text-field, .text-area {
     -fx-text-fill: -fx-text-base-color;
+    -underline-color: -swatch-gray;
+}
+
+.text-field:focused, .text-area:focused {
+    -fx-border-color: -swatch-200;
 }
 
 /*******************************************************************************
@@ -235,15 +240,6 @@
 .list-view:hover .list-cell:filled:hover {
     -fx-background-color: -swatch-light-gray;
     -fx-text-fill: -fx-text-base-color;
-}
-
-/*******************************************************************************
- *                                                                             *
- * Text field, text area                                                       *
- *                                                                             *
- ******************************************************************************/
-.text-area, .text-field {
-    -underline-color: -swatch-500;
 }
 
 /*******************************************************************************

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/dark.css
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/dark.css
@@ -125,7 +125,7 @@
 }
 
 .toggle-switch > .thumb {
-    -fx-background-color: -swatch-light-gray;
+    -fx-background-color: #AAAAAA;
 }
 
 .toggle-switch:selected > .thumb-area {

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -23,6 +23,7 @@ import edu.wpi.first.shuffleboard.plugin.base.data.types.NumberType;
 import edu.wpi.first.shuffleboard.plugin.base.data.types.PIDControllerType;
 import edu.wpi.first.shuffleboard.plugin.base.data.types.PowerDistributionType;
 import edu.wpi.first.shuffleboard.plugin.base.data.types.RawByteType;
+import edu.wpi.first.shuffleboard.plugin.base.data.types.RobotPreferencesType;
 import edu.wpi.first.shuffleboard.plugin.base.data.types.SendableChooserType;
 import edu.wpi.first.shuffleboard.plugin.base.data.types.SpeedControllerType;
 import edu.wpi.first.shuffleboard.plugin.base.data.types.StringArrayType;
@@ -44,6 +45,7 @@ import edu.wpi.first.shuffleboard.plugin.base.widget.NumberBarWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.NumberSlider;
 import edu.wpi.first.shuffleboard.plugin.base.widget.PIDControllerWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.PowerDistributionPanelWidget;
+import edu.wpi.first.shuffleboard.plugin.base.widget.RobotPreferencesWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.SimpleDialWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.SpeedController;
 import edu.wpi.first.shuffleboard.plugin.base.widget.TextView;
@@ -76,6 +78,7 @@ public class BasePlugin extends Plugin {
         new AnalogInputType(),
         new PowerDistributionType(),
         new EncoderType(),
+        new RobotPreferencesType(),
         new SendableChooserType(),
         new SpeedControllerType(),
         new SubsystemType(),
@@ -100,6 +103,7 @@ public class BasePlugin extends Plugin {
         WidgetType.forAnnotatedWidget(PowerDistributionPanelWidget.class),
         WidgetType.forAnnotatedWidget(ComboBoxChooser.class),
         WidgetType.forAnnotatedWidget(EncoderWidget.class),
+        WidgetType.forAnnotatedWidget(RobotPreferencesWidget.class),
         WidgetType.forAnnotatedWidget(SpeedController.class),
         WidgetType.forAnnotatedWidget(CommandWidget.class),
         WidgetType.forAnnotatedWidget(ThreeAxisAccelerometerWidget.class),
@@ -134,6 +138,7 @@ public class BasePlugin extends Plugin {
         .put(new PowerDistributionType(), WidgetType.forAnnotatedWidget(PowerDistributionPanelWidget.class))
         .put(new SendableChooserType(), WidgetType.forAnnotatedWidget(ComboBoxChooser.class))
         .put(new EncoderType(), WidgetType.forAnnotatedWidget(EncoderWidget.class))
+        .put(new RobotPreferencesType(), WidgetType.forAnnotatedWidget(RobotPreferencesWidget.class))
         .put(new SpeedControllerType(), WidgetType.forAnnotatedWidget(SpeedController.class))
         .put(new CommandType(), WidgetType.forAnnotatedWidget(CommandWidget.class))
         .put(new ThreeAxisAccelerometerType(), WidgetType.forAnnotatedWidget(ThreeAxisAccelerometerWidget.class))

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/RobotPreferencesData.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/RobotPreferencesData.java
@@ -1,0 +1,21 @@
+package edu.wpi.first.shuffleboard.plugin.base.data;
+
+import edu.wpi.first.shuffleboard.api.data.MapData;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class RobotPreferencesData extends MapData {
+
+  public RobotPreferencesData(Map<String, Object> map) {
+    super(map);
+  }
+
+  @Override
+  public RobotPreferencesData put(String key, Object value) {
+    HashMap<String, Object> map = new HashMap<>(asMap());
+    map.put(key, value);
+    return new RobotPreferencesData(map);
+  }
+
+}

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/types/RobotPreferencesType.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/types/RobotPreferencesType.java
@@ -1,0 +1,26 @@
+package edu.wpi.first.shuffleboard.plugin.base.data.types;
+
+import edu.wpi.first.shuffleboard.api.data.ComplexDataType;
+import edu.wpi.first.shuffleboard.plugin.base.data.RobotPreferencesData;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+public final class RobotPreferencesType extends ComplexDataType<RobotPreferencesData> {
+
+  public RobotPreferencesType() {
+    super("RobotPreferences", RobotPreferencesData.class);
+  }
+
+  @Override
+  public Function<Map<String, Object>, RobotPreferencesData> fromMap() {
+    return RobotPreferencesData::new;
+  }
+
+  @Override
+  public RobotPreferencesData getDefaultValue() {
+    return new RobotPreferencesData(new HashMap<>());
+  }
+
+}

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/RobotPreferencesWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/RobotPreferencesWidget.java
@@ -1,0 +1,85 @@
+package edu.wpi.first.shuffleboard.plugin.base.widget;
+
+import edu.wpi.first.shuffleboard.api.components.WidgetPropertySheet;
+import edu.wpi.first.shuffleboard.api.util.AlphanumComparator;
+import edu.wpi.first.shuffleboard.api.widget.Description;
+import edu.wpi.first.shuffleboard.api.widget.ParametrizedController;
+import edu.wpi.first.shuffleboard.api.widget.SimpleAnnotatedWidget;
+import edu.wpi.first.shuffleboard.plugin.base.data.RobotPreferencesData;
+
+import org.controlsfx.control.PropertySheet;
+
+import java.util.Comparator;
+import java.util.Map;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.MapChangeListener;
+import javafx.collections.ObservableMap;
+import javafx.fxml.FXML;
+import javafx.scene.layout.Pane;
+
+/**
+ * A widget for displaying and editing preferences for an FRC robot.
+ */
+@Description(name = "Robot Preferences", dataTypes = RobotPreferencesData.class)
+@ParametrizedController("RobotPreferencesWidget.fxml")
+public class RobotPreferencesWidget extends SimpleAnnotatedWidget<RobotPreferencesData> {
+
+  @FXML
+  private Pane root;
+  @FXML
+  private PropertySheet propertySheet;
+
+  // Keep map of properties
+  // If we just used the data map in the property sheet, a new item (and editor) would be created for each change
+  // For example, typing a new character in a text field would remove that field and replace it with a new one
+  // This approach makes it so that editors don't appear to lose focus when users are interacting with them
+  private final ObservableMap<String, ObjectProperty<Object>> wrapperProperties = FXCollections.observableHashMap();
+
+  private static final Comparator<PropertySheet.Item> itemSorter =
+      Comparator.comparing(PropertySheet.Item::getName, AlphanumComparator.INSTANCE);
+
+  @FXML
+  private void initialize() {
+    dataOrDefault.addListener((__, prevData, curData) -> {
+      Map<String, Object> updated = curData.changesFrom(prevData);
+      if (prevData != null) {
+        // Remove items for any deleted robot preferences
+        prevData.asMap().entrySet().stream()
+            .map(Map.Entry::getKey)
+            .filter(k -> !curData.containsKey(k))
+            .forEach(wrapperProperties::remove);
+      }
+      updated.forEach((key, value) -> {
+        if (wrapperProperties.containsKey(key)) {
+          // Already created a wrapper, update it
+          wrapperProperties.get(key).set(value);
+        } else {
+          // Create a new wrapper property
+          SimpleObjectProperty<Object> wrapper = new SimpleObjectProperty<>(this, key, value);
+          wrapper.addListener((o, p, newValue) -> setData(getData().put(key, newValue)));
+          wrapperProperties.put(key, wrapper);
+        }
+      });
+    });
+
+    wrapperProperties.addListener((MapChangeListener<String, ObjectProperty<? super Object>>) change -> {
+      if (change.wasAdded()) {
+        propertySheet.getItems().add(new WidgetPropertySheet.PropertyItem<>(change.getValueAdded(), change.getKey()));
+      } else if (change.wasRemoved()) {
+        propertySheet.getItems().removeIf(i -> i.getName().equals(change.getKey()));
+      }
+      propertySheet.getItems().sort(itemSorter);
+    });
+
+    exportProperties(propertySheet.searchBoxVisibleProperty());
+  }
+
+  @Override
+  public Pane getView() {
+    return root;
+  }
+
+}

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/RobotPreferencesWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/RobotPreferencesWidget.java
@@ -2,6 +2,7 @@ package edu.wpi.first.shuffleboard.plugin.base.widget;
 
 import edu.wpi.first.shuffleboard.api.components.WidgetPropertySheet;
 import edu.wpi.first.shuffleboard.api.util.AlphanumComparator;
+import edu.wpi.first.shuffleboard.api.util.NetworkTableUtils;
 import edu.wpi.first.shuffleboard.api.widget.Description;
 import edu.wpi.first.shuffleboard.api.widget.ParametrizedController;
 import edu.wpi.first.shuffleboard.api.widget.SimpleAnnotatedWidget;
@@ -10,6 +11,7 @@ import edu.wpi.first.shuffleboard.plugin.base.data.RobotPreferencesData;
 import org.controlsfx.control.PropertySheet;
 
 import java.util.Comparator;
+import java.util.Locale;
 import java.util.Map;
 
 import javafx.beans.property.ObjectProperty;
@@ -39,7 +41,7 @@ public class RobotPreferencesWidget extends SimpleAnnotatedWidget<RobotPreferenc
   private final ObservableMap<String, ObjectProperty<Object>> wrapperProperties = FXCollections.observableHashMap();
 
   private static final Comparator<PropertySheet.Item> itemSorter =
-      Comparator.comparing(PropertySheet.Item::getName, AlphanumComparator.INSTANCE);
+      Comparator.comparing(i -> i.getName().toLowerCase(Locale.US), AlphanumComparator.INSTANCE);
 
   @FXML
   private void initialize() {
@@ -53,6 +55,9 @@ public class RobotPreferencesWidget extends SimpleAnnotatedWidget<RobotPreferenc
             .forEach(wrapperProperties::remove);
       }
       updated.forEach((key, value) -> {
+        if (NetworkTableUtils.isMetadata(key)) {
+          return;
+        }
         if (wrapperProperties.containsKey(key)) {
           // Already created a wrapper, update it
           wrapperProperties.get(key).set(value);

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/RobotPreferencesWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/RobotPreferencesWidget.java
@@ -58,15 +58,7 @@ public class RobotPreferencesWidget extends SimpleAnnotatedWidget<RobotPreferenc
         if (NetworkTableUtils.isMetadata(key)) {
           return;
         }
-        if (wrapperProperties.containsKey(key)) {
-          // Already created a wrapper, update it
-          wrapperProperties.get(key).set(value);
-        } else {
-          // Create a new wrapper property
-          SimpleObjectProperty<Object> wrapper = new SimpleObjectProperty<>(this, key, value);
-          wrapper.addListener((o, p, newValue) -> setData(getData().put(key, newValue)));
-          wrapperProperties.put(key, wrapper);
-        }
+        wrapperProperties.computeIfAbsent(key, k -> generateWrapper(k, value)).setValue(value);
       });
     });
 
@@ -85,6 +77,12 @@ public class RobotPreferencesWidget extends SimpleAnnotatedWidget<RobotPreferenc
   @Override
   public Pane getView() {
     return root;
+  }
+
+  private <T> SimpleObjectProperty<T> generateWrapper(String key, T initialValue) {
+    SimpleObjectProperty<T> wrapper = new SimpleObjectProperty<>(this, key, initialValue);
+    wrapper.addListener((__, prev, value) -> setData(dataOrDefault.get().put(key, value)));
+    return wrapper;
   }
 
 }

--- a/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/RobotPreferencesWidget.fxml
+++ b/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/RobotPreferencesWidget.fxml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import edu.wpi.first.shuffleboard.api.components.WidgetPropertySheet?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.geometry.Insets?>
+<StackPane xmlns="http://javafx.com/javafx"
+           xmlns:fx="http://javafx.com/fxml"
+           fx:controller="edu.wpi.first.shuffleboard.plugin.base.widget.RobotPreferencesWidget"
+           fx:id="root"
+           minWidth="192" minHeight="100">
+    <padding>
+        <Insets topRightBottomLeft="4"/>
+    </padding>
+    <WidgetPropertySheet fx:id="propertySheet" searchBoxVisible="true"/>
+</StackPane>


### PR DESCRIPTION
Move WidgetPropertySheet to API so plugins can use it
Make text fields on dark theme only have colored underline when focused
Relies on wpilibsuite/allwpilib#701 for type metadata

Fixes #28 (for real this time) by updating to a newer version of controlsfx
Fixes #175

Search field is toggleable in the widget settings

![prefs-0](https://user-images.githubusercontent.com/6320992/32205828-e3c4bf38-bdc7-11e7-9f7a-122b69e8798c.PNG)
![prefs-1](https://user-images.githubusercontent.com/6320992/32205829-e3cfaf56-bdc7-11e7-8a56-f9da2150aa94.PNG)
![prefs-2](https://user-images.githubusercontent.com/6320992/32205830-e3d9d008-bdc7-11e7-8020-a1d8b0192c5d.PNG)
![prefs-3](https://user-images.githubusercontent.com/6320992/32205831-e3e4d840-bdc7-11e7-923b-78e3cb04d19c.PNG)