### PR TITLE
Fix camera server looking at the wrong table when removing URIs

### DIFF
--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/CameraServerSource.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/CameraServerSource.java
@@ -2,6 +2,7 @@ package edu.wpi.first.shuffleboard.plugin.cameraserver.source;
 
 import edu.wpi.cscore.CvSink;
 import edu.wpi.cscore.HttpCamera;
+import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.NetworkTableType;
@@ -35,8 +36,9 @@ public final class CameraServerSource extends AbstractDataSource<CameraServerDat
 
   private static final Map<String, CameraServerSource> sources = new HashMap<>();
 
-  private static final NetworkTableEntry streams
-      = NetworkTableInstance.getDefault().getEntry("/CameraPublisher/streams");
+  private final NetworkTable cameraPublisherTable = NetworkTableInstance.getDefault().getTable("/CameraPublisher");
+  private final NetworkTableEntry streams;
+  private static final String STREAMS_KEY = "streams";
   private static final String[] emptyStringArray = new String[0];
   private HttpCamera camera;
   private final CvSink videoSink;
@@ -58,6 +60,7 @@ public final class CameraServerSource extends AbstractDataSource<CameraServerDat
     setName(name);
     videoSink = new CvSink(name + "-videosink");
 
+    streams = cameraPublisherTable.getSubTable(name).getEntry(STREAMS_KEY);
     String[] streamUrls = removeCameraProtocols(streams.getStringArray(emptyStringArray));
     if (streamUrls.length > 0) {
       camera = new HttpCamera(name, streamUrls);

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/CameraServerSourceType.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/CameraServerSourceType.java
@@ -1,5 +1,6 @@
 package edu.wpi.first.shuffleboard.plugin.cameraserver.source;
 
+import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.shuffleboard.api.sources.SourceEntry;
 import edu.wpi.first.shuffleboard.api.sources.SourceType;
@@ -30,8 +31,8 @@ public final class CameraServerSourceType extends SourceType {
           // 0 is "/", 1 is "/CameraPublisher", 2 is "/CameraPublisher/<name>"
           String name = NetworkTableUtils.simpleKey(hierarchy.get(2));
           String uri = toUri(name);
-          if (NetworkTableInstance.getDefault().getTable(name).getKeys().isEmpty()
-              && NetworkTableInstance.getDefault().getTable(name).getSubTables().isEmpty()) {
+          NetworkTable table = NetworkTableInstance.getDefault().getTable(hierarchy.get(2));
+          if (table.getKeys().isEmpty() && table.getSubTables().isEmpty()) {
             // No keys and no subtables, remove it
             availableUris.remove(uri);
             availableSources.remove(uri);


### PR DESCRIPTION
Was looking at `/<name>` instead of `/CameraPublisher/<name>`

Was looking at `/CameraPublisher/streams` for stream URLs instead of `/CameraPublisher/<name>/streams`