### PR TITLE
Use startDSClient(), remove unused startClient/Server util functions

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/NetworkTableUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/NetworkTableUtils.java
@@ -183,29 +183,6 @@ public final class NetworkTableUtils {
   }
 
   /**
-   * Sets ntcore to server mode.
-   *
-   * @param port the port on the local machine to run the ntcore server on
-   */
-  public static void setServer(int port) {
-    NetworkTableInstance inst = NetworkTableInstance.getDefault();
-    shutdown(inst);
-    inst.startServer("networktables.ini", "", port);
-  }
-
-  /**
-   * Sets ntcore to client mode.
-   *
-   * @param serverIp   the ip of the server to connect to, eg "127.0.0.1" or "localhost"
-   * @param serverPort the port of the server to connect to. This is normally 1735.
-   */
-  public static void setClient(String serverIp, int serverPort) {
-    NetworkTableInstance inst = NetworkTableInstance.getDefault();
-    shutdown(inst);
-    inst.startClient(serverIp, serverPort);
-  }
-
-  /**
    * Concatenates multiple keys.
    *
    * @param key1 the first key

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
@@ -59,6 +59,7 @@ public class NetworkTablesPlugin extends Plugin {
       inst.setServer(value[0], port);
     }
     inst.startClient();
+    inst.startDSClient();
   };
 
   public NetworkTablesPlugin() {
@@ -88,6 +89,7 @@ public class NetworkTablesPlugin extends Plugin {
     }, 0xFF);
 
     inst.startClient();
+    inst.startDSClient();
     serverChangeListener.changed(null, null, serverId.get());
     serverId.addListener(serverChangeListener);
   }


### PR DESCRIPTION
This should allow shuffleboard to automatically connect to a robot when running on a driver station. Can someone with a RoboRIO (@bradamiller, @AustinShalit) please test this behavior?

Fixes #275 