### PR TITLE
Pipe log output to a file on disk, log uncaught exceptions on FX thread

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -14,6 +14,14 @@ import it.sauronsoftware.junique.AlreadyLockedException;
 import it.sauronsoftware.junique.JUnique;
 
 import java.io.IOException;
+import java.util.logging.FileHandler;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -23,7 +31,10 @@ import javafx.scene.layout.Pane;
 import javafx.stage.Screen;
 import javafx.stage.Stage;
 
+@SuppressWarnings("PMD.MoreThanOneLogger") // there's only one logger used, the others are for setting up file logging
 public class Shuffleboard extends Application {
+
+  private static final Logger logger = Logger.getLogger(Shuffleboard.class.getName());
 
   private Pane mainPane; //NOPMD local variable
   private Runnable onOtherAppStart = () -> {};
@@ -40,12 +51,18 @@ public class Shuffleboard extends Application {
       throw alreadyLockedException;
     }
 
+    // Set up the loggers
+    setupLoggers();
+
     // Install SVG image loaders so SVGs can be used like any other image
     SvgImageLoaderFactory.install();
   }
 
   @Override
   public void start(Stage primaryStage) throws IOException {
+    // Set up the application thread to log exceptions instead of using printStackTrace()
+    // Must be called in start() because init() is run on the main thread, not the FX application thread
+    Thread.currentThread().setUncaughtExceptionHandler(Shuffleboard::uncaughtException);
     mainPane = FXMLLoader.load(MainWindowController.class.getResource("MainWindow.fxml"));
     onOtherAppStart = () -> Platform.runLater(primaryStage::toFront);
     primaryStage.setScene(new Scene(mainPane));
@@ -66,4 +83,54 @@ public class Shuffleboard extends Application {
     primaryStage.show();
     Time.setStartTime(Time.now());
   }
+
+  /**
+   * Sets up loggers to print to stdout (rather than stderr) and log to ~/SmartDashboard/shuffleboard.log
+   */
+  private void setupLoggers() throws IOException {
+    //Set up the global level logger. This handles IO for all loggers.
+    final Logger globalLogger = LogManager.getLogManager().getLogger("");
+
+    // Remove the default handlers that stream to System.err
+    for (Handler handler : globalLogger.getHandlers()) {
+      globalLogger.removeHandler(handler);
+    }
+
+    final Handler fileHandler = new FileHandler(Storage.getStorageDir() + "/shuffleboard.log");
+
+    fileHandler.setLevel(Level.INFO);    // Only log INFO and above to disk
+    globalLogger.setLevel(Level.CONFIG); // Log CONFIG and higher
+
+    // We need to stream to System.out instead of System.err
+    final StreamHandler sh = new StreamHandler(System.out, new SimpleFormatter()) {
+      @Override
+      public synchronized void publish(final LogRecord record) { // NOPMD this is the same signature as the superclass
+        super.publish(record);
+        // For some reason this doesn't happen automatically.
+        // This will ensure we get all of the logs printed to the console immediately instead of at shutdown
+        flush();
+      }
+    };
+    sh.setLevel(Level.CONFIG); // Log CONFIG and higher to stdout
+
+    globalLogger.addHandler(sh);
+    globalLogger.addHandler(fileHandler);
+    fileHandler.setFormatter(new SimpleFormatter()); //log in text, not xml
+
+    globalLogger.config("Configuration done."); //Log that we are done setting up the logger
+    globalLogger.config("Shuffleboard app version: " + Shuffleboard.class.getPackage().getImplementationVersion());
+  }
+
+  /**
+   * Logs an uncaught exception on a thread. This is in a method instead of directly in a lambda to make the log a bit
+   * cleaner ({@code edu.wpi.first.shuffleboard.app.Shuffleboard uncaughtException} vs
+   * {@code edu.wpi.first.shuffleboard.app.Shuffleboard start$lambda$2$}).
+   *
+   * @param thread    the thread on which the exception was thrown
+   * @param throwable the uncaught exception
+   */
+  private static void uncaughtException(Thread thread, Throwable throwable) {
+    logger.log(Level.WARNING, "Uncaught exception on " + thread.getName(), throwable);
+  }
+
 }


### PR DESCRIPTION
Code more-or-less copy-pasted from GRIP

Log files stored in ~/SmartDashboard/shuffleboard.log

This configuration is global, so any plugin using `java.util.logging.Logger` will have its logs automatically placed in the shuffleboard log file.