### PR TITLE
Remove NetworkTable constructor call

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/NetworkTableUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/NetworkTableUtils.java
@@ -22,7 +22,7 @@ public final class NetworkTableUtils {
    * The root network table.
    */
   public static final NetworkTableInstance inst = NetworkTableInstance.getDefault();
-  public static final NetworkTable rootTable = new NetworkTable(inst, "");
+  public static final NetworkTable rootTable = inst.getTable("");
 
   private static final Pattern oldMetadataPattern = Pattern.compile("(^|/)~\\w+~($|/)");
   private static final Pattern newMetadataPattern = Pattern.compile("(^|/)\\.");


### PR DESCRIPTION
Constructor was made package-private in an upstream ntcore update