### PR TITLE
Fix autopopulation bugs

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
@@ -310,12 +310,12 @@ public class DashboardTabPane extends TabPane {
     @Override
     public boolean supports(String sourceId) {
       SourceType type = SourceTypes.getDefault().typeForUri(sourceId);
+      String name = NetworkTableUtils.normalizeKey(type.removeProtocol(sourceId), false);
       return !deferPopulation
           && isAutoPopulate()
           && type.dataTypeForSource(DataTypes.getDefault(), sourceId) != DataTypes.Map
           && !NetworkTableUtils.isMetadata(sourceId)
-          && (SourceTypes.getDefault().typeForUri(sourceId).removeProtocol(sourceId).startsWith(getSourcePrefix())
-          || sourceId.startsWith(getSourcePrefix()));
+          && (name.startsWith(getSourcePrefix()) || sourceId.startsWith(getSourcePrefix()));
     }
 
     @Override

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSourceType.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSourceType.java
@@ -106,7 +106,7 @@ public final class NetworkTableSourceType extends SourceType {
 
   @Override
   public DataType<?> dataTypeForSource(DataTypes registry, String sourceUri) {
-    return NetworkTableUtils.dataTypeForEntry(sourceUri);
+    return NetworkTableUtils.dataTypeForEntry(removeProtocol(sourceUri));
   }
 
   @Override


### PR DESCRIPTION
- NetworkTableSource wasn't removing the source protocol when getting a NetworkTableEntry
- DashboardTab wasn't removing leading slashes to match with the source names