### PR TITLE
Fix a null-pointer with PropertyUtils bidirectional binding

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/PropertyUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/PropertyUtils.java
@@ -29,31 +29,35 @@ public final class PropertyUtils {
   /**
    * Binds two properties bidirectionally. This is more powerful than the methods in
    * {@link javafx.beans.binding.Bindings} because the two properties can be of any type, not just
-   * the same type (eg {@code firstProperty} can be {@code String} and {@code secondProperty} can be
+   * the same type (eg {@code sourceProperty} can be {@code String} and {@code bindingTarget} can be
    * {@code Double} and the bindings will "just work").
    *
-   * @param firstProperty  the first property to bind
-   * @param secondProperty the second property to bind
+   * <p>Note: the source property will have its value set to the converted value of the binding target.
+   * The converters will not be called if a value changes to {@code null}; instead, the corresponding
+   * property has its value set directly to {@code null}.
+   *
+   * @param sourceProperty the property to apply the binding to
+   * @param bindingTarget  the property to bind to
    * @param t2uConverter   the conversion function to convert values of type {@code T} to {@code U}
    * @param u2tConverter   the conversion function to convert values of type {@code U} to {@code T}
    */
   public static <T, U> void bindBidirectionalWithConverter(
-      Property<T> firstProperty,
-      Property<U> secondProperty,
+      Property<T> sourceProperty,
+      Property<U> bindingTarget,
       Function<? super T, ? extends U> t2uConverter,
       Function<? super U, ? extends T> u2tConverter) {
-    firstProperty.setValue(u2tConverter.apply(secondProperty.getValue()));
-    secondProperty.setValue(t2uConverter.apply(firstProperty.getValue()));
-    firstProperty.addListener((__, old, newValue) -> {
-      U apply = t2uConverter.apply(newValue);
-      if (EqualityUtils.isDifferent(secondProperty.getValue(), apply)) {
-        secondProperty.setValue(t2uConverter.apply(newValue));
+    U targetValue = bindingTarget.getValue();
+    sourceProperty.setValue(targetValue == null ? null : u2tConverter.apply(targetValue));
+    sourceProperty.addListener((__, old, newValue) -> {
+      U newMappedValue = newValue == null ? null : t2uConverter.apply(newValue);
+      if (EqualityUtils.isDifferent(bindingTarget.getValue(), newMappedValue)) {
+        bindingTarget.setValue(newMappedValue);
       }
     });
-    secondProperty.addListener((__, old, newValue) -> {
-      T apply = u2tConverter.apply(newValue);
-      if (EqualityUtils.isDifferent(firstProperty.getValue(), apply)) {
-        firstProperty.setValue(apply);
+    bindingTarget.addListener((__, old, newValue) -> {
+      T newMappedValue = newValue == null ? null : u2tConverter.apply(newValue);
+      if (EqualityUtils.isDifferent(sourceProperty.getValue(), newMappedValue)) {
+        sourceProperty.setValue(newMappedValue);
       }
     });
   }

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/util/PropertyUtilsTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/util/PropertyUtilsTest.java
@@ -2,12 +2,75 @@ package edu.wpi.first.shuffleboard.api.util;
 
 import org.junit.jupiter.api.Test;
 
+import javafx.beans.property.Property;
+import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PropertyUtilsTest extends UtilityClassTest<PropertyUtils> {
+
+  @Test
+  public void testBindBidirectionalWithConverterNullFirstInitialValue() {
+    // given
+    Property<String> str = new SimpleStringProperty(null);
+    Property<Number> num = new SimpleDoubleProperty(0.0);
+
+    // when
+    PropertyUtils.bindBidirectionalWithConverter(str, num, Double::parseDouble, Object::toString);
+
+    // then
+    assertAll(
+        () -> assertEquals("0.0", str.getValue(), "String was not set correctly"),
+        () -> assertEquals(0.0, num.getValue().doubleValue(), "Number should not have changed")
+    );
+  }
+
+  @Test
+  public void testBindBidirectionalWithConverterNullSecondInitialValue() {
+    // given
+    Property<String> str = new SimpleStringProperty("41");
+    Property<Number> num = new SimpleObjectProperty<>(null);
+
+    // when
+    PropertyUtils.bindBidirectionalWithConverter(str, num, Double::parseDouble, Object::toString);
+
+    // then
+    assertAll(
+        () -> assertEquals(null, str.getValue(), "String should not have changed"),
+        () -> assertEquals(null, num.getValue(), "Binding target should not have changed")
+    );
+  }
+
+  @Test
+  public void testBindBidirectionalWithConverter() {
+    // given
+    Property<String> str = new SimpleStringProperty("-42");
+    Property<Number> num = new SimpleDoubleProperty(1.23);
+
+    // when
+    PropertyUtils.bindBidirectionalWithConverter(str, num, Double::parseDouble, Object::toString);
+
+    // then (initial conditions)
+    assertAll(
+        () -> assertEquals("1.23", str.getValue(), "String was not set correctly"),
+        () -> assertEquals(1.23, num.getValue().doubleValue(), "Binding target should not have changed")
+    );
+
+    // when changing one value
+    str.setValue("89");
+    // then
+    assertEquals(89, num.getValue().doubleValue(), "Number was not set correctly");
+
+    // when changing the other value
+    num.setValue(10.01);
+    // then
+    assertEquals("10.01", str.getValue(), "String was not set correctly");
+  }
 
   @Test
   @SuppressWarnings("LocalVariableName")


### PR DESCRIPTION
Also makes it follow the same pattern as a normal bidirectional binding, where the source property has its value to the binding target but not the other way around (ie `a.bindBidriectional(b)` will do `a.set(b)` but not `b.set(a)`)