### PR TITLE
Fix bug with camera stream images

### DIFF
--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/recording/serialization/ImageConverter.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/recording/serialization/ImageConverter.java
@@ -5,7 +5,6 @@ import org.opencv.core.Size;
 import org.opencv.imgproc.Imgproc;
 
 import java.nio.ByteBuffer;
-import java.nio.IntBuffer;
 
 import javafx.scene.image.Image;
 import javafx.scene.image.PixelFormat;
@@ -23,7 +22,6 @@ import static org.opencv.imgproc.Imgproc.INTER_CUBIC;
  */
 public final class ImageConverter {
 
-  private static final PixelFormat<IntBuffer> argbPixelFormat = PixelFormat.getIntArgbInstance();
   private WritableImage image;
   private byte[] data;
   private ByteBuffer buffer;

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/recording/serialization/ImageConverter.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/recording/serialization/ImageConverter.java
@@ -1,11 +1,7 @@
 package edu.wpi.first.shuffleboard.plugin.cameraserver.recording.serialization;
 
-import com.google.common.primitives.UnsignedBytes;
-
 import org.opencv.core.Mat;
-import org.opencv.core.MatOfByte;
 import org.opencv.core.Size;
-import org.opencv.imgcodecs.Imgcodecs;
 import org.opencv.imgproc.Imgproc;
 
 import java.nio.ByteBuffer;
@@ -17,6 +13,8 @@ import javafx.scene.image.WritableImage;
 
 import static org.opencv.core.CvType.CV_8S;
 import static org.opencv.core.CvType.CV_8U;
+import static org.opencv.imgproc.Imgproc.COLOR_BGR2RGB;
+import static org.opencv.imgproc.Imgproc.COLOR_GRAY2RGB;
 import static org.opencv.imgproc.Imgproc.INTER_CUBIC;
 
 /**
@@ -27,8 +25,8 @@ public final class ImageConverter {
 
   private static final PixelFormat<IntBuffer> argbPixelFormat = PixelFormat.getIntArgbInstance();
   private WritableImage image;
-  private IntBuffer pixels;
-  private final MatOfByte imageBuffer = new MatOfByte();
+  private byte[] data;
+  private ByteBuffer buffer;
 
   /**
    * Convert a BGR-formatted OpenCV {@link Mat} into a JavaFX {@link Image}. JavaFX understands ARGB
@@ -55,17 +53,16 @@ public final class ImageConverter {
       return null;
     }
 
-    Mat toRender;
+    Mat toRender = new Mat();
     if (mat.rows() > desiredHeight) {
       // Scale the image down
-      toRender = new Mat();
       Imgproc.resize(
           mat, toRender,
           new Size((int) (((double) mat.cols() * desiredHeight) / mat.rows()), desiredHeight),
           0, 0, INTER_CUBIC
       );
     } else {
-      toRender = mat;
+      mat.copyTo(toRender);
     }
 
     final int width = toRender.cols();
@@ -76,46 +73,26 @@ public final class ImageConverter {
     // dimensions and a buffer big enough to hold all of the pixels in the image.
     if (image == null || image.getWidth() != width || image.getHeight() != height) {
       image = new WritableImage(width, height);
-      pixels = IntBuffer.allocate(width * height);
+      data = new byte[width * height * channels];
+      buffer = ByteBuffer.wrap(data);
     }
 
-    // Copy the data from the image into a MatOfByte so we can extract the raw byte information
-    Imgcodecs.imencode(".bmp", toRender, imageBuffer);
-
-    final ByteBuffer buffer = ByteBuffer.wrap(imageBuffer.toArray());
-    final int stride = buffer.capacity() / height;
-
-    // Convert the data from the Mat into ARGB data that we can put into a JavaFX WritableImage
+    // Convert BGR to RGB so it can be rendered  easily
     switch (channels) {
       case 1:
-        // 1 channel - convert grayscale to ARGB
-        for (int y = 0; y < height; y++) {
-          for (int x = 0; x < width; x++) {
-            final int value = UnsignedBytes.toInt(buffer.get(stride * y + channels * x));
-            pixels.put(width * (height - y - 1) + x, (0xff << 24) | (value << 16) | (value << 8) | value);
-          }
-        }
-
+        Imgproc.cvtColor(toRender, toRender, COLOR_GRAY2RGB);
         break;
-
       case 3:
-        // 3 channels - convert BGR to RGBA
-        for (int y = 0; y < height; y++) {
-          for (int x = 0; x < width; x++) {
-            final int b = UnsignedBytes.toInt(buffer.get(stride * y + channels * x));
-            final int g = UnsignedBytes.toInt(buffer.get(stride * y + channels * x + 1));
-            final int r = UnsignedBytes.toInt(buffer.get(stride * y + channels * x + 2));
-            pixels.put(width * (height - y - 1) + x, (0xff << 24) | (r << 16) | (g << 8) | b);
-          }
-        }
-
+        Imgproc.cvtColor(toRender, toRender, COLOR_BGR2RGB);
         break;
       default:
-        throw new UnsupportedOperationException("Only 1 or 3 channel images can be shown, tried "
-            + "to show a " + channels + " channel image");
+        throw new UnsupportedOperationException("Only 1 or 3-channel images are supported");
     }
 
-    image.getPixelWriter().setPixels(0, 0, width, height, argbPixelFormat, pixels, width);
+    // Grab the image data
+    toRender.get(0, 0, data);
+
+    image.getPixelWriter().setPixels(0, 0, width, height, PixelFormat.getByteRgbInstance(), buffer, width * channels);
 
     return image;
   }

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/CameraServerSource.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/CameraServerSource.java
@@ -1,5 +1,6 @@
 package edu.wpi.first.shuffleboard.plugin.cameraserver.source;
 
+import edu.wpi.cscore.CameraServerJNI;
 import edu.wpi.cscore.CvSink;
 import edu.wpi.cscore.HttpCamera;
 import edu.wpi.first.networktables.NetworkTable;
@@ -40,6 +41,7 @@ public final class CameraServerSource extends AbstractDataSource<CameraServerDat
   private final NetworkTableEntry streams;
   private static final String STREAMS_KEY = "streams";
   private static final String[] emptyStringArray = new String[0];
+  private final int eventListenerId;
   private HttpCamera camera;
   private final CvSink videoSink;
   private final Mat imageStorage = new Mat();
@@ -59,17 +61,38 @@ public final class CameraServerSource extends AbstractDataSource<CameraServerDat
     super(CameraServerDataType.INSTANCE);
     setName(name);
     videoSink = new CvSink(name + "-videosink");
+    eventListenerId = CameraServerJNI.addListener(e -> {
+      if (e.name.equals(name)) {
+        switch (e.kind) {
+          case kSourceConnected:
+            setConnected(true);
+            break;
+          case kSourceDisconnected:
+            setConnected(false);
+            break;
+          default:
+            // don't care
+            break;
+        }
+      }
+    }, 0xFF, true);
 
     streams = cameraPublisherTable.getSubTable(name).getEntry(STREAMS_KEY);
     String[] streamUrls = removeCameraProtocols(streams.getStringArray(emptyStringArray));
     if (streamUrls.length > 0) {
       camera = new HttpCamera(name, streamUrls);
       videoSink.setSource(camera);
+      videoSink.setEnabled(true);
     }
 
+    connected.addListener((__, was, is) -> {
+      if (!is) {
+        // Only listen to changes in the streams when there's a connection
+        streams.removeListener(streamsListener);
+      }
+    });
+
     enabledListener = (__, was, is) -> {
-      // Disable the stream when not active or not connected to save on bandwidth
-      videoSink.setEnabled(is);
       if (is) {
         data.addListener(recordingListener);
         frameFuture = frameGrabberService.submit(this::grabForever);
@@ -92,13 +115,11 @@ public final class CameraServerSource extends AbstractDataSource<CameraServerDat
       } else {
         data.removeListener(recordingListener);
         cancelFrameGrabber();
-        streams.removeListener(streamsListener);
       }
     };
     enabled.addListener(enabledListener);
 
     setActive(camera != null && camera.getUrls().length > 0);
-    setConnected(true);
   }
 
   private void cancelFrameGrabber() {
@@ -181,6 +202,7 @@ public final class CameraServerSource extends AbstractDataSource<CameraServerDat
   public void close() {
     streams.removeListener(streamsListener);
     enabled.removeListener(enabledListener);
+    CameraServerJNI.removeListener(eventListenerId);
     cancelFrameGrabber();
     sources.remove(getName());
   }

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/CameraServerSource.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/CameraServerSource.java
@@ -82,6 +82,7 @@ public final class CameraServerSource extends AbstractDataSource<CameraServerDat
             String[] urls = removeCameraProtocols(entryNotification.value.getStringArray());
             if (camera == null) {
               camera = new HttpCamera(name, urls);
+              videoSink.setSource(camera);
             } else if (EqualityUtils.isDifferent(camera.getUrls(), urls)) {
               camera.setUrls(urls);
             }


### PR DESCRIPTION
Images would have a strip of pixels from the right edge shown on the left side of the image
Also fixes the video sink not being connected when the stream URLs are set after a source is created
Fixes CameraServer widget not reconnecting when losing and regaining connection to the server