### PR TITLE
Change default voltage view range to (0, 5) volts

### DIFF
--- a/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/VoltageView.fxml
+++ b/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/VoltageView.fxml
@@ -10,5 +10,5 @@
     <padding>
         <Insets top="8" right="16" bottom="8" left="16"/>
     </padding>
-    <LinearIndicator fx:id="indicator" styleClass="voltage-view" min="-12" max="12" showTickLabels="true" showTickMarks="true"/>
+    <LinearIndicator fx:id="indicator" styleClass="voltage-view" min="0" max="5" showTickLabels="true" showTickMarks="true"/>
 </StackPane>


### PR DESCRIPTION
Note that old save files will still show in the range (-12, 12) since the min and max values are saved configurable properties.