### PR TITLE
Change command widgets to toggle buttons with the command name

### DIFF
--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/CommandWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/CommandWidget.java
@@ -5,8 +5,11 @@ import edu.wpi.first.shuffleboard.api.widget.ParametrizedController;
 import edu.wpi.first.shuffleboard.api.widget.SimpleAnnotatedWidget;
 import edu.wpi.first.shuffleboard.plugin.base.data.CommandData;
 
+import org.fxmisc.easybind.EasyBind;
+
 import javafx.fxml.FXML;
 import javafx.scene.control.CheckBox;
+import javafx.scene.control.ToggleButton;
 import javafx.scene.layout.Pane;
 
 @Description(name = "Command", dataTypes = CommandData.class)
@@ -16,12 +19,13 @@ public class CommandWidget extends SimpleAnnotatedWidget<CommandData> {
   @FXML
   private Pane root;
   @FXML
-  private CheckBox checkBox;
+  private ToggleButton button;
 
   @FXML
   private void initialize() {
-    dataProperty().addListener((__, oldData, newData) -> checkBox.setSelected(newData.isRunning()));
-    checkBox.selectedProperty().addListener((__, was, is) -> setData(getData().withRunning(is)));
+    button.textProperty().bind(EasyBind.monadic(dataOrDefault).map(CommandData::getName));
+    dataProperty().addListener((__, oldData, newData) -> button.setSelected(newData.isRunning()));
+    button.selectedProperty().addListener((__, was, is) -> setData(getData().withRunning(is)));
   }
 
   @Override

--- a/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/Command.fxml
+++ b/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/Command.fxml
@@ -1,17 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import javafx.geometry.Insets?>
-<?import javafx.scene.control.CheckBox?>
-<?import javafx.scene.layout.HBox?>
-<HBox xmlns="http://javafx.com/javafx"
-      xmlns:fx="http://javafx.com/fxml"
-      fx:controller="edu.wpi.first.shuffleboard.plugin.base.widget.CommandWidget"
-      fx:id="root"
-      spacing="8"
-      minWidth="128" minHeight="64"
-      alignment="CENTER">
+<?import javafx.scene.control.ToggleButton?>
+<?import javafx.scene.layout.StackPane?>
+<StackPane xmlns="http://javafx.com/javafx"
+           xmlns:fx="http://javafx.com/fxml"
+           fx:controller="edu.wpi.first.shuffleboard.plugin.base.widget.CommandWidget"
+           fx:id="root">
     <padding>
         <Insets topRightBottomLeft="8"/>
     </padding>
-    <CheckBox fx:id="checkBox" text="Enabled"/>
-</HBox>
+    <ToggleButton fx:id="button"/>
+</StackPane>


### PR DESCRIPTION
This makes it much more obvious as to which command the widget is controlling
Note that the command name is just the name of the command, not accounting for custom preset names like those given in `SmartDashboard.putData` in WPILib

# Screenshots

![light](https://user-images.githubusercontent.com/6320992/34500058-e97b5f0e-efbd-11e7-80a2-55d1c4f9cfd9.png)


![dark](https://user-images.githubusercontent.com/6320992/34500044-dd328e0c-efbd-11e7-8f43-db1364b3f39f.png)
