### PR TITLE
Remove redundant information from titles

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
@@ -528,7 +528,10 @@ public class WidgetPaneController {
               if (!name.equals(widget.getName())) {
                 Components.getDefault()
                     .createWidget(name, widget.getSources())
-                    .ifPresent(tile::setContent);
+                    .ifPresent(newWidget -> {
+                      newWidget.setTitle(widget.getTitle());
+                      tile.setContent(newWidget);
+                    });
               }
             }));
     return list;

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
@@ -279,8 +279,9 @@ public class DashboardTab extends Tab implements HandledTab, Populatable {
           .ifPresent(c -> {
             // Remove redundant source name information from the title, if necessary
             String sourcePrefix = getSourcePrefix();
-            if (sourcePrefix != null && !sourcePrefix.isEmpty() && c.getTitle().startsWith(sourcePrefix + "/")) {
-              c.setTitle(c.getTitle().substring(sourcePrefix.length() + 1));
+            sourcePrefix = sourcePrefix.endsWith("/") ? sourcePrefix : sourcePrefix + "/";
+            if (!sourcePrefix.equals("/") && c.getTitle().startsWith(sourcePrefix)) {
+              c.setTitle(c.getTitle().substring(sourcePrefix.length()));
             }
             getWidgetPane().addComponent(c);
             if (c instanceof Populatable) {

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
@@ -277,6 +277,11 @@ public class DashboardTab extends Tab implements HandledTab, Populatable {
       Components.getDefault().defaultComponentNameFor(source.getDataType())
           .flatMap(s -> Components.getDefault().createComponent(s, source))
           .ifPresent(c -> {
+            // Remove redundant source name information from the title, if necessary
+            String sourcePrefix = getSourcePrefix();
+            if (sourcePrefix != null && !sourcePrefix.isEmpty() && c.getTitle().startsWith(sourcePrefix + "/")) {
+              c.setTitle(c.getTitle().substring(sourcePrefix.length() + 1));
+            }
             getWidgetPane().addComponent(c);
             if (c instanceof Populatable) {
               Autopopulator.getDefault().addTarget((Populatable) c);

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/SubsystemLayout.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/SubsystemLayout.java
@@ -63,8 +63,9 @@ public class SubsystemLayout extends ListLayout implements Populatable, Sourced 
     // underneath named "Elevator/Foo" would show the "Elevator" bit again, even though it's redundant.
     if (getSource() != null) {
       String sourceName = getSource().getName();
-      if (child.getTitle().startsWith(sourceName + "/")) {
-        child.setTitle(child.getTitle().substring(sourceName.length() + 1));
+      String prefix = sourceName.endsWith("/") ? sourceName : sourceName + "/";
+      if (child.getTitle().startsWith(prefix)) {
+        child.setTitle(child.getTitle().substring(prefix.length()));
       }
     }
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/SubsystemLayout.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/SubsystemLayout.java
@@ -8,6 +8,7 @@ import edu.wpi.first.shuffleboard.api.sources.DataSource;
 import edu.wpi.first.shuffleboard.api.sources.SourceTypes;
 import edu.wpi.first.shuffleboard.api.util.NetworkTableUtils;
 import edu.wpi.first.shuffleboard.api.util.TypeUtils;
+import edu.wpi.first.shuffleboard.api.widget.Component;
 import edu.wpi.first.shuffleboard.api.widget.Components;
 import edu.wpi.first.shuffleboard.api.widget.ParametrizedController;
 import edu.wpi.first.shuffleboard.api.widget.Sourced;
@@ -53,6 +54,19 @@ public class SubsystemLayout extends ListLayout implements Populatable, Sourced 
     Components.getDefault().defaultComponentNameFor(source.getDataType())
         .flatMap(name -> Components.getDefault().createComponent(name, source))
         .ifPresent(this::addChild);
+  }
+
+  @Override
+  public void addChild(Component child) {
+    super.addChild(child);
+    // Remove redundant source name information. If a subsystem is named "Elevator", anything
+    // underneath named "Elevator/Foo" would show the "Elevator" bit again, even though it's redundant.
+    if (getSource() != null) {
+      String sourceName = getSource().getName();
+      if (child.getTitle().startsWith(sourceName + "/")) {
+        child.setTitle(child.getTitle().substring(sourceName.length() + 1));
+      }
+    }
   }
 
   DataSource<?> getSource() {


### PR DESCRIPTION
Only applies to components inside subsystem layouts or components that are autopopulated into tabs
Custom titles are also now preserved when changing the widget inside a tile.

Due to crunch time, a later PR can make this also apply to components manually added by users or when changing the source for an existing widget.