### PR TITLE
Always enable the "Edit Properties" action on widget tiles

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
@@ -354,12 +354,8 @@ public class WidgetPaneController {
         if (changeMenus.hasItems()) {
           widgetPaneActions.addNested(changeMenus);
         }
-
-        // Only add the properties menu item if the widget has properties
-        if (!widgetTile.getContent().getProperties().isEmpty()) {
-          widgetPaneActions.addAction("Edit Properties",
-              () -> showPropertySheet(widgetTile));
-        }
+        widgetPaneActions.addAction("Edit Properties",
+            () -> showPropertySheet(widgetTile));
       }
       return widgetPaneActions;
     });


### PR DESCRIPTION
Since there will always be at least one property (`title`) to edit