### PR TITLE
Fixes for sources being deleted on remote and re-added with different data

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/SourceTreeTable.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/SourceTreeTable.java
@@ -7,6 +7,8 @@ import edu.wpi.first.shuffleboard.api.util.EqualityUtils;
 
 import edu.wpi.first.networktables.NetworkTable;
 
+import org.fxmisc.easybind.EasyBind;
+
 import java.util.Comparator;
 import java.util.List;
 
@@ -14,6 +16,7 @@ import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.ReadOnlyObjectWrapper;
 import javafx.beans.property.ReadOnlyStringWrapper;
 import javafx.beans.property.SimpleObjectProperty;
+import javafx.scene.control.Label;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeTableColumn;
 import javafx.scene.control.TreeTableView;
@@ -54,6 +57,12 @@ public class SourceTreeTable<S extends SourceEntry, V> extends TreeTableView<S> 
         f -> new ReadOnlyStringWrapper(getEntryForCellData(f).getViewName()));
     valueColumn.setCellValueFactory(
         f -> new ReadOnlyObjectWrapper(getEntryForCellData(f).getValueView()));
+    Label placeholder = new Label();
+    placeholder.textProperty().bind(EasyBind.monadic(sourceType)
+        .map(SourceType::getName)
+        .map(n -> "No data available. Is there a connection to " + n + "?")
+        .orElse("No data available. Is the source connected?"));
+    setPlaceholder(placeholder);
 
     getColumns().addAll(keyColumn, valueColumn);
   }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/sources/DestroyedSource.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/sources/DestroyedSource.java
@@ -99,11 +99,16 @@ public class DestroyedSource<T> implements DataSource<T> {
   public DataSource<T> restore() throws DataTypeChangedException, IllegalStateException {
     SourceType sourceType = getSourceType();
     if (SourceTypes.getDefault().isRegistered(sourceType)) {
+      boolean restoredExists = sourceType.getAvailableSourceUris().contains(oldId);
       DataSource<T> restored = (DataSource<T>) sourceType.forUri(oldId);
       if (!possibleTypes.contains(restored.getDataType())) {
         throw new DataTypeChangedException(
             "The new data type is " + restored.getDataType() + ", was expecting one of: "
                 + Iterables.toString(possibleTypes));
+      }
+      if (restoredExists) {
+        // The restored source already existed at restoration time, no need to set its name or data
+        return restored;
       }
       restored.nameProperty().set(name.get());
       restored.activeProperty().set(true);

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSource.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSource.java
@@ -56,9 +56,12 @@ public abstract class NetworkTableSource<T> extends AbstractDataSource<T> {
     listenerUid = inst.addEntryListener(fullTableKey, (event) -> {
       if (isConnected()) {
         AsyncUtils.runAsync(() -> {
-          ntUpdate = true;
-          listener.onChange(event.name, event.value.getValue(), event.flags);
-          ntUpdate = false;
+          try {
+            ntUpdate = true;
+            listener.onChange(event.name, event.value.getValue(), event.flags);
+          } finally {
+            ntUpdate = false;
+          }
         });
       }
     },
@@ -101,6 +104,20 @@ public abstract class NetworkTableSource<T> extends AbstractDataSource<T> {
      */
     void onChange(String key, Object value, int flags);
 
+  }
+
+  /**
+   * Removes a cached NetworkTable source for the given source ID.
+   */
+  public static void removeCachedSource(String sourceId) {
+    sources.remove(sourceId);
+  }
+
+  /**
+   * Removes all cached NetworkTable sources.
+   */
+  public static void removeAllCachedSources() {
+    sources.clear();
   }
 
   /**


### PR DESCRIPTION
E.g, deleting a NetworkTable entry `"foo"=true` with type `boolean` and adding an entry `"foo"=1.23` with type `number` would still be assumed to supply `boolean`, and suggestions for widgets to show that source would only suggest `boolean`-supporting widgets.

This fix removes the cached sources and forces them to be recomputed when they're rediscovered after being deleted.

This also clears the available NetworkTable sources when disconnecting from the server  
<sup>\*Does not apply when disconnecting from the network that the server is running on</sup>

Deleting a network table entry will disable all widgets with a source for that entry.