### PR TITLE
Fix spurious test failures

### DIFF
--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/components/NumberFieldTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/components/NumberFieldTest.java
@@ -23,7 +23,7 @@ public class NumberFieldTest extends ApplicationTest {
 
   @Test
   public void numberPropertyIsUpdatedTest() {
-    numberField.clear();
+    interact(numberField::clear);
     clickOn(".text-field").write("123.456");
 
     assertEquals(123.456, numberField.numberProperty().getValue().doubleValue());
@@ -32,7 +32,7 @@ public class NumberFieldTest extends ApplicationTest {
   @ParameterizedTest
   @ValueSource(strings = {"0.0", "1.0", "12.56", "-0", "-1", "-10", "+0", "+55.99", "-54.21"})
   public void validNumberTest(String number) {
-    numberField.clear();
+    interact(numberField::clear);
     clickOn(".text-field").write(number);
 
     assertEquals(Double.parseDouble(number), numberField.getNumber().doubleValue());
@@ -45,7 +45,7 @@ public class NumberFieldTest extends ApplicationTest {
                  "0.0, 0.......0",
                  "0.0, 0.0."})
   public void invalidNumberTest(String expectedResult, String test) {
-    numberField.clear();
+    interact(numberField::clear);
     clickOn(".text-field").write(test);
 
     assertEquals(expectedResult, numberField.getText());

--- a/plugins/base/src/test/java/edu/wpi/first/shuffleboard/plugin/base/widget/AllWidgetSanityTest.java
+++ b/plugins/base/src/test/java/edu/wpi/first/shuffleboard/plugin/base/widget/AllWidgetSanityTest.java
@@ -3,6 +3,8 @@ package edu.wpi.first.shuffleboard.plugin.base.widget;
 import edu.wpi.first.shuffleboard.api.data.DataType;
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
 import edu.wpi.first.shuffleboard.api.sources.DummySource;
+import edu.wpi.first.shuffleboard.api.util.AsyncUtils;
+import edu.wpi.first.shuffleboard.api.util.FxUtils;
 import edu.wpi.first.shuffleboard.api.util.TypeUtils;
 import edu.wpi.first.shuffleboard.api.widget.Widget;
 import edu.wpi.first.shuffleboard.api.widget.WidgetType;
@@ -28,6 +30,7 @@ public class AllWidgetSanityTest extends ApplicationTest {
 
   @BeforeAll
   public static void setup() {
+    AsyncUtils.setAsyncRunner(Runnable::run);
     DataTypes.setDefault(new DataTypes());
     plugin.getDataTypes().forEach(DataTypes.getDefault()::register);
   }
@@ -35,6 +38,7 @@ public class AllWidgetSanityTest extends ApplicationTest {
   @AfterAll
   public static void tearDown() {
     DataTypes.setDefault(new DataTypes());
+    AsyncUtils.setAsyncRunner(FxUtils::runOnFxThread);
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Root cause in all cases: updating JavaFX components or properties from not-the-FX-thread