### PR TITLE
Use executors to move frames in playback

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/properties/AsyncProperty.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/properties/AsyncProperty.java
@@ -1,54 +1,115 @@
 package edu.wpi.first.shuffleboard.api.properties;
 
-import edu.wpi.first.shuffleboard.api.util.AsyncUtils;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.value.ChangeListener;
+import java.util.concurrent.atomic.AtomicReference;
 
-import java.util.Map;
-import java.util.WeakHashMap;
+import javafx.beans.InvalidationListener;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
 
 /**
  * A thread-safe implementation of a property. Any changes to the value will execute on the JavaFX
  * application thread.
  */
-public class AsyncProperty<T> extends SimpleObjectProperty<T> {
+@SuppressWarnings("OverloadMethodsDeclarationOrder")
+public class AsyncProperty<T> extends ObjectProperty<T> implements AtomicProperty<T> {
 
-  private final Map<ChangeListener<? super T>, ChangeListener<? super T>> wrappers = new WeakHashMap<>();
+  private final AtomicReference<T> holder = new AtomicReference<>(null);
+
+  private final AtomicPropertyListenerDelegate<T> delegate;
+  private final Object bean;
+  private final String name;
 
   public AsyncProperty() {
-    super();
+    this(null, null, null);
   }
 
   public AsyncProperty(T initialValue) {
-    super(initialValue);
+    this(null, null, initialValue);
   }
 
   public AsyncProperty(Object bean, String name) {
-    super(bean, name);
+    this(bean, name, null);
   }
 
+  @SuppressWarnings("JavadocMethod")
   public AsyncProperty(Object bean, String name, T initialValue) {
-    super(bean, name, initialValue);
+    this.bean = bean;
+    this.name = name;
+    holder.set(initialValue);
+    delegate = new AtomicPropertyListenerDelegate<>(this);
   }
 
   @Override
-  public void addListener(ChangeListener<? super T> listener) {
-    if (wrappers.containsKey(listener)) {
-      return;
-    }
-    wrappers.put(listener, (obs, prev, cur) -> AsyncUtils.runAsync(() -> listener.changed(obs, prev, cur)));
-    super.addListener(wrappers.get(listener));
+  public void bind(ObservableValue<? extends T> observable) {
+    delegate.bind(observable);
   }
 
   @Override
-  public void removeListener(ChangeListener<? super T> listener) {
-    super.removeListener(wrappers.get(listener));
-    wrappers.remove(listener);
+  public void unbind() {
+    delegate.unbind();
+  }
+
+  @Override
+  public boolean isBound() {
+    return delegate.isBound();
+  }
+
+  @Override
+  public Object getBean() {
+    return bean;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public T get() {
+    return holder.get();
   }
 
   @Override
   public void set(T newValue) {
-    AsyncUtils.runAsync(() -> super.set(newValue));
+    T oldValue = holder.get();
+    holder.set(newValue);
+    delegate.invalidated(oldValue, newValue);
+  }
+
+  @Override
+  public void setValue(T v) {
+    set(v);
+  }
+
+  @Override
+  public void addImmediateListener(ImmediateChangeListener<? super T> listener) {
+    delegate.addImmediateListener(listener);
+  }
+
+  @Override
+  public void removeImmediateListener(ImmediateChangeListener<? super T> listener) {
+    delegate.removeImmediateListener(listener);
+  }
+
+  @Override
+  public void addListener(ChangeListener<? super T> listener) {
+    delegate.addChangeListener(listener);
+  }
+
+  @Override
+  public void removeListener(ChangeListener<? super T> listener) {
+    delegate.removeChangeListener(listener);
+  }
+
+  @Override
+  public void removeListener(InvalidationListener listener) {
+    delegate.removeInvalidationListener(listener);
+  }
+
+  @Override
+  public void addListener(InvalidationListener listener) {
+    delegate.addInvalidationListener(listener);
   }
 
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/properties/AtomicBooleanProperty.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/properties/AtomicBooleanProperty.java
@@ -1,0 +1,110 @@
+package edu.wpi.first.shuffleboard.api.properties;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javafx.beans.InvalidationListener;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+
+/**
+ * An implementation of {@link BooleanProperty} that makes all reads and writes atomic.
+ */
+@SuppressWarnings("OverloadMethodsDeclarationOrder")
+public class AtomicBooleanProperty extends BooleanProperty implements AtomicProperty<Boolean> {
+
+  private final AtomicBoolean holder = new AtomicBoolean(false);
+  private final String name;
+  private final Object bean;
+  
+  private final AtomicPropertyListenerDelegate<Boolean> listenerDelegate;
+
+  public AtomicBooleanProperty(boolean initialValue) {
+    this(null, null, initialValue);
+  }
+
+  public AtomicBooleanProperty(String name, boolean initialValue) {
+    this(null, name, initialValue);
+  }
+
+  @SuppressWarnings("JavadocMethod")
+  public AtomicBooleanProperty(Object bean, String name, boolean initialValue) {
+    this.bean = bean;
+    this.name = name;
+    holder.set(initialValue);
+    listenerDelegate = new AtomicPropertyListenerDelegate<>(this);
+  }
+
+  @Override
+  public void bind(ObservableValue<? extends Boolean> observable) {
+    listenerDelegate.bind(observable);
+  }
+
+  @Override
+  public void unbind() {
+    listenerDelegate.unbind();
+  }
+
+  @Override
+  public boolean isBound() {
+    return listenerDelegate.isBound();
+  }
+
+  @Override
+  public Object getBean() {
+    return bean;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public boolean get() {
+    return holder.get();
+  }
+
+  @Override
+  public void set(boolean value) {
+    boolean oldValue = holder.get();
+    holder.set(value);
+    listenerDelegate.invalidated(oldValue, value);
+  }
+
+  @Override
+  public void setValue(Boolean v) {
+    set(v != null && v);
+  }
+
+  @Override
+  public void addImmediateListener(ImmediateChangeListener<? super Boolean> listener) {
+    listenerDelegate.addImmediateListener(listener);
+  }
+
+  @Override
+  public void removeImmediateListener(ImmediateChangeListener<? super Boolean> listener) {
+    listenerDelegate.removeImmediateListener(listener);
+  }
+
+  @Override
+  public void addListener(ChangeListener<? super Boolean> listener) {
+    listenerDelegate.addChangeListener(listener);
+  }
+
+  @Override
+  public void removeListener(ChangeListener<? super Boolean> listener) {
+    listenerDelegate.removeChangeListener(listener);
+  }
+
+  @Override
+  public void addListener(InvalidationListener listener) {
+    listenerDelegate.addInvalidationListener(listener);
+  }
+
+  @Override
+  public void removeListener(InvalidationListener listener) {
+    listenerDelegate.removeInvalidationListener(listener);
+  }
+
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/properties/AtomicIntegerProperty.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/properties/AtomicIntegerProperty.java
@@ -1,0 +1,114 @@
+package edu.wpi.first.shuffleboard.api.properties;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import javafx.beans.InvalidationListener;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+
+/**
+ * An implementation of {@link IntegerProperty} that makes all reads and writes atomic.
+ */
+@SuppressWarnings("OverloadMethodsDeclarationOrder")
+public class AtomicIntegerProperty extends IntegerProperty implements AtomicProperty<Number> {
+
+  private final AtomicInteger holder = new AtomicInteger(0);
+  private final String name;
+  private final Object bean;
+
+  private final AtomicPropertyListenerDelegate<Number> listenerDelegate;
+
+  public AtomicIntegerProperty() {
+    this(null, null, 0);
+  }
+
+  public AtomicIntegerProperty(int initialValue) {
+    this(null, null, initialValue);
+  }
+
+  public AtomicIntegerProperty(String name, int initialValue) {
+    this(null, name, initialValue);
+  }
+
+  @SuppressWarnings("JavadocMethod")
+  public AtomicIntegerProperty(Object bean, String name, int initialValue) {
+    this.bean = bean;
+    this.name = name;
+    holder.set(initialValue);
+    listenerDelegate = new AtomicPropertyListenerDelegate<>(this);
+  }
+
+  @Override
+  public void bind(ObservableValue<? extends Number> observable) {
+    listenerDelegate.bind(observable);
+  }
+
+  @Override
+  public void unbind() {
+    listenerDelegate.unbind();
+  }
+
+  @Override
+  public boolean isBound() {
+    return listenerDelegate.isBound();
+  }
+
+  @Override
+  public Object getBean() {
+    return bean;
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public int get() {
+    return holder.get();
+  }
+
+  @Override
+  public void set(int value) {
+    int oldValue = holder.get();
+    holder.set(value);
+    listenerDelegate.invalidated(oldValue, value);
+  }
+
+  @Override
+  public void setValue(Number v) {
+    set(v == null ? 0 : v.intValue());
+  }
+
+  @Override
+  public void addImmediateListener(ImmediateChangeListener<? super Number> listener) {
+    listenerDelegate.addImmediateListener(listener);
+  }
+
+  @Override
+  public void removeImmediateListener(ImmediateChangeListener<? super Number> listener) {
+    listenerDelegate.removeImmediateListener(listener);
+  }
+
+  @Override
+  public void addListener(ChangeListener<? super Number> listener) {
+    listenerDelegate.addChangeListener(listener);
+  }
+
+  @Override
+  public void removeListener(ChangeListener<? super Number> listener) {
+    listenerDelegate.removeChangeListener(listener);
+  }
+
+  @Override
+  public void addListener(InvalidationListener listener) {
+    listenerDelegate.addInvalidationListener(listener);
+  }
+
+  @Override
+  public void removeListener(InvalidationListener listener) {
+    listenerDelegate.removeInvalidationListener(listener);
+  }
+
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/properties/AtomicProperty.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/properties/AtomicProperty.java
@@ -1,0 +1,30 @@
+package edu.wpi.first.shuffleboard.api.properties;
+
+import javafx.beans.property.Property;
+
+/**
+ * A type of property that makes all reads and writes atomic. This is intended for multithreaded use. Because the
+ * JavaFX model assumes all changes are made on the JavaFX application thread, listeners and bindings may cause
+ * subtle problems when not called from the JavaFX thread. Atomic properties have their values set immediately
+ * from the calling thread, which then triggers all {@link ImmediateChangeListener immediate change listeers}
+ * to also run from that thread; invalidation and normal change listeners are invoked asynchronously from the JavaFX
+ * application thread. If a change is made on the JavaFX thread, then all listeners will run immediately.
+ */
+public interface AtomicProperty<T> extends Property<T> {
+
+  /**
+   * Adds a listener to be called immediately after the value changes, even when it changes from a thread other than
+   * the JavaFX application thread.
+   *
+   * @see #addListener(javafx.beans.value.ChangeListener)
+   */
+  void addImmediateListener(ImmediateChangeListener<? super T> listener);
+
+  /**
+   * Removes an immediate listener from this property.
+   *
+   * @see #removeListener(javafx.beans.value.ChangeListener)
+   */
+  void removeImmediateListener(ImmediateChangeListener<? super T> listener);
+
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/properties/AtomicPropertyListenerDelegate.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/properties/AtomicPropertyListenerDelegate.java
@@ -1,0 +1,107 @@
+package edu.wpi.first.shuffleboard.api.properties;
+
+import edu.wpi.first.shuffleboard.api.util.EqualityUtils;
+import edu.wpi.first.shuffleboard.api.util.FxUtils;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import javafx.beans.InvalidationListener;
+import javafx.beans.property.Property;
+import javafx.beans.value.ChangeListener;
+import javafx.beans.value.ObservableValue;
+
+/**
+ * A helper class that implements many of the listener and binding related methods for atomic properties. Since Java
+ * does not support multiple inheritance, these could not have been implemented in an abstract superclass for atomic
+ * properties that also need to subclass {@link javafx.beans.property.IntegerProperty IntegerProperty},
+ * {@link javafx.beans.property.BooleanProperty BooleanProperty}, etc., as there are many helper functions in JavaFX
+ * that expect {@code IntegerProperty} instead of {@code Property<Integer>}.
+ */
+public final class AtomicPropertyListenerDelegate<T> {
+
+  private static final WeakReference EMPTY_REF = new WeakReference<>(null);
+  private WeakReference<ObservableValue<? extends T>> bound = EMPTY_REF;
+  private final List<InvalidationListener> invalidationListeners = new ArrayList<>();
+  private final List<ImmediateChangeListener<? super T>> immediateListeners = new ArrayList<>();
+  private final List<ChangeListener<? super T>> changeListeners = new ArrayList<>();
+
+  private final AtomicProperty<T> atomicProperty;
+  private final ChangeListener<? super T> bindingListener;
+
+  public AtomicPropertyListenerDelegate(AtomicProperty<T> atomicProperty) {
+    this.atomicProperty = atomicProperty;
+    bindingListener = (__, oldValue, newValue) -> this.atomicProperty.setValue(newValue);
+  }
+
+  /**
+   * Binds the atomic property to an observable value.
+   *
+   * @see Property#bind(ObservableValue)
+   */
+  public void bind(ObservableValue<? extends T> observableValue) {
+    Objects.requireNonNull(observableValue, "Cannot bind to a null observable");
+    bound = new WeakReference<>(observableValue);
+    observableValue.addListener(bindingListener);
+  }
+
+  /**
+   * Unbinds the atomic property.
+   *
+   * @see Property#unbind()
+   */
+  public void unbind() {
+    if (isBound()) {
+      ObservableValue<? extends T> oldBound = bound.get();
+      if (oldBound != null) {
+        oldBound.removeListener(bindingListener);
+      }
+      bound = EMPTY_REF;
+    }
+  }
+
+  public boolean isBound() {
+    return bound.get() != null;
+  }
+
+  /**
+   * Fires all listeners when the value of the property changes. Invalidation listeners are scheduled first (but may not
+   * <i>run</i> first if this is not called from the JavaFX application thread), then, if the value has changed,
+   * the immediate listeners are called, and then the change listeners are scheduled to be called from the JavaFX
+   * application thread.
+   */
+  public void invalidated(T oldValue, T newValue) {
+    invalidationListeners.forEach(l -> FxUtils.runOnFxThread(() -> l.invalidated(atomicProperty)));
+    if (EqualityUtils.isDifferent(oldValue, newValue)) {
+      immediateListeners.forEach(l -> l.changed(atomicProperty, oldValue, newValue));
+      changeListeners.forEach(l -> FxUtils.runOnFxThread(() -> l.changed(atomicProperty, oldValue, newValue)));
+    }
+  }
+
+  public void addImmediateListener(ImmediateChangeListener<? super T> listener) {
+    immediateListeners.add(listener);
+  }
+
+  public void removeImmediateListener(ImmediateChangeListener<? super T> listener) {
+    immediateListeners.remove(listener);
+  }
+
+  public void addChangeListener(ChangeListener<? super T> listener) {
+    changeListeners.add(listener);
+  }
+
+  public void removeChangeListener(ChangeListener<? super T> listener) {
+    changeListeners.remove(listener);
+  }
+
+  public void addInvalidationListener(InvalidationListener listener) {
+    invalidationListeners.add(listener);
+  }
+
+  public void removeInvalidationListener(InvalidationListener listener) {
+    invalidationListeners.remove(listener);
+  }
+
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/properties/ImmediateChangeListener.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/properties/ImmediateChangeListener.java
@@ -1,0 +1,19 @@
+package edu.wpi.first.shuffleboard.api.properties;
+
+import javafx.beans.value.ChangeListener;
+
+/**
+ * A change listener that is invoked <i>immediately</i> when an atomic property changes. When used as a normal change
+ * listener, it has no special attributes; however, when added as an immediate listener to an atomic property, it will
+ * always be called immediately from the same thread that changed the value, rather than the (potentially) asynchronous
+ * call from the JavaFX thread made for normal change listeners.
+ *
+ * <p>This type of listener must <strong>not</strong> make any changes to normal JavaFX properties or call
+ * methods on JavaFX nodes, as there is no guarantee that it will occur on the JavaFX thread.
+ *
+ * <p>This interface intentionally does not define any methods to maintain use as a functional interface.
+ */
+@FunctionalInterface
+public interface ImmediateChangeListener<T> extends ChangeListener<T> {
+
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/SourceTypes.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/SourceTypes.java
@@ -2,6 +2,7 @@ package edu.wpi.first.shuffleboard.api.sources;
 
 import edu.wpi.first.shuffleboard.api.data.DataType;
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
+import edu.wpi.first.shuffleboard.api.sources.recording.TimestampedData;
 import edu.wpi.first.shuffleboard.api.util.PropertyUtils;
 import edu.wpi.first.shuffleboard.api.util.Registry;
 
@@ -156,6 +157,11 @@ public final class SourceTypes extends Registry<SourceType> {
     @Override
     public DataType<?> dataTypeForSource(DataTypes registry, String sourceUri) {
       return DataTypes.None;
+    }
+
+    @Override
+    public void read(TimestampedData recordedData) {
+      // NOPE
     }
   }
 

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/Scrubber.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/Scrubber.java
@@ -22,10 +22,8 @@ public class Scrubber extends Slider {
 
   private Property<Number> progressProperty = null;
   private final ChangeListener<Number> progressListener = (__, oldProgress, newProgress) -> {
-    if (isViewMode()) {
-      if (newProgress != null) {
-        FxUtils.runOnFxThread(() -> setValue(newProgress.doubleValue()));
-      }
+    if (isViewMode() && newProgress != null) {
+      FxUtils.runOnFxThread(() -> setValue(newProgress.doubleValue()));
     }
   };
 

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/Scrubber.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/Scrubber.java
@@ -23,7 +23,9 @@ public class Scrubber extends Slider {
   private Property<Number> progressProperty = null;
   private final ChangeListener<Number> progressListener = (__, oldProgress, newProgress) -> {
     if (isViewMode()) {
-      FxUtils.runOnFxThread(() -> setValue(newProgress.doubleValue()));
+      if (newProgress != null) {
+        FxUtils.runOnFxThread(() -> setValue(newProgress.doubleValue()));
+      }
     }
   };
 

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/sources/recording/Playback.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/sources/recording/Playback.java
@@ -108,9 +108,9 @@ public final class Playback {
       }
       currentFrame = data.get(newFrame);
       if (newFrame > lastFrame) {
-        forward(newFrame, lastFrame);
+        forward(lastFrame, newFrame);
       } else {
-        backward(newFrame, lastFrame);
+        backward(lastFrame, newFrame);
       }
     });
     paused.addListener((__, wasPaused, isPaused) -> {


### PR DESCRIPTION
This is MUCH simpler and easier to reason about than the old infinite-loop-in-a-thread-with-sleeps
Adds proper atomic JavaFX properties and moves AsyncProperty to use `AtomicReference<T>` instead of using the non-atomic, non-threadsafe field in `SimpleObjectProperty`