### PR TITLE
Allow themes to be defined in the Shuffleboard directory

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/theme/Theme.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/theme/Theme.java
@@ -2,6 +2,9 @@ package edu.wpi.first.shuffleboard.api.theme;
 
 import com.google.common.collect.ImmutableList;
 
+import java.net.URL;
+import java.util.stream.Stream;
+
 /**
  * A theme is a way of stying the shuffleboard application. Themes specify the location of CSS stylesheets that modify
  * the appearance of the UI.
@@ -14,12 +17,35 @@ public class Theme {
   /**
    * Creates a new theme with the given name and styled by the given style sheets.
    *
+   * <p><strong>Themes defined in plugins MUST NOT use this constructor.</strong> Themes defined in plugin jars
+   * will be unable to find their stylesheets, since those stylesheets are in a JAR somewhere that shuffleboard will
+   * not necessarily be aware of.
+   *
    * @param name        the name of the theme
    * @param styleSheets the locations of the style sheets that the theme uses
    */
   public Theme(String name, String... styleSheets) {
     this.name = name;
     this.styleSheets = ImmutableList.copyOf(styleSheets);
+  }
+
+  /**
+   * Creates a new theme with the given name and styled by the given style sheets. This is intended for use for
+   * themes defined in plugins.
+   *
+   * @param localClass  a class defined in the plugin. This parameter allows Shuffleboard to be able to locate the
+   *                    stylesheets within the plugin JAR.
+   * @param name        the name of the theme
+   * @param styleSheets the locations of the style sheets that the theme uses
+   */
+  public Theme(Class<?> localClass, String name, String... styleSheets) {
+    this.name = name;
+    ImmutableList.Builder<String> builder = ImmutableList.builder();
+    Stream.of(styleSheets)
+        .map(localClass.getClassLoader()::getResource)
+        .map(URL::toExternalForm)
+        .forEach(builder::add);
+    this.styleSheets = builder.build();
   }
 
   /**

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/Storage.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/Storage.java
@@ -31,6 +31,8 @@ public final class Storage {
 
   private static final String RECORDING_DIR = STORAGE_DIR + "/recordings";
 
+  private static final String THEMES_DIR = STORAGE_DIR + "/themes";
+
   private static final String RECORDING_FILE_FORMAT = RECORDING_DIR + "/${date}/recording-${time}.sbr";
 
   private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ISO_DATE;
@@ -76,6 +78,14 @@ public final class Storage {
    */
   public static Path getPluginPath() throws IOException {
     return findOrCreate(PLUGINS_DIR);
+  }
+
+  /**
+   * Gets the directory for custom external themes, creating it if it does not exist.
+   * @throws IOException if the directory cannot be created
+   */
+  public static Path getThemesDir() throws IOException {
+    return findOrCreate(THEMES_DIR);
   }
 
   /**

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -1,6 +1,7 @@
 package edu.wpi.first.shuffleboard.app;
 
 import edu.wpi.first.shuffleboard.api.sources.recording.Recorder;
+import edu.wpi.first.shuffleboard.api.theme.Themes;
 import edu.wpi.first.shuffleboard.api.util.Storage;
 import edu.wpi.first.shuffleboard.api.util.Time;
 import edu.wpi.first.shuffleboard.app.plugin.PluginLoader;
@@ -59,6 +60,11 @@ public class Shuffleboard extends Application {
 
     // Install SVG image loaders so SVGs can be used like any other image
     SvgImageLoaderFactory.install();
+
+    // Search for and load themes from the custom theme directory before loading application preferences
+    // This avoids an issue with attempting to load a theme at startup that hasn't yet been registered
+    logger.finer("Registering custom user themes from external dir");
+    Themes.getDefault().loadThemesFromDir();
   }
 
   @Override


### PR DESCRIPTION
This makes it so that themes can be easily defined and edited without having to write any code

Workaround for #347 

---

Custom themes can be created by adding a directory to `~/Shuffleboard/themes`, named with the desired name of the theme. For example, if a team wants to call their theme "Team 2084 Theme", the directory should also be named "Team 2084 Theme". The stylesheets for these themes should be in that directory without nesting. Note that a stylesheet may still import a stylesheet in a nested directory. Variants of themes should be in different directories under `~/Shuffleboard/themes`.

Custom themes can also import the stylesheets bundled in the shuffleboard jar. These currently include:

```
/edu/wpi/first/shuffleboard/api/material.css
/edu/wpi/first/shuffleboard/api/base.css
/edu/wpi/first/shuffleboard/app/light.css
/edu/wpi/first/shuffleboard/app/dark.css
```

These may be imported with
```css
@import "/edu/wpi/first/api/base.css"
```

Note the leading slash in the path.

Importing the default stylesheets makes it very easy to simply change the primary colors of the dashboard. For example, importing the stylesheet for the dark theme allows users to change the primary colors simply with

```css
@import "/edu/wpi/first/shuffleboard/app/dark.css"

.root {
    -swatch-100: ... ;
    -swatch-200: ... ;
    -swatch-300: ... ;
    -swatch-400: ... ;
    -swatch-500: ... ;
}
```