### PR TITLE
Allow plugins to define default tabs, allow users to create a new layout without restarting the app 

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/plugin/Plugin.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/plugin/Plugin.java
@@ -3,6 +3,7 @@ package edu.wpi.first.shuffleboard.api.plugin;
 import edu.wpi.first.shuffleboard.api.data.DataType;
 import edu.wpi.first.shuffleboard.api.sources.SourceType;
 import edu.wpi.first.shuffleboard.api.sources.recording.serialization.TypeAdapter;
+import edu.wpi.first.shuffleboard.api.tab.TabInfo;
 import edu.wpi.first.shuffleboard.api.theme.Theme;
 import edu.wpi.first.shuffleboard.api.util.Storage;
 import edu.wpi.first.shuffleboard.api.widget.ComponentType;
@@ -202,6 +203,13 @@ public class Plugin {
    * occur when a user manually confirms the change.
    */
   public List<Property<?>> getProperties() {
+    return ImmutableList.of();
+  }
+
+  /**
+   * Gets a list of information about any default tabs that shuffleboard should use.
+   */
+  public List<TabInfo> getDefaultTabInfo() {
     return ImmutableList.of();
   }
 

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/tab/TabInfo.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/tab/TabInfo.java
@@ -1,0 +1,125 @@
+package edu.wpi.first.shuffleboard.api.tab;
+
+import java.util.Objects;
+
+/**
+ * Represents a tab in the dashboard.
+ */
+public final class TabInfo {
+
+  private final String name;
+  private final boolean autoPopulate;
+  private final String sourcePrefix;
+
+  /**
+   * Creates a new TabInfo object.
+   *
+   * @param name         the name of the tab
+   * @param autoPopulate whether or not the tab should autopopulate
+   * @param sourcePrefix the source prefix to use when autopopulating
+   */
+  public TabInfo(String name, boolean autoPopulate, String sourcePrefix) {
+    this.name = Objects.requireNonNull(name, "name");
+    this.autoPopulate = autoPopulate;
+    this.sourcePrefix = Objects.requireNonNull(sourcePrefix, "sourcePrefix");
+  }
+
+  /**
+   * Gets the name of the tab this represents.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Checks if the tab should autopopulate.
+   */
+  public boolean isAutoPopulate() {
+    return autoPopulate;
+  }
+
+  /**
+   * The source prefix the tab should use when autopopulating.
+   */
+  public String getSourcePrefix() {
+    return sourcePrefix;
+  }
+
+  public static TabInfoBuilder builder() {
+    return new TabInfoBuilder();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    TabInfo tabInfo = (TabInfo) o;
+    return autoPopulate == tabInfo.autoPopulate
+        && Objects.equals(name, tabInfo.name)
+        && Objects.equals(sourcePrefix, tabInfo.sourcePrefix);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, autoPopulate, sourcePrefix);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("TabInfo(name='%s', autoPopulate=%s, sourcePrefix='%s')", name, autoPopulate, sourcePrefix);
+  }
+
+  public static final class TabInfoBuilder {
+
+    private String name;
+    private boolean autoPopulate = false;
+    private String sourcePrefix = "";
+
+    /**
+     * Sets the name of the built tab.
+     */
+    public TabInfoBuilder name(String name) {
+      this.name = Objects.requireNonNull(name, "name");
+      return this;
+    }
+
+    /**
+     * Sets the built tab to autopopulate. Autopopulation is {@code false} by default; use this method to enable it.
+     */
+    public TabInfoBuilder autoPopulate() {
+      this.autoPopulate = true;
+      return this;
+    }
+
+    /**
+     * Sets the source prefix the built tab should use during autopopulation.
+     */
+    public TabInfoBuilder sourcePrefix(String sourcePrefix) {
+      this.sourcePrefix = Objects.requireNonNull(sourcePrefix, "sourcePrefix");
+      return this;
+    }
+
+    /**
+     * Creates a new TabInfo object from this builder.
+     *
+     * @throws IllegalStateException if the tab name was not set with {@link #name}
+     * @throws IllegalStateException if the tab was set to autopopulate but no source prefix was provided
+     */
+    public TabInfo build() {
+      if (name == null) {
+        throw new IllegalStateException("Tab name was not set");
+      }
+      if (autoPopulate && sourcePrefix.isEmpty()) {
+        throw new IllegalStateException("A tab cannot autopopulate with no source prefix set");
+      }
+      return new TabInfo(name, autoPopulate, sourcePrefix);
+    }
+
+  }
+
+
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/Registry.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/Registry.java
@@ -106,6 +106,28 @@ public abstract class Registry<T> {
   }
 
   /**
+   * Unregisters many items at once.
+   *
+   * @param items the items to unregister
+   */
+  public final void unregisterAll(T... items) {
+    Objects.requireNonNull(items, "items");
+    for (T item : items) {
+      unregister(item);
+    }
+  }
+
+  /**
+   * Unregisters many items at once.
+   *
+   * @param items the items to unregister
+   */
+  public final void unregisterAll(Collection<? extends T> items) {
+    Objects.requireNonNull(items, "items");
+    items.forEach(this::unregister);
+  }
+
+  /**
    * Gets a <i>read-only</i> view of the list of registered items.
    */
   public final ObservableList<T> getItems() {

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -9,6 +9,7 @@ import edu.wpi.first.shuffleboard.api.prefs.FlushableProperty;
 import edu.wpi.first.shuffleboard.api.sources.DataSource;
 import edu.wpi.first.shuffleboard.api.sources.SourceEntry;
 import edu.wpi.first.shuffleboard.api.sources.recording.Recorder;
+import edu.wpi.first.shuffleboard.api.tab.TabInfo;
 import edu.wpi.first.shuffleboard.api.theme.Theme;
 import edu.wpi.first.shuffleboard.api.util.FxUtils;
 import edu.wpi.first.shuffleboard.api.util.Storage;
@@ -21,6 +22,7 @@ import edu.wpi.first.shuffleboard.app.json.JsonBuilder;
 import edu.wpi.first.shuffleboard.app.plugin.PluginLoader;
 import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
 import edu.wpi.first.shuffleboard.app.sources.recording.Playback;
+import edu.wpi.first.shuffleboard.app.tab.TabInfoRegistry;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
@@ -358,6 +360,22 @@ public class MainWindowController {
     AppPreferences.getInstance().setSaveFile(currentFile);
   }
 
+  /**
+   * Generates a new layout.
+   */
+  @FXML
+  public void newLayout() {
+    currentFile = null;
+    double[] dividerPositions = centerSplitPane.getDividerPositions();
+    List<TabInfo> tabInfo = TabInfoRegistry.getDefault().getItems();
+    if (tabInfo.isEmpty()) {
+      // No tab info, so add a placeholder tab so there's SOMETHING in the dashboard
+      setDashboard(new DashboardTabPane(new DashboardTab("Tab 1")));
+    } else {
+      setDashboard(new DashboardTabPane(tabInfo));
+    }
+    centerSplitPane.setDividerPositions(dividerPositions);
+  }
 
   /**
    * Load the dashboard from a save file.

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -3,11 +3,8 @@ package edu.wpi.first.shuffleboard.app;
 import edu.wpi.first.shuffleboard.api.sources.recording.Recorder;
 import edu.wpi.first.shuffleboard.api.util.Storage;
 import edu.wpi.first.shuffleboard.api.util.Time;
-import edu.wpi.first.shuffleboard.app.components.DashboardTab;
-import edu.wpi.first.shuffleboard.app.components.DashboardTabPane;
 import edu.wpi.first.shuffleboard.app.plugin.PluginLoader;
 import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
-import edu.wpi.first.shuffleboard.app.tab.TabInfoRegistry;
 import edu.wpi.first.shuffleboard.plugin.base.BasePlugin;
 import edu.wpi.first.shuffleboard.plugin.cameraserver.CameraServerPlugin;
 import edu.wpi.first.shuffleboard.plugin.networktables.NetworkTablesPlugin;
@@ -89,15 +86,8 @@ public class Shuffleboard extends Application {
     Platform.runLater(() -> {
       if (AppPreferences.getInstance().isAutoLoadLastSaveFile()) {
         mainWindowController.load(AppPreferences.getInstance().getSaveFile());
-      } else if (TabInfoRegistry.getDefault().getItems().isEmpty()) {
-        // No plugins define default tabs, so we need to add at least one tab to make the dashboard usable at startup
-        mainWindowController.setDashboard(new DashboardTabPane(new DashboardTab("Tab 1")));
       } else {
-        DashboardTab[] tabs = TabInfoRegistry.getDefault().getItems()
-            .stream()
-            .map(DashboardTab::new)
-            .toArray(DashboardTab[]::new);
-        mainWindowController.setDashboard(new DashboardTabPane(tabs));
+        mainWindowController.newLayout();
       }
     });
 

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -3,6 +3,7 @@ package edu.wpi.first.shuffleboard.app;
 import edu.wpi.first.shuffleboard.api.sources.recording.Recorder;
 import edu.wpi.first.shuffleboard.api.util.Storage;
 import edu.wpi.first.shuffleboard.api.util.Time;
+import edu.wpi.first.shuffleboard.app.components.DashboardTabPane;
 import edu.wpi.first.shuffleboard.app.plugin.PluginLoader;
 import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
 import edu.wpi.first.shuffleboard.plugin.base.BasePlugin;
@@ -82,12 +83,14 @@ public class Shuffleboard extends Application {
     PluginLoader.getDefault().load(new CameraServerPlugin());
     PluginLoader.getDefault().loadAllJarsFromDir(Storage.getPluginPath());
 
-    // Load the most recent save file after loading all plugins
-    if (AppPreferences.getInstance().isAutoLoadLastSaveFile()) {
-      Platform.runLater(() -> {
+    // Setup the dashboard tabs after all plugins are loaded
+    Platform.runLater(() -> {
+      if (AppPreferences.getInstance().isAutoLoadLastSaveFile()) {
         mainWindowController.load(AppPreferences.getInstance().getSaveFile());
-      });
-    }
+      } else {
+        mainWindowController.setDashboard(DashboardTabPane.createDefaultFrcPane());
+      }
+    });
 
     primaryStage.setTitle("Shuffleboard");
     primaryStage.setMinWidth(640);

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -3,9 +3,11 @@ package edu.wpi.first.shuffleboard.app;
 import edu.wpi.first.shuffleboard.api.sources.recording.Recorder;
 import edu.wpi.first.shuffleboard.api.util.Storage;
 import edu.wpi.first.shuffleboard.api.util.Time;
+import edu.wpi.first.shuffleboard.app.components.DashboardTab;
 import edu.wpi.first.shuffleboard.app.components.DashboardTabPane;
 import edu.wpi.first.shuffleboard.app.plugin.PluginLoader;
 import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
+import edu.wpi.first.shuffleboard.app.tab.TabInfoRegistry;
 import edu.wpi.first.shuffleboard.plugin.base.BasePlugin;
 import edu.wpi.first.shuffleboard.plugin.cameraserver.CameraServerPlugin;
 import edu.wpi.first.shuffleboard.plugin.networktables.NetworkTablesPlugin;
@@ -87,8 +89,15 @@ public class Shuffleboard extends Application {
     Platform.runLater(() -> {
       if (AppPreferences.getInstance().isAutoLoadLastSaveFile()) {
         mainWindowController.load(AppPreferences.getInstance().getSaveFile());
+      } else if (TabInfoRegistry.getDefault().getItems().isEmpty()) {
+        // No plugins define default tabs, so we need to add at least one tab to make the dashboard usable at startup
+        mainWindowController.setDashboard(new DashboardTabPane(new DashboardTab("Tab 1")));
       } else {
-        mainWindowController.setDashboard(DashboardTabPane.createDefaultFrcPane());
+        DashboardTab[] tabs = TabInfoRegistry.getDefault().getItems()
+            .stream()
+            .map(DashboardTab::new)
+            .toArray(DashboardTab[]::new);
+        mainWindowController.setDashboard(new DashboardTabPane(tabs));
       }
     });
 

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
@@ -6,6 +6,7 @@ import edu.wpi.first.shuffleboard.api.data.DataTypes;
 import edu.wpi.first.shuffleboard.api.sources.DataSource;
 import edu.wpi.first.shuffleboard.api.sources.SourceType;
 import edu.wpi.first.shuffleboard.api.sources.SourceTypes;
+import edu.wpi.first.shuffleboard.api.tab.TabInfo;
 import edu.wpi.first.shuffleboard.api.util.Debouncer;
 import edu.wpi.first.shuffleboard.api.util.FxUtils;
 import edu.wpi.first.shuffleboard.api.util.NetworkTableUtils;
@@ -113,6 +114,15 @@ public class DashboardTab extends Tab implements HandledTab, Populatable {
     MenuItem prefItem = FxUtils.menuItem("Preferences", __ -> showPrefsDialog());
     prefItem.setStyle("-fx-text-fill: black;");
     setContextMenu(new ContextMenu(prefItem));
+  }
+
+  /**
+   * Creates a new tab from a tab info object.
+   */
+  public DashboardTab(TabInfo tabInfo) {
+    this(tabInfo.getName());
+    setSourcePrefix(tabInfo.getSourcePrefix());
+    setAutoPopulate(tabInfo.isAutoPopulate());
   }
 
   /**

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
@@ -18,31 +18,11 @@ import static edu.wpi.first.shuffleboard.api.util.TypeUtils.optionalCast;
  */
 public class DashboardTabPane extends TabPane {
 
+  /**
+   * Creates a dashboard with no tabs.
+   */
   public DashboardTabPane() {
-  }
-
-  /**
-   * Creates a dashboard tab that will auto populate for the given source prefix.
-   *
-   * @param name         the name of the tab
-   * @param sourcePrefix the prefixes to sources to populate the tab with
-   */
-  public static DashboardTab createAutoPopulateTab(String name, String sourcePrefix) {
-    DashboardTab tab = new DashboardTab(name);
-    tab.setAutoPopulate(true);
-    tab.setSourcePrefix(sourcePrefix);
-    return tab;
-  }
-
-  /**
-   * Creates a dashboard tab pane with two autopopulating tabs for FRC use: "SmartDashboard" and "LiveWindow".
-   */
-  // TODO move this to the FRC plugin. This doesn't belong here
-  public static DashboardTabPane createDefaultFrcPane() {
-    return new DashboardTabPane(
-        createAutoPopulateTab("SmartDashboard", "SmartDashboard/"),
-        createAutoPopulateTab("LiveWindow", "LiveWindow/")
-    );
+    this((Tab[]) null);
   }
 
   /**

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
@@ -1,10 +1,12 @@
 package edu.wpi.first.shuffleboard.app.components;
 
+import edu.wpi.first.shuffleboard.api.tab.TabInfo;
 import edu.wpi.first.shuffleboard.api.util.Debouncer;
 import edu.wpi.first.shuffleboard.api.util.TypeUtils;
 import edu.wpi.first.shuffleboard.api.widget.Component;
 import edu.wpi.first.shuffleboard.api.widget.Widget;
 
+import java.util.Collection;
 import java.util.function.Predicate;
 
 import javafx.collections.ListChangeListener;
@@ -23,6 +25,10 @@ public class DashboardTabPane extends TabPane {
    */
   public DashboardTabPane() {
     this((Tab[]) null);
+  }
+
+  public DashboardTabPane(Collection<TabInfo> tabInfo) {
+    this(tabInfo.stream().map(DashboardTab::new).toArray(DashboardTab[]::new));
   }
 
   /**

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
@@ -18,19 +18,31 @@ import static edu.wpi.first.shuffleboard.api.util.TypeUtils.optionalCast;
  */
 public class DashboardTabPane extends TabPane {
 
-  /**
-   * Creates a dashboard with one default tab.
-   */
   public DashboardTabPane() {
-    this(createAutoPopulateTab("SmartDashboard", "SmartDashboard/"),
-        createAutoPopulateTab("LiveWindow", "LiveWindow/"));
   }
 
-  private static DashboardTab createAutoPopulateTab(String name, String sourcePrefix) {
+  /**
+   * Creates a dashboard tab that will auto populate for the given source prefix.
+   *
+   * @param name         the name of the tab
+   * @param sourcePrefix the prefixes to sources to populate the tab with
+   */
+  public static DashboardTab createAutoPopulateTab(String name, String sourcePrefix) {
     DashboardTab tab = new DashboardTab(name);
     tab.setAutoPopulate(true);
     tab.setSourcePrefix(sourcePrefix);
     return tab;
+  }
+
+  /**
+   * Creates a dashboard tab pane with two autopopulating tabs for FRC use: "SmartDashboard" and "LiveWindow".
+   */
+  // TODO move this to the FRC plugin. This doesn't belong here
+  public static DashboardTabPane createDefaultFrcPane() {
+    return new DashboardTabPane(
+        createAutoPopulateTab("SmartDashboard", "SmartDashboard/"),
+        createAutoPopulateTab("LiveWindow", "LiveWindow/")
+    );
   }
 
   /**

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoader.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoader.java
@@ -15,6 +15,7 @@ import edu.wpi.first.shuffleboard.api.widget.SingleSourceWidget;
 import edu.wpi.first.shuffleboard.api.widget.Widget;
 import edu.wpi.first.shuffleboard.app.sources.DataTypeChangedException;
 import edu.wpi.first.shuffleboard.app.sources.DestroyedSource;
+import edu.wpi.first.shuffleboard.app.tab.TabInfoRegistry;
 
 import com.cedarsoft.version.Version;
 import com.google.common.annotations.VisibleForTesting;
@@ -49,7 +50,13 @@ public class PluginLoader {
   private static final Logger log = Logger.getLogger(PluginLoader.class.getName());
 
   private static final PluginLoader defaultLoader =
-      new PluginLoader(DataTypes.getDefault(), SourceTypes.getDefault(), Components.getDefault(), Themes.getDefault());
+      new PluginLoader(
+          DataTypes.getDefault(),
+          SourceTypes.getDefault(),
+          Components.getDefault(),
+          Themes.getDefault(),
+          TabInfoRegistry.getDefault()
+      );
 
   private final ObservableSet<Plugin> loadedPlugins = FXCollections.observableSet();
   private final Set<Class<? extends Plugin>> knownPluginClasses = new HashSet<>();
@@ -58,23 +65,30 @@ public class PluginLoader {
   private final SourceTypes sourceTypes;
   private final Components components;
   private final Themes themes;
+  private final TabInfoRegistry tabInfoRegistry;
 
   /**
    * Creates a new plugin loader object. For app use, use {@link #getDefault() the default instance}; this should only
    * be used for tests.
    *
-   * @param dataTypes   the data type registry to use for registering data types from plugins
-   * @param sourceTypes the source type registry to use for registering source types from plugins
-   * @param components  the component registry to use for registering components from plugins
-   * @param themes      the theme registry to use for registering themes from plugins
+   * @param dataTypes       the data type registry to use for registering data types from plugins
+   * @param sourceTypes     the source type registry to use for registering source types from plugins
+   * @param components      the component registry to use for registering components from plugins
+   * @param themes          the theme registry to use for registering themes from plugins
+   * @param tabInfoRegistry the registry for tab information provided by plugins
    *
    * @throws NullPointerException if any of the parameters is {@code null}
    */
-  public PluginLoader(DataTypes dataTypes, SourceTypes sourceTypes, Components components, Themes themes) {
+  public PluginLoader(DataTypes dataTypes,
+                      SourceTypes sourceTypes,
+                      Components components,
+                      Themes themes,
+                      TabInfoRegistry tabInfoRegistry) {
     this.dataTypes = Objects.requireNonNull(dataTypes, "dataTypes");
     this.sourceTypes = Objects.requireNonNull(sourceTypes, "sourceTypes");
     this.components = Objects.requireNonNull(components, "components");
     this.themes = Objects.requireNonNull(themes, "themes");
+    this.tabInfoRegistry = Objects.requireNonNull(tabInfoRegistry, "tabInfoRegistry");
   }
 
   /**
@@ -259,10 +273,10 @@ public class PluginLoader {
       return false;
     }
     log.info("Loading plugin " + plugin.fullIdString());
-    plugin.getDataTypes().forEach(dataTypes::register);
-    plugin.getSourceTypes().forEach(sourceTypes::register);
+    dataTypes.registerAll(plugin.getDataTypes());
+    sourceTypes.registerAll(plugin.getSourceTypes());
     plugin.getTypeAdapters().forEach(Serializers::add);
-    plugin.getComponents().forEach(components::register);
+    components.registerAll(plugin.getComponents());
     plugin.getDefaultComponents().forEach(components::setDefaultComponent);
     components.getActiveWidgets().stream()
         .filter(w -> w.getSources().stream().anyMatch(s -> s instanceof DestroyedSource))
@@ -278,6 +292,7 @@ public class PluginLoader {
               .forEach(s -> tryRestoreSource(w, (DestroyedSource) s));
         });
     plugin.getThemes().forEach(themes::register);
+    tabInfoRegistry.registerAll(plugin.getDefaultTabInfo());
 
     plugin.onLoad();
     plugin.setLoaded(true);
@@ -454,12 +469,13 @@ public class PluginLoader {
             });
           }
         });
-    plugin.getComponents().forEach(components::unregister);
-    plugin.getSourceTypes().forEach(sourceTypes::unregister);
+    components.unregisterAll(plugin.getComponents());
+    sourceTypes.unregisterAll(plugin.getSourceTypes());
     plugin.getTypeAdapters().forEach(Serializers::remove);
-    plugin.getDataTypes().forEach(dataTypes::unregister);
+    dataTypes.unregisterAll(plugin.getDataTypes());
     // TODO figure out a good way to remember the theme & reapply it when reloading the plugin
-    plugin.getThemes().forEach(themes::unregister);
+    themes.unregisterAll(plugin.getThemes());
+    tabInfoRegistry.unregisterAll(plugin.getDefaultTabInfo());
 
     plugin.onUnload();
     plugin.setLoaded(false);

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/tab/TabInfoRegistry.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/tab/TabInfoRegistry.java
@@ -1,0 +1,30 @@
+package edu.wpi.first.shuffleboard.app.tab;
+
+import edu.wpi.first.shuffleboard.api.tab.TabInfo;
+import edu.wpi.first.shuffleboard.api.util.Registry;
+
+import java.util.Objects;
+
+public final class TabInfoRegistry extends Registry<TabInfo> {
+
+  private static final TabInfoRegistry defaultInstance = new TabInfoRegistry();
+
+  public static TabInfoRegistry getDefault() {
+    return defaultInstance;
+  }
+
+  @Override
+  public void register(TabInfo item) {
+    Objects.requireNonNull(item, "item");
+    if (isRegistered(item)) {
+      throw new IllegalArgumentException("Item is already registered: " + item);
+    }
+    addItem(item);
+  }
+
+  @Override
+  public void unregister(TabInfo item) {
+    removeItem(item);
+  }
+
+}

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/MainWindow.fxml
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/MainWindow.fxml
@@ -18,6 +18,7 @@
 
     <MenuBar>
         <Menu mnemonicParsing="false" text="File">
+            <MenuItem onAction="#newLayout" text="New" accelerator="SHORTCUT+N"/>
             <MenuItem onAction="#save" text="Save" accelerator="SHORTCUT+S"/>
             <MenuItem onAction="#saveAs" text="Save as..." accelerator="SHORTCUT+SHIFT+S"/>
             <MenuItem onAction="#load" text="Load layout" accelerator="SHORTCUT+O"/>

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoaderTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoaderTest.java
@@ -7,11 +7,13 @@ import edu.wpi.first.shuffleboard.api.plugin.Plugin;
 import edu.wpi.first.shuffleboard.api.plugin.Requires;
 import edu.wpi.first.shuffleboard.api.sources.SourceType;
 import edu.wpi.first.shuffleboard.api.sources.SourceTypes;
+import edu.wpi.first.shuffleboard.api.tab.TabInfo;
 import edu.wpi.first.shuffleboard.api.theme.Theme;
 import edu.wpi.first.shuffleboard.api.theme.Themes;
 import edu.wpi.first.shuffleboard.api.widget.Component;
 import edu.wpi.first.shuffleboard.api.widget.ComponentType;
 import edu.wpi.first.shuffleboard.api.widget.Components;
+import edu.wpi.first.shuffleboard.app.tab.TabInfoRegistry;
 import edu.wpi.first.shuffleboard.testplugins.BasicPlugin;
 import edu.wpi.first.shuffleboard.testplugins.DependentOnUnknownPlugin;
 
@@ -46,6 +48,7 @@ public class PluginLoaderTest {
   private SourceTypes sourceTypes;
   private Components components;
   private Themes themes;
+  private TabInfoRegistry tabInfoRegistry;
 
   @BeforeEach
   public void setup() {
@@ -53,7 +56,8 @@ public class PluginLoaderTest {
     sourceTypes = new SourceTypes();
     components = new Components();
     themes = new Themes();
-    loader = new PluginLoader(dataTypes, sourceTypes, components, themes);
+    tabInfoRegistry = new TabInfoRegistry();
+    loader = new PluginLoader(dataTypes, sourceTypes, components, themes, tabInfoRegistry);
   }
 
   @Test
@@ -170,6 +174,18 @@ public class PluginLoaderTest {
     assertFalse(sourceTypes.isRegistered(MockPlugin.sourceType));
     assertFalse(components.isRegistered(MockPlugin.component));
     assertFalse(themes.isRegistered(MockPlugin.theme));
+  }
+
+  @Test
+  public void testDefaultTabs() {
+    // given
+    Plugin plugin = new DefaultTabsPlugin();
+
+    // when
+    loader.load(plugin);
+
+    // then
+    assertTrue(tabInfoRegistry.isRegistered(DefaultTabsPlugin.tabInfo), "Tab info was not registered");
   }
 
   @Test
@@ -388,5 +404,19 @@ public class PluginLoaderTest {
   @Requires(group = "test", name = "SelfDependentPlugin", minVersion = "0.0.0")
   private static final class SelfDependentPlugin extends Plugin {
   }
+
+  @Description(group = "test", name = "DefaultTabsPlugin", version = "0.0.0", summary = "")
+  private static final class DefaultTabsPlugin extends Plugin {
+
+    private static final TabInfo tabInfo = new TabInfo("tabName", false, "sourcePrefix");
+
+    @Override
+    public List<TabInfo> getDefaultTabInfo() {
+      return ImmutableList.of(
+          tabInfo
+      );
+    }
+  }
+
 
 }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -4,6 +4,7 @@ import edu.wpi.first.shuffleboard.api.data.DataType;
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
 import edu.wpi.first.shuffleboard.api.plugin.Description;
 import edu.wpi.first.shuffleboard.api.plugin.Plugin;
+import edu.wpi.first.shuffleboard.api.tab.TabInfo;
 import edu.wpi.first.shuffleboard.api.widget.ComponentType;
 import edu.wpi.first.shuffleboard.api.widget.LayoutClass;
 import edu.wpi.first.shuffleboard.api.widget.WidgetType;
@@ -150,6 +151,14 @@ public class BasePlugin extends Plugin {
         return ImmutableSet.of(new SubsystemType());
       }
     };
+  }
+
+  @Override
+  public List<TabInfo> getDefaultTabInfo() {
+    return ImmutableList.of(
+        TabInfo.builder().name("SmartDashboard").autoPopulate().sourcePrefix("SmartDashboard/").build(),
+        TabInfo.builder().name("LiveWindow").autoPopulate().sourcePrefix("LiveWindow/").build()
+    );
   }
 
 }

--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -23,7 +23,9 @@
         <exclude name="RedundantFieldInitializer"/>
         <exclude name="AvoidInstantiatingObjectsInLoops"/>
     </rule>
-    <rule ref="rulesets/java/strings.xml"/>
+    <rule ref="rulesets/java/strings.xml">
+        <exclude name="AvoidDuplicateLiterals"/>
+    </rule>
     <rule ref="rulesets/java/imports.xml">
         <exclude name="TooManyStaticImports"/>
     </rule>


### PR DESCRIPTION
Changes startup a bit to load the default tabs only after attempting to load the last save file. Previously, the default tabs were loaded first, then overwritten with the new ones. The old tabs would also perform autopopulation and source caching, which isn't something we should do before we have to