### PR TITLE
Fix FXML widgets from external plugins failing to load

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Components.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Components.java
@@ -295,6 +295,7 @@ public class Components extends Registry<ComponentType> {
     if (controller != null) { //NOPMD readability
       try {
         FXMLLoader loader = new FXMLLoader(annotatedClass.getResource(controller.value()));
+        loader.setClassLoader(annotatedClass.getClassLoader());
         loader.load();
         return Optional.of(loader.getController());
       } catch (IOException e) {


### PR DESCRIPTION
Was caused by the FXML loader using the default classloader instead of the one used to load the plugin JAR

Bug reported by rudun in [this CD thread](https://www.chiefdelphi.com/forums/showthread.php?p=1723401)