### PR TITLE
Rewrite of PluginLoader getRequirements to fix Eclipse error

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 # shuffleboard
 
-This is the 604 fork of shuffeboard. **The `604version` branch will be repeatedly forced-pushed as necessary in order to bring in updates from the main repo.**
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 # shuffleboard
 
+This is the 604 fork of shuffeboard. **The `604version` branch will be repeatedly forced-pushed as necessary in order to bring in updates from the main repo.**
 
 ## Structure
 

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoader.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoader.java
@@ -33,7 +33,6 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -336,20 +335,14 @@ public class PluginLoader {
   private static List<Requires> getRequirements(Class<? extends Plugin> pluginClass) {
     Requirements requirements = pluginClass.getAnnotation(Requirements.class);
     Requires[] requires = pluginClass.getAnnotationsByType(Requires.class);
-    List<Requires> requirementsArray = new ArrayList<Requires>();
+    // No need to initialize hear because it is set equal to something later
+    List<Requires> requirementsArray;
     // Split into two pieces because Stream.concat has weird type inference issues
     requirementsArray = Stream.of(requirements)
             .filter(Objects::nonNull)
             .map(Requirements::value)
             .flatMap(Stream::of).collect(Collectors.toList());
     requirementsArray.addAll(Stream.of(requires).collect(Collectors.toList()));
-    /*List<Object> test = Stream.concat(
-            Stream.of(requirements)
-                .filter(Objects::nonNull)
-                .map(Requirements::value)
-                .flatMap(Stream::of),
-            Stream.of(requires)
-        ).collect(Collectors.toList());*/
     return requirementsArray;
   }
 

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoader.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoader.java
@@ -321,14 +321,12 @@ public class PluginLoader {
     Requirements requirements = pluginClass.getAnnotation(Requirements.class);
     Requires[] requires = pluginClass.getAnnotationsByType(Requires.class);
     List<Requires> requirementsArray = new ArrayList<Requires>();
-    // First half of concat
-    for ( Requires r : requirements.value()) {
-        requirementsArray.add(r);
-    }
-    // Second half of concat
-    for( Requires r : requires ) {
-        requirementsArray.add(r);
-    }
+    // Split into two pieces because Stream.concat has weird type inference issues
+    requirementsArray = Stream.of(requirements)
+            .filter(Objects::nonNull)
+            .map(Requirements::value)
+            .flatMap(Stream::of).collect(Collectors.toList());
+    requirementsArray.addAll(Stream.of(requires).collect(Collectors.toList()));
     /*List<Object> test = Stream.concat(
             Stream.of(requirements)
                 .filter(Objects::nonNull)

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoader.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoader.java
@@ -31,6 +31,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Comparator;
 import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -319,13 +320,23 @@ public class PluginLoader {
   private static List<Requires> getRequirements(Class<? extends Plugin> pluginClass) {
     Requirements requirements = pluginClass.getAnnotation(Requirements.class);
     Requires[] requires = pluginClass.getAnnotationsByType(Requires.class);
-    return Stream.concat(
-        Stream.of(requirements)
-            .filter(Objects::nonNull)
-            .map(Requirements::value)
-            .flatMap(Stream::of),
-        Stream.of(requires)
-    ).collect(Collectors.toList());
+    List<Requires> requirementsArray = new ArrayList<Requires>();
+    // First half of concat
+    for ( Requires r : requirements.value()) {
+        requirementsArray.add(r);
+    }
+    // Second half of concat
+    for( Requires r : requires ) {
+        requirementsArray.add(r);
+    }
+    /*List<Object> test = Stream.concat(
+            Stream.of(requirements)
+                .filter(Objects::nonNull)
+                .map(Requirements::value)
+                .flatMap(Stream::of),
+            Stream.of(requires)
+        ).collect(Collectors.toList());*/
+    return requirementsArray;
   }
 
   /**


### PR DESCRIPTION
With the `Stream.concat` method, Eclipse would complain that the return type should be `List<Object>`. This is a slight adjustment to the code to avoid this issue by combining the contents separately. I locally ran the `./gradlew spotlessCheck check jacocoJunit5TestReport --stacktrace --console=plain -PlogTests -Pheadless` command from `.travis.ubuntu.sh` on my computer (Ubuntu 17.10) to confirm that the tests pass.