### PR TITLE
Fix for incorrect display on gyro for negative degrees

### DIFF
--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/GyroData.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/GyroData.java
@@ -23,6 +23,14 @@ public final class GyroData extends ComplexData<GyroData> {
   public Map<String, Object> asMap() {
     return ImmutableMap.of("Value", value);
   }
+  
+  public double getWrappedValue() {
+	  double tempval = value;
+	  while (tempval<0) {
+		  tempval+=360;
+	  }
+	  return tempval%360;
+  }
 
   public double getValue() {
     return value;

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/GyroData.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/GyroData.java
@@ -24,12 +24,16 @@ public final class GyroData extends ComplexData<GyroData> {
     return ImmutableMap.of("Value", value);
   }
   
+  /**
+   * Version of getValue that always returns value between 0 and 360.
+   * This is guaranteed to be displayed properly by the Gyro widget. 
+   */
   public double getWrappedValue() {
-	  double tempval = value;
-	  while (tempval<0) {
-		  tempval+=360;
-	  }
-	  return tempval%360;
+    double tempval = value;
+    while (tempval < 0) {
+      tempval += 360;
+    }
+    return tempval % 360;
   }
 
   public double getValue() {

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/GyroData.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/GyroData.java
@@ -29,11 +29,12 @@ public final class GyroData extends ComplexData<GyroData> {
    * This is guaranteed to be displayed properly by the Gyro widget. 
    */
   public double getWrappedValue() {
-    double tempval = value;
-    while (tempval < 0) {
-      tempval += 360;
+    if (value < 0) {
+      int addmultiplier = (((int) Math.abs(value) / 360) + 1) * 360;
+      return (addmultiplier + value) % 360;
+    } else {
+      return value % 360;
     }
-    return tempval % 360;
   }
 
   public double getValue() {

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/GyroData.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/GyroData.java
@@ -30,8 +30,7 @@ public final class GyroData extends ComplexData<GyroData> {
    */
   public double getWrappedValue() {
     if (value < 0) {
-      int addmultiplier = (((int) Math.abs(value) / 360) + 1) * 360;
-      return (addmultiplier + value) % 360;
+      return ((value % 360) + 360) % 360;
     } else {
       return value % 360;
     }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/GyroWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/GyroWidget.java
@@ -24,7 +24,7 @@ public class GyroWidget extends SimpleAnnotatedWidget<GyroData> {
 
   @FXML
   private void initialize() {
-    gauge.valueProperty().bind(dataOrDefault.map(GyroData::getValue));
+    gauge.valueProperty().bind(dataOrDefault.map(GyroData::getWrappedValue));
     valueLabel.textProperty().bind(dataOrDefault.map(GyroData::getValue).map(d -> String.format("%.2f°", d)));
 
     exportProperties(


### PR DESCRIPTION
This PR fixes #372 by implementing a `getWrappedValue` function.

Pinging @SamCarlberg since he wrote the original gyro code.