### PR TITLE
Only expand the first source tree

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -277,7 +277,9 @@ public class MainWindowController {
       TitledPane titledPane = new TitledPane(sourceType.getName(), tree);
       sourcePanes.put(plugin, titledPane);
       sourcesAccordion.getPanes().add(titledPane);
-      sourcesAccordion.setExpandedPane(titledPane);
+      if (sourcesAccordion.getExpandedPane() == null) {
+        sourcesAccordion.setExpandedPane(titledPane);
+      }
     });
 
     // Add widgets to the gallery as well


### PR DESCRIPTION
In practice, this will make the network table source tree be the expanded one at startup instead of the less-useful cameraserver tree