### PR TITLE
Fix race condition in NetworkTable source updating

### DIFF
--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSource.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSource.java
@@ -54,6 +54,7 @@ public abstract class NetworkTableSource<T> extends AbstractDataSource<T> {
   protected final void setTableListener(TableListener listener) {
     NetworkTableInstance inst = NetworkTableInstance.getDefault();
     inst.removeEntryListener(listenerUid);
+    setConnected(true);
     listenerUid = inst.addEntryListener(fullTableKey, (event) -> {
       if (isConnected()) {
         AsyncUtils.runAsync(() -> {
@@ -67,7 +68,6 @@ public abstract class NetworkTableSource<T> extends AbstractDataSource<T> {
       }
     },
     0xFF);
-    connect();
   }
 
   protected boolean isUpdateFromNetworkTables() {


### PR DESCRIPTION
Was caused by the source checking if was connected prior to setting the value, which had a small chance of happening before it was set to be connected