### PR TITLE
Allow layouts in widget panes to be unwrapped

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/ComponentContainer.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/ComponentContainer.java
@@ -17,6 +17,13 @@ public interface ComponentContainer {
   void addComponent(Component component);
 
   /**
+   * Removes a component from this container.
+   *
+   * @param component the component to remove
+   */
+  void removeComponent(Component component);
+
+  /**
    * Gets a stream of all the first-level components in this container.
    */
   Stream<Component> components();

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Layout.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Layout.java
@@ -41,6 +41,11 @@ public interface Layout extends Component, ComponentContainer {
   void removeChild(Component component);
 
   @Override
+  default void removeComponent(Component component) {
+    removeChild(component);
+  }
+
+  @Override
   default void addComponent(Component component) {
     addChild(component);
   }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
@@ -578,7 +578,14 @@ public class WidgetPaneController {
 
       // Layout unwrapping
       if (tile instanceof LayoutTile) {
-        widgetPaneActions.addAction("Unwrap", () -> unwrapLayout(tile));
+        widgetPaneActions.addAction("Unwrap", () -> {
+          if (selector.getSelectedTiles().stream().allMatch(t -> t instanceof LayoutTile)) {
+            selector.getSelectedTiles().forEach(t -> unwrapLayout((LayoutTile) t));
+          } else {
+            unwrapLayout(tile);
+          }
+          selector.deselectAll();
+        });
       }
       return widgetPaneActions;
     });

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/TilePane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/TilePane.java
@@ -289,7 +289,7 @@ public class TilePane extends GridPane {
    * @return the node added to the view
    */
   public Node addTile(Node node, TileSize size) {
-    GridPoint placement = firstPoint(size.getWidth(), size.getHeight());
+    GridPoint placement = firstPoint(size);
     if (placement == null) {
       // Nowhere to place the node
       return null;
@@ -343,6 +343,15 @@ public class TilePane extends GridPane {
       }
     }
     return null;
+  }
+
+  /**
+   * Finds the first point where a tile with the given size can be added, or {@code null} if no such point exists.
+   *
+   * @param tileSize the tile size to check
+   */
+  public GridPoint firstPoint(TileSize tileSize) {
+    return firstPoint(tileSize.getWidth(), tileSize.getHeight());
   }
 
   /**

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/WidgetPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/WidgetPane.java
@@ -285,6 +285,25 @@ public class WidgetPane extends TilePane implements ComponentContainer {
     return addComponent(component, location, sizeOfWidget(component));
   }
 
+  /*
+   * Checks if there is enough open space to add the given component.
+   *
+   * @param component the component to check
+   *
+   * @return true if there is enough open space to add the component, false if not
+   */
+  public boolean canAdd(Component component) {
+    return firstPoint(sizeOfWidget(component)) != null;
+  }
+
+  @Override
+  public void removeComponent(Component component) {
+    tiles.stream()
+        .filter(tile -> tile.getContent() == component)
+        .findFirst()
+        .ifPresent(tiles::remove);
+  }
+
   @Override
   public Stream<Component> components() {
     return tiles.stream().map(Tile::getContent);


### PR DESCRIPTION
Unwrapped layouts with no remaining components are removed from the pane. Nested layouts do not have this behavior

Addded a helper `isOpen(TileSize)` method in TilePane
Added a `removeComponent()` method to ComponentContainer. This is technically API breaking
Fixes #224