### PR TITLE
Fix no tabs present if the last save file was renamed, moved, or deleted

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -452,22 +452,17 @@ public class MainWindowController {
    *
    * @param saveFile the save file to load
    */
-  public void load(File saveFile) {
+  public void load(File saveFile) throws IOException {
     if (saveFile == null) {
       return;
     }
-    try {
-      Reader reader = Files.newReader(saveFile, Charset.forName("UTF-8"));
+    Reader reader = Files.newReader(saveFile, Charset.forName("UTF-8"));
 
-      DashboardData dashboardData = JsonBuilder.forSaveFile().fromJson(reader, DashboardData.class);
-      setDashboard(dashboardData.getTabPane());
-      Platform.runLater(() -> {
-        centerSplitPane.setDividerPositions(dashboardData.getDividerPosition());
-      });
-    } catch (Exception e) {
-      log.log(Level.WARNING, "Couldn't load", e);
-      return;
-    }
+    DashboardData dashboardData = JsonBuilder.forSaveFile().fromJson(reader, DashboardData.class);
+    setDashboard(dashboardData.getTabPane());
+    Platform.runLater(() -> {
+      centerSplitPane.setDividerPositions(dashboardData.getDividerPosition());
+    });
 
     currentFile = saveFile;
     AppPreferences.getInstance().setSaveFile(currentFile);

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -91,7 +91,12 @@ public class Shuffleboard extends Application {
     // Setup the dashboard tabs after all plugins are loaded
     Platform.runLater(() -> {
       if (AppPreferences.getInstance().isAutoLoadLastSaveFile()) {
-        mainWindowController.load(AppPreferences.getInstance().getSaveFile());
+        try {
+          mainWindowController.load(AppPreferences.getInstance().getSaveFile());
+        } catch (IOException e) {
+          logger.log(Level.WARNING, "Could not load the last save file", e);
+          mainWindowController.newLayout();
+        }
       } else {
         mainWindowController.newLayout();
       }


### PR DESCRIPTION
Fixes #388. Enabling "load last save" and deleting/moving/renaming the last save file before opening shuffleboard would cause no tabs to be present.