### PR TITLE
Fix graph widgets throwing errors when backing data is deleted

### DIFF
--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/SingleKeyNetworkTableSource.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/SingleKeyNetworkTableSource.java
@@ -43,8 +43,6 @@ public class SingleKeyNetworkTableSource<T> extends NetworkTableSource<T> {
 
       if (isActive()) {
         setData((T) value);
-      } else {
-        setData(null);
       }
     });
 


### PR DESCRIPTION
Also fixes errors thrown when containing a DestroyedSource with null data
Changes SingleKeyNetworkTableSource to not set the data to null when not active
Fixes #391, #396