### PR TITLE
Improve CPU and memory usage of graphs

### DIFF
--- a/app/app.gradle.kts
+++ b/app/app.gradle.kts
@@ -36,6 +36,7 @@ val theMainClassName = "edu.wpi.first.shuffleboard.app.Shuffleboard"
 
 application {
     mainClassName = theMainClassName
+    applicationDefaultJvmArgs = listOf("-Xverify:none", "-Dprism.order=d3d,es2,sw")
 }
 
 tasks.withType<Jar> {

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -66,7 +66,7 @@ import java.util.Set;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "Base",
-    version = "1.0.0",
+    version = "1.0.1",
     summary = "Defines all the WPILib data types and stock widgets"
 )
 public class BasePlugin extends Plugin {

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/GraphWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/GraphWidget.java
@@ -120,7 +120,7 @@ public class GraphWidget implements AnnotatedWidget {
   };
 
   /**
-   * Keep track of all graph widgets so they update at the same time
+   * Keep track of all graph widgets so they update at the same time.
    * It's jarring to see a bunch of graphs all updating at different times
    */
   private static final Collection<GraphWidget> graphWidgets =
@@ -469,16 +469,16 @@ public class GraphWidget implements AnnotatedWidget {
       yValues.add(y);
     }
 
+    public void add(Data<? extends Number, ? extends Number> point) {
+      add(point.getXValue().doubleValue(), point.getYValue().doubleValue());
+    }
+
     public PrimitiveDoubleArrayList getXValues() {
       return xValues;
     }
 
     public PrimitiveDoubleArrayList getYValues() {
       return yValues;
-    }
-
-    public void add(Data<? extends Number, ? extends Number> point) {
-      add(point.getXValue().doubleValue(), point.getYValue().doubleValue());
     }
 
     public Data<Number, Number> asData(int index) {

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/GraphWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/GraphWidget.java
@@ -6,6 +6,7 @@ import edu.wpi.first.shuffleboard.api.data.types.NumberType;
 import edu.wpi.first.shuffleboard.api.sources.DataSource;
 import edu.wpi.first.shuffleboard.api.util.AlphanumComparator;
 import edu.wpi.first.shuffleboard.api.util.FxUtils;
+import edu.wpi.first.shuffleboard.api.util.ThreadUtils;
 import edu.wpi.first.shuffleboard.api.util.Time;
 import edu.wpi.first.shuffleboard.api.widget.AnnotatedWidget;
 import edu.wpi.first.shuffleboard.api.widget.Description;
@@ -17,11 +18,17 @@ import com.sun.prism.j2d.J2DPipeline;
 import com.sun.prism.sw.SWPipeline;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.WeakHashMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -40,8 +47,12 @@ import javafx.collections.FXCollections;
 import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.scene.CacheHint;
+import javafx.scene.Parent;
 import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.XYChart;
+import javafx.scene.chart.XYChart.Data;
+import javafx.scene.chart.XYChart.Series;
 import javafx.scene.layout.Pane;
 import javafx.util.StringConverter;
 
@@ -54,7 +65,7 @@ public class GraphWidget implements AnnotatedWidget {
 
   static {
     GraphicsPipeline pipeline = GraphicsPipeline.getPipeline();
-    System.out.println("Using graphics pipeline: " + pipeline);
+    log.info("Using graphics pipeline: " + pipeline);
     if (pipeline instanceof SWPipeline || pipeline instanceof J2DPipeline) {
       log.warning("Software rendering detected! Graphs will be VERY slow and will most likely make the entire "
           + "application slow down to the point of being completely unusable");
@@ -73,23 +84,15 @@ public class GraphWidget implements AnnotatedWidget {
   private final StringProperty title = new SimpleStringProperty(this, "title", "");
 
   private final ObservableList<DataSource> sources = FXCollections.observableArrayList();
-  private final Map<DataSource<? extends Number>, XYChart.Series<Number, Number>> numberSeriesMap = new HashMap<>();
-  private final Map<DataSource<double[]>, List<XYChart.Series<Number, Number>>> arraySeriesMap = new HashMap<>();
+  private final Map<DataSource<? extends Number>, Series<Number, Number>> numberSeriesMap = new HashMap<>();
+  private final Map<DataSource<double[]>, List<Series<Number, Number>>> arraySeriesMap = new HashMap<>();
   private final DoubleProperty visibleTime = new SimpleDoubleProperty(this, "Visible time", 30);
 
-  private final Map<XYChart.Series<Number, Number>, BooleanProperty> visibleSeries = new HashMap<>();
-  private final Map<XYChart.Series<Number, Number>, ObservableList<XYChart.Data<Number, Number>>> realData
-      = new HashMap<>();
+  private final Map<Series<Number, Number>, BooleanProperty> visibleSeries = new HashMap<>();
+  private final Map<Series<Number, Number>, List<Data<Number, Number>>> realData = new HashMap<>();
 
-  // The number of data points to average
-  private static final int SAMPLING_SIZE = 5;
-
-  // How many times each series has been updated in the range [0, SAMPLING_SIZE)
-  private final Map<XYChart.Series, Integer> seen = new HashMap<>();
-
-  // The average value of the past N values in each series, where 0 <= N < SAMPLING_SIZE
-  // Once the series has been updated SAMPLING_SIZE times, the average value is reset to zero.
-  private final Map<XYChart.Series, Double> avg = new HashMap<>();
+  private final Object queueLock = new Object();
+  private final Map<Series<Number, Number>, List<Data<Number, Number>>> queuedData = new HashMap<>();
 
   private final ChangeListener<Number> numberChangeLister = (property, oldNumber, newNumber) -> {
     final DataSource<Number> source = sourceFor(property);
@@ -101,7 +104,7 @@ public class GraphWidget implements AnnotatedWidget {
     updateFromArraySource(source);
   };
 
-  private final Function<XYChart.Series<Number, Number>, BooleanProperty> createVisibleProperty = s -> {
+  private final Function<Series<Number, Number>, BooleanProperty> createVisibleProperty = s -> {
     SimpleBooleanProperty visible = new SimpleBooleanProperty(this, s.getName() + " visible", true);
     visible.addListener((__, was, is) -> {
       if (is) {
@@ -114,6 +117,34 @@ public class GraphWidget implements AnnotatedWidget {
     });
     return visible;
   };
+
+  /**
+   * Keep track of all graph widgets so they update at the same time
+   * It's jarring to see a bunch of graphs all updating at different times
+   */
+  private static final Collection<GraphWidget> graphWidgets =
+      Collections.synchronizedSet(Collections.newSetFromMap(new WeakHashMap<>()));
+
+  /**
+   * How often graphs should be redrawn, in milliseconds.
+   */
+  private static final long UPDATE_PERIOD = 250;
+
+  private static final Future<?> updater = ThreadUtils.newDaemonScheduledExecutorService()
+      .scheduleAtFixedRate(() -> {
+        synchronized (graphWidgets) {
+          graphWidgets.forEach(GraphWidget::update);
+        }
+      }, 500, UPDATE_PERIOD, TimeUnit.MILLISECONDS);
+
+  /**
+   * Creates a new graph widget.
+   */
+  public GraphWidget() {
+    synchronized (graphWidgets) {
+      graphWidgets.add(this);
+    }
+  }
 
   @FXML
   private void initialize() {
@@ -176,7 +207,7 @@ public class GraphWidget implements AnnotatedWidget {
       if (cur.doubleValue() > prev.doubleValue()) {
         // insert data at the beginning of each series
         realData.forEach((series, dataList) -> {
-          List<XYChart.Data<Number, Number>> toAdd = dataList.stream()
+          List<Data<Number, Number>> toAdd = dataList.stream()
               .filter(d -> d.getXValue().doubleValue() >= xAxis.getLowerBound())
               .filter(d -> d.getXValue().doubleValue() < series.getData().get(0).getXValue().doubleValue())
               .collect(Collectors.toList());
@@ -204,7 +235,7 @@ public class GraphWidget implements AnnotatedWidget {
 
   private void updateFromNumberSource(DataSource<? extends Number> source) {
     final long now = Time.now();
-    final XYChart.Series<Number, Number> series = getNumberSeries(source);
+    final Series<Number, Number> series = getNumberSeries(source);
 
     // The update HAS TO run on the FX thread, otherwise we run the risk of ConcurrentModificationExceptions
     // when the chart goes to lay out the data
@@ -216,7 +247,7 @@ public class GraphWidget implements AnnotatedWidget {
   private void updateFromArraySource(DataSource<double[]> source) {
     final long now = System.currentTimeMillis();
     final double[] data = source.getData();
-    final List<XYChart.Series<Number, Number>> series = getArraySeries(source);
+    final List<Series<Number, Number>> series = getArraySeries(source);
 
     // The update HAS TO run on the FX thread, otherwise we run the risk of ConcurrentModificationExceptions
     // when the chart goes to lay out the data
@@ -227,61 +258,81 @@ public class GraphWidget implements AnnotatedWidget {
     });
   }
 
-  private void updateSeries(XYChart.Series<Number, Number> series, long now, double newData) {
-    int lastSeen = seen.put(series, (seen.computeIfAbsent(series, __ -> SAMPLING_SIZE - 1) + 1) % SAMPLING_SIZE);
-    double currentAvg = (avg.computeIfAbsent(series, __ -> 0.0) + newData) / SAMPLING_SIZE;
-    if (lastSeen != 0) {
-      avg.put(series, currentAvg);
-      return;
-    }
-    avg.put(series, 0.0);
-    long elapsed = now - Time.getStartTime();
-    XYChart.Data<Number, Number> point = new XYChart.Data<>(elapsed, currentAvg);
-    ObservableList<XYChart.Data<Number, Number>> dataList = series.getData();
-    if (!dataList.isEmpty()) {
-      // Make the graph a square wave
-      // This prevents the graph from appearing to be continuous when the data is discreet
-      // Note this only affects the chart; the actual data is not changed
-      double prev = dataList.get(dataList.size() - 1).getYValue().doubleValue();
-      if (prev != currentAvg) {
-        dataList.add(new XYChart.Data<>(elapsed - 1, prev));
+  private void updateSeries(Series<Number, Number> series, long now, double newData) {
+    final long elapsed = now - Time.getStartTime();
+    final Data<Number, Number> point = new Data<>(elapsed, newData);
+    final ObservableList<Data<Number, Number>> dataList = series.getData();
+    Data<Number, Number> squarifier = null;
+    realData.computeIfAbsent(series, __ -> new ArrayList<>()).add(point);
+    synchronized (queueLock) {
+      List<Data<Number, Number>> queue = queuedData.computeIfAbsent(series, __ -> new ArrayList<>());
+      if (queue.isEmpty()) {
+        if (!dataList.isEmpty()) {
+          squarifier = createSquarifier(newData, elapsed, dataList);
+        }
+      } else {
+        squarifier = createSquarifier(newData, elapsed, queue);
       }
+      if (squarifier != null) {
+        queue.add(squarifier);
+      }
+      queue.add(point);
     }
-    dataList.add(point);
-    realData.computeIfAbsent(series, __ -> FXCollections.observableArrayList()).add(point);
     if (!chart.getData().contains(series)
         && Optional.ofNullable(visibleSeries.get(series)).map(Property::getValue).orElse(true)) {
       chart.getData().add(series);
     }
-    updateBounds(elapsed);
   }
 
-  private XYChart.Series<Number, Number> getNumberSeries(DataSource<? extends Number> source) {
+  private Data<Number, Number> createSquarifier(double newData, long elapsed, List<Data<Number, Number>> queue) {
+    // Make the graph a square wave
+    // This prevents the graph from appearing to be continuous when the data is discreet
+    // Note this only affects the chart; the actual data is not changed
+    Data<Number, Number> squarifier = null;
+    double prev = queue.get(queue.size() - 1).getYValue().doubleValue();
+    if (prev != newData) {
+      squarifier = new Data<>(elapsed - 1, prev);
+    }
+    return squarifier;
+  }
+
+  private Series<Number, Number> getNumberSeries(DataSource<? extends Number> source) {
     if (!numberSeriesMap.containsKey(source)) {
-      XYChart.Series<Number, Number> series = new XYChart.Series<>();
+      Series<Number, Number> series = new Series<>();
       series.setName(source.getName());
       numberSeriesMap.put(source, series);
-      realData.put(series, FXCollections.observableArrayList());
+      realData.put(series, new ArrayList<>());
       visibleSeries.computeIfAbsent(series, createVisibleProperty);
+      series.nodeProperty().addListener((__, old, node) -> {
+        if (node instanceof Parent) {
+          Parent parent = (Parent) node;
+          parent.getChildrenUnmodifiable().forEach(child -> {
+            child.setCache(true);
+            child.setCacheHint(CacheHint.SPEED);
+          });
+          parent.setCache(true);
+          parent.setCacheHint(CacheHint.SPEED);
+        }
+      });
     }
     return numberSeriesMap.get(source);
   }
 
-  private List<XYChart.Series<Number, Number>> getArraySeries(DataSource<double[]> source) {
-    List<XYChart.Series<Number, Number>> series = arraySeriesMap.computeIfAbsent(source, __ -> new ArrayList<>());
+  private List<Series<Number, Number>> getArraySeries(DataSource<double[]> source) {
+    List<Series<Number, Number>> series = arraySeriesMap.computeIfAbsent(source, __ -> new ArrayList<>());
     final double[] data = source.getData();
     if (data.length < series.size()) {
       while (series.size() != data.length) {
-        XYChart.Series<Number, Number> removed = series.remove(series.size() - 1);
+        Series<Number, Number> removed = series.remove(series.size() - 1);
         realData.remove(removed);
         visibleSeries.remove(removed);
       }
     } else if (data.length > series.size()) {
       for (int i = series.size(); i < data.length; i++) {
-        XYChart.Series<Number, Number> newSeries = new XYChart.Series<>();
+        Series<Number, Number> newSeries = new Series<>();
         newSeries.setName(source.getName() + "[" + i + "]"); // eg "array[0]", "array[1]", etc
         series.add(newSeries);
-        realData.put(newSeries, FXCollections.observableArrayList());
+        realData.put(newSeries, new ArrayList<>());
         visibleSeries.computeIfAbsent(newSeries, createVisibleProperty);
       }
     }
@@ -291,6 +342,28 @@ public class GraphWidget implements AnnotatedWidget {
   private void updateBounds(long elapsed) {
     xAxis.setUpperBound(elapsed);
     removeInvisibleData();
+  }
+
+  private void update() {
+    FxUtils.runOnFxThread(() -> {
+      if (chart.getData().isEmpty()) {
+        return;
+      }
+      synchronized (queueLock) {
+        queuedData.forEach((series, queuedData) -> series.getData().addAll(queuedData));
+        queuedData.forEach((series, queuedData) -> queuedData.clear());
+        OptionalLong maxX = chart.getData().stream()
+            .map(Series::getData)
+            .filter(d -> !d.isEmpty())
+            .map(d -> d.get(d.size() - 1))
+            .map(Data::getXValue)
+            .mapToLong(Number::longValue)
+            .max();
+        if (maxX.isPresent()) {
+          updateBounds(maxX.getAsLong());
+        }
+      }
+    });
   }
 
   @Override
@@ -356,7 +429,7 @@ public class GraphWidget implements AnnotatedWidget {
     realData.forEach((series, dataList) -> {
       int firstBeforeOutOfRange = -1;
       for (int i = 0; i < series.getData().size(); i++) {
-        XYChart.Data<Number, Number> data = series.getData().get(i);
+        Data<Number, Number> data = series.getData().get(i);
         if (data.getXValue().doubleValue() >= lower) {
           firstBeforeOutOfRange = i;
           break;

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/PrimitiveDoubleArrayList.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/PrimitiveDoubleArrayList.java
@@ -2,6 +2,7 @@ package edu.wpi.first.shuffleboard.plugin.base.widget;
 
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 import java.util.function.Consumer;
 import java.util.function.DoubleConsumer;
 import java.util.stream.DoubleStream;
@@ -54,7 +55,7 @@ public class PrimitiveDoubleArrayList implements Iterable<Double> {
   }
 
   /**
-   * Gets the value at the given index
+   * Gets the value at the given index.
    *
    * @param index the index to get the value at
    *
@@ -139,17 +140,19 @@ public class PrimitiveDoubleArrayList implements Iterable<Double> {
   @Override
   public Iterator<Double> iterator() {
     return new Iterator<Double>() {
-
-      int index = 0;
+      private int index = 0;
 
       @Override
       public boolean hasNext() {
-        return index < size - 1;
+        return index < size() - 1;
       }
 
       @Override
       public Double next() {
-        return array[index++];
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
+        return get(index++);
       }
     };
   }
@@ -161,6 +164,12 @@ public class PrimitiveDoubleArrayList implements Iterable<Double> {
     }
   }
 
+  /**
+   * Performs the given action for each element until all elements have been processed or the action
+   * throws an exception. Exceptions thrown by the action are relayed to the caller.
+   *
+   * @param action the action to be performed on each element
+   */
   public void forEach(DoubleConsumer action) {
     for (int i = 0; i < size; i++) {
       action.accept(array[i]);

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/PrimitiveDoubleArrayList.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/PrimitiveDoubleArrayList.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.function.Consumer;
-import java.util.function.DoubleConsumer;
 import java.util.stream.DoubleStream;
 
 /**
@@ -144,7 +143,7 @@ public class PrimitiveDoubleArrayList implements Iterable<Double> {
 
       @Override
       public boolean hasNext() {
-        return index < size() - 1;
+        return index < size();
       }
 
       @Override
@@ -165,15 +164,16 @@ public class PrimitiveDoubleArrayList implements Iterable<Double> {
   }
 
   /**
-   * Performs the given action for each element until all elements have been processed or the action
-   * throws an exception. Exceptions thrown by the action are relayed to the caller.
+   * Creates a new primitive <tt>double</tt> array containing all the values in this list.
    *
-   * @param action the action to be performed on each element
+   * @return a new <tt>double</tt> array
    */
-  public void forEach(DoubleConsumer action) {
-    for (int i = 0; i < size; i++) {
-      action.accept(array[i]);
+  public double[] toArray() {
+    double[] arr = new double[size];
+    if (size > 0) {
+      System.arraycopy(array, 0, arr, 0, size);
     }
+    return arr;
   }
 
 }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/PrimitiveDoubleArrayList.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/PrimitiveDoubleArrayList.java
@@ -1,0 +1,170 @@
+package edu.wpi.first.shuffleboard.plugin.base.widget;
+
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.function.Consumer;
+import java.util.function.DoubleConsumer;
+import java.util.stream.DoubleStream;
+
+/**
+ * An arraylist of primitive doubles. This class behaves much like {@link java.util.ArrayList}.
+ *
+ * <p>The <tt>size</tt>, <tt>isEmpty</tt>, <tt>get</tt>, and
+ * <tt>iterator</tt> operations run in constant
+ * time.  The <tt>add</tt> operation runs in <i>amortized constant time</i>,
+ * that is, adding n elements requires O(n) time.  All of the other operations
+ * run in linear time (roughly speaking).  The constant factor is low compared
+ * to that for the <tt>LinkedList</tt> implementation.
+ */
+public class PrimitiveDoubleArrayList implements Iterable<Double> {
+
+  private static final int INITIAL_SIZE = 16;
+
+  private double[] array = new double[INITIAL_SIZE];
+  private int size = 0;
+
+  /**
+   * Creates a new array list with space for 16 initial values.
+   */
+  public PrimitiveDoubleArrayList() {
+    this(INITIAL_SIZE);
+  }
+
+  /**
+   * Creates a new array list with a given size.
+   *
+   * @param initialSize the initial number of values the list should contain before needing to be resized
+   */
+  public PrimitiveDoubleArrayList(int initialSize) {
+    if (initialSize <= 0) {
+      throw new IllegalArgumentException("Initial size must be at least 1, was given: " + initialSize);
+    }
+    array = new double[initialSize];
+  }
+
+  /**
+   * Adds a value to the end of this list.
+   *
+   * @param value the value to add
+   */
+  public void add(double value) {
+    ensureCapacity(size + 1);
+    array[size] = value;
+    size++;
+  }
+
+  /**
+   * Gets the value at the given index
+   *
+   * @param index the index to get the value at
+   *
+   * @return the value at the given index
+   *
+   * @throws IndexOutOfBoundsException if <tt>index</tt> is negative or greater than the upper index
+   */
+  public double get(int index) {
+    if (index < 0 || index >= size) {
+      throw new IndexOutOfBoundsException("Index must be in [0," + size + "), but was " + index);
+    }
+    return array[index];
+  }
+
+  /**
+   * Removes excess entries from the backing array.
+   */
+  public void trimToSize() {
+    if (size == array.length) {
+      return;
+    }
+    double[] trimmed = new double[size];
+    System.arraycopy(array, 0, trimmed, 0, size);
+    array = trimmed;
+  }
+
+  /**
+   * Gets the number of elements in this list.
+   *
+   * @return the number of elements in this list
+   */
+  public int size() {
+    return size;
+  }
+
+  /**
+   * Checks if this list contains any elements.
+   *
+   * @return <tt>false</tt> if this list contains anything, <tt>true</tt> if this list contains at least one element
+   */
+  public boolean isEmpty() {
+    return size == 0;
+  }
+
+  /**
+   * Removes all elements from this list.
+   */
+  public void clear() {
+    array = new double[INITIAL_SIZE];
+    size = 0;
+  }
+
+  /**
+   * Creates a stream of all the elements in this list.
+   */
+  public DoubleStream stream() {
+    if (size == 0) {
+      return DoubleStream.empty();
+    }
+    return Arrays.stream(array, 0, size);
+  }
+
+  /**
+   * Ensures that this list can contain at least <tt>capacity</tt> number of elements. This will grow the backing array
+   * if needed.
+   *
+   * @param capacity the desired capacity of the list
+   */
+  private void ensureCapacity(int capacity) {
+    if (array.length < capacity) {
+      double[] bigger;
+      if (array.length > Integer.MAX_VALUE / 2) {
+        bigger = new double[Integer.MAX_VALUE];
+      } else {
+        bigger = new double[array.length * 2];
+      }
+      System.arraycopy(array, 0, bigger, 0, array.length);
+      array = bigger;
+    }
+  }
+
+  @Override
+  public Iterator<Double> iterator() {
+    return new Iterator<Double>() {
+
+      int index = 0;
+
+      @Override
+      public boolean hasNext() {
+        return index < size - 1;
+      }
+
+      @Override
+      public Double next() {
+        return array[index++];
+      }
+    };
+  }
+
+  @Override
+  public void forEach(Consumer<? super Double> action) {
+    for (int i = 0; i < size; i++) {
+      action.accept(array[i]);
+    }
+  }
+
+  public void forEach(DoubleConsumer action) {
+    for (int i = 0; i < size; i++) {
+      action.accept(array[i]);
+    }
+  }
+
+}

--- a/plugins/base/src/test/java/edu/wpi/first/shuffleboard/plugin/base/widget/PrimitiveDoubleArrayListTest.java
+++ b/plugins/base/src/test/java/edu/wpi/first/shuffleboard/plugin/base/widget/PrimitiveDoubleArrayListTest.java
@@ -1,0 +1,91 @@
+package edu.wpi.first.shuffleboard.plugin.base.widget;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PrimitiveDoubleArrayListTest {
+
+  @Test
+  public void testEmpty() {
+    PrimitiveDoubleArrayList list = new PrimitiveDoubleArrayList();
+    assertAll(
+        () -> assertEquals(0, list.size(), "Size is not zero"),
+        () -> assertTrue(list.isEmpty(), "List is not empty")
+    );
+  }
+
+  @Test
+  public void testAdd() {
+    PrimitiveDoubleArrayList list = new PrimitiveDoubleArrayList();
+    list.add(12.34);
+    list.add(Math.PI);
+    assertAll(
+        () -> assertEquals(2, list.size(), "Size is not two"),
+        () -> assertFalse(list.isEmpty(), "List should not be empty"),
+        () -> assertEquals(12.34, list.get(0)),
+        () -> assertEquals(Math.PI, list.get(1))
+    );
+  }
+
+  @Test
+  public void testAddALot() {
+    PrimitiveDoubleArrayList list = new PrimitiveDoubleArrayList();
+    for (int i = 0; i < 256; i++) {
+      list.add(i);
+    }
+    assertEquals(256, list.size());
+    assertAll(IntStream.range(0, 256).mapToObj(i -> (Executable) () -> assertEquals((double) i, list.get(i))));
+  }
+
+  @Test
+  public void testToArray() {
+    PrimitiveDoubleArrayList list = new PrimitiveDoubleArrayList();
+    for (int i = 0; i < 256; i++) {
+      list.add(i);
+    }
+    double[] array = list.toArray();
+    assertEquals(256, array.length);
+    assertAll(IntStream.range(0, 256).mapToObj(i -> (Executable) () -> assertEquals(list.get(i), array[i])));
+  }
+
+  @Test
+  public void testStream() {
+    PrimitiveDoubleArrayList list = new PrimitiveDoubleArrayList();
+    for (int i = 0; i < 256; i++) {
+      list.add(i);
+    }
+    assertAll(list.stream()
+        .mapToObj(d -> (Executable) () -> assertEquals(d, list.get((int) d))));
+  }
+
+  @Test
+  public void testEmptyIterator() {
+    int count = 0;
+    PrimitiveDoubleArrayList list = new PrimitiveDoubleArrayList();
+    for (double value : list) {
+      count++;
+    }
+    assertEquals(0, count);
+  }
+
+  @Test
+  public void testPopulatedIterator() {
+    PrimitiveDoubleArrayList list = new PrimitiveDoubleArrayList();
+    for (int i = 0; i < 256; i++) {
+      list.add(i);
+    }
+    int count = 0;
+    for (double value : list) {
+      count++;
+    }
+    assertEquals(count, list.size());
+  }
+
+}


### PR DESCRIPTION
Fixes #428 

Stores the "real" data in parallel primitive `double[]` arrays to reduce memory footprint by a factor of 20.
Does 4Hz batch updates to graph data to reduce the amount of render calls
Caches rendered series nodes to speed up rendering

Overall reduces CPU use by ~30-40% for rendering graphs on both my desktop (i7-7700K @ 4.2GHz) and laptop (i7-6700HQ @ 2.6GHz) - render thread use drops from 95-100% use down to 60-70%