### PR TITLE
Make recording more efficient

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recorder.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recorder.java
@@ -82,11 +82,9 @@ public final class Recorder {
         recordingFile = file.toFile();
       }
       if (firstSave) {
-        System.out.println("First-time save");
         Serialization.saveRecording(recording, file);
         firstSave = false;
       } else {
-        System.out.println("Updating existing save");
         Serialization.updateRecordingSave(recording, file);
       }
       recording.getData().clear();
@@ -110,7 +108,6 @@ public final class Recorder {
     recording = new Recording();
     // Record initial conditions
     synchronized (recordingLock) {
-      System.out.println("Recording initial data");
       SourceTypes.getDefault().getItems().stream()
           .map(SourceType::getAvailableSources)
           .forEach(sources -> sources.forEach((id, value) -> {

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -2,6 +2,8 @@ package edu.wpi.first.shuffleboard.api.sources.recording;
 
 import edu.wpi.first.shuffleboard.api.data.DataType;
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
+import edu.wpi.first.shuffleboard.api.data.types.StringArrayType;
+import edu.wpi.first.shuffleboard.api.data.types.StringType;
 import edu.wpi.first.shuffleboard.api.sources.recording.serialization.Serializers;
 import edu.wpi.first.shuffleboard.api.sources.recording.serialization.TypeAdapter;
 
@@ -24,7 +26,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -455,7 +456,7 @@ public final class Serialization {
    * Encodes a string array as a big-endian byte array. These can be read with {@link #readStringArray(byte[], int)}.
    */
   public static byte[] toByteArray(String[] array) { // NOPMD varargs
-    return useSerializer(String[].class, s -> s.serialize(array));
+    return Serializers.get(StringArrayType.Instance).serialize(array);
   }
 
   /**
@@ -583,7 +584,7 @@ public final class Serialization {
    * @param pos   the starting position of the encoded string
    */
   public static String readString(byte[] array, int pos) {
-    return useSerializer(String.class, s -> s.deserialize(array, pos));
+    return Serializers.get(StringType.Instance).deserialize(array, pos);
   }
 
   /**
@@ -593,14 +594,7 @@ public final class Serialization {
    * @param pos   the starting position of the encoded string array
    */
   public static String[] readStringArray(byte[] array, int pos) {
-    return useSerializer(String[].class, s -> s.deserialize(array, pos));
-  }
-
-  private static <T, U> U useSerializer(Class<T> type, Function<TypeAdapter<T>, U> function) {
-    return DataTypes.getDefault().forJavaType(type)
-        .map(Serializers::get)
-        .map(function)
-        .orElseThrow(() -> new UnsupportedOperationException("No type adapter for " + type.getSimpleName()));
+    return Serializers.get(StringArrayType.Instance).deserialize(array, pos);
   }
 
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -168,6 +168,7 @@ public final class Serialization {
         .reduce(new byte[0], Serialization::concat);
     byte[] withUpdatedHeader = insert(newConstantPoolEntries, bytes, constantPoolEnd);
     byte[] result = concat(withUpdatedHeader, newBodyEntries);
+    put(result, toByteArray(readInt(bytes, 4) + recording.getData().size()), 4); // Update number of data points
     put(result, toByteArray(sourceIdList.size()), 8); // Make sure to update the number of source IDs
     Files.write(file, result);
   }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -83,15 +83,11 @@ public final class Serialization {
       final DataType type = data.getDataType();
       final Object value = data.getData();
 
-      final byte[] timestamp = toByteArray(data.getTimestamp()); // NOPMD
+      final byte[] timestamp = toByteArray(data.getTimestamp());
       // use int16 instead of int32 -- 32,767 sources should be enough
-      final byte[] sourceIdIndex = toByteArray((short) sourceNames.indexOf(data.getSourceId())); //NOPMD
-      final byte[] dataType = toByteArray(type.getName()); // NOPMD
-      final byte[] dataBytes = encode(value, type); // NOPMD
-
-      if (dataBytes == null) {
-        throw new IOException("Cannot serialize value of type " + type.getName());
-      }
+      final byte[] sourceIdIndex = toByteArray((short) sourceNames.indexOf(data.getSourceId()));
+      final byte[] dataType = toByteArray(type.getName());
+      final byte[] dataBytes = encode(value, type);
 
       segments.add(timestamp);
       segments.add(sourceIdIndex);
@@ -149,19 +145,11 @@ public final class Serialization {
           final DataType type = data.getDataType();
           final Object value = data.getData();
 
-          final byte[] timestamp = toByteArray(data.getTimestamp()); // NOPMD
+          final byte[] timestamp = toByteArray(data.getTimestamp());
           // use int16 instead of int32 -- 32,767 sources should be enough
-          int index = sourceIdList.indexOf(data.getSourceId());
-          if (index < 0) {
-            throw new IllegalStateException("Source ID list does not contain '" + data.getSourceId() + "'");
-          }
-          final byte[] sourceIdIndex = toByteArray((short) index); //NOPMD
-          final byte[] dataType = toByteArray(type.getName()); // NOPMD
-          final byte[] dataBytes = encode(value, type); // NOPMD
-
-          if (dataBytes == null) {
-            throw new IllegalStateException("Cannot serialize value of type " + type.getName());
-          }
+          final byte[] sourceIdIndex = toByteArray((short) sourceIdList.indexOf(data.getSourceId()));
+          final byte[] dataType = toByteArray(type.getName());
+          final byte[] dataBytes = encode(value, type);
 
           return Bytes.concat(timestamp, sourceIdIndex, dataType, dataBytes);
         })

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -603,30 +603,4 @@ public final class Serialization {
         .orElseThrow(() -> new UnsupportedOperationException("No type adapter for " + type.getSimpleName()));
   }
 
-  /**
-   * Inserts one array into another, returning the result. Neither array is modified.
-   *
-   * @param src the source array to insert
-   * @param dst the array to insert into
-   * @param pos the position to insert into
-   *
-   * @return the result of insertion
-   */
-  public static byte[] insert(byte[] src, byte[] dst, int pos) {
-    if (src.length == 0) {
-      return dst;
-    }
-    if (pos == 0) {
-      // Shortcut: inserting src at the start of dst
-      return Bytes.concat(src, dst);
-    }
-    if (pos == dst.length) {
-      // Shortcut: appending src at the end of dst
-      return Bytes.concat(dst, src);
-    }
-    byte[] left = Arrays.copyOfRange(dst, 0, pos);
-    byte[] right = Arrays.copyOfRange(dst, pos, dst.length);
-    return Bytes.concat(left, src, right);
-  }
-
 }

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/SerializationTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/SerializationTest.java
@@ -2,13 +2,15 @@ package edu.wpi.first.shuffleboard.api.sources.recording;
 
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -59,15 +61,54 @@ public class SerializationTest {
   }
 
   @Test
-  @Disabled("Adapters will be moved")
-  public void testEncodeRecode() throws IOException {
-    final Path file = Files.createTempFile("testEncodeRecode", "frc");
+  public void testSimpleEncodeRecode() throws IOException {
+    final Path file = Files.createTempFile("testEncodeRecode", "sbr");
     final Recording recording = new Recording();
-    recording.append(new TimestampedData("foo", DataTypes.All, 0.0, 0));
-    recording.append(new TimestampedData("foo", DataTypes.All, 100.0, 1));
+    recording.append(new TimestampedData("foo", DataTypes.Number, 0.0, 0));
+    recording.append(new TimestampedData("foo", DataTypes.Number, 100.0, 1));
     Serialization.saveRecording(recording, file);
     final Recording loaded = Serialization.loadRecording(file);
     assertEquals(recording, loaded, "The loaded recording differs from the encoded one");
+  }
+
+  @Test
+  public void testUpdateFile() throws IOException {
+    final Path file = Files.createTempFile("testEncodeRecode", "sbr");
+    final Recording recording = new Recording();
+    final List<TimestampedData> data = new ArrayList<>();
+    data.add(new TimestampedData("foo", DataTypes.Number, 42.0, 0));
+    data.add(new TimestampedData("bar", DataTypes.Boolean, true, 1));
+    recording.getData().addAll(data);
+    Serialization.saveRecording(recording, file);
+    final Recording loaded = Serialization.loadRecording(file);
+    assertEquals(recording, loaded, "The loaded recording differs from the encoded one");
+
+    TimestampedData newData = new TimestampedData("foo", DataTypes.Number, 123.456, 2);
+    recording.getData().clear();
+    data.add(newData);
+    recording.getData().add(newData);
+    Serialization.updateRecordingSave(recording, file);
+    final Recording loadedUpdate = Serialization.loadRecording(file);
+    assertEquals(data, loadedUpdate.getData());
+  }
+
+  @Test
+  public void testInsert() {
+    byte[] src = {-128, 0, 127};
+    byte[] dst = {1, 1, 1, 1};
+    byte[] index0 = Serialization.insert(src, dst, 0);
+    byte[] index1 = Serialization.insert(src, dst, 1);
+    byte[] index2 = Serialization.insert(src, dst, 2);
+    byte[] index3 = Serialization.insert(src, dst, 3);
+    byte[] atEnd = Serialization.insert(src, dst, 4);
+    assertAll(
+        () -> assertArrayEquals(new byte[]{-128, 0, 127, 1, 1, 1, 1}, index0),
+        () -> assertArrayEquals(new byte[]{1, -128, 0, 127, 1, 1, 1}, index1),
+        () -> assertArrayEquals(new byte[]{1, 1, -128, 0, 127, 1, 1}, index2),
+        () -> assertArrayEquals(new byte[]{1, 1, 1, -128, 0, 127, 1}, index3),
+        () -> assertArrayEquals(new byte[]{1, 1, 1, 1, -128, 0, 127}, atEnd)
+    );
+
   }
 
 }

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/SerializationTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/SerializationTest.java
@@ -10,7 +10,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -90,25 +89,6 @@ public class SerializationTest {
     Serialization.updateRecordingSave(recording, file);
     final Recording loadedUpdate = Serialization.loadRecording(file);
     assertEquals(data, loadedUpdate.getData());
-  }
-
-  @Test
-  public void testInsert() {
-    byte[] src = {-128, 0, 127};
-    byte[] dst = {1, 1, 1, 1};
-    byte[] index0 = Serialization.insert(src, dst, 0);
-    byte[] index1 = Serialization.insert(src, dst, 1);
-    byte[] index2 = Serialization.insert(src, dst, 2);
-    byte[] index3 = Serialization.insert(src, dst, 3);
-    byte[] atEnd = Serialization.insert(src, dst, 4);
-    assertAll(
-        () -> assertArrayEquals(new byte[]{-128, 0, 127, 1, 1, 1, 1}, index0),
-        () -> assertArrayEquals(new byte[]{1, -128, 0, 127, 1, 1, 1}, index1),
-        () -> assertArrayEquals(new byte[]{1, 1, -128, 0, 127, 1, 1}, index2),
-        () -> assertArrayEquals(new byte[]{1, 1, 1, -128, 0, 127, 1}, index3),
-        () -> assertArrayEquals(new byte[]{1, 1, 1, 1, -128, 0, 127}, atEnd)
-    );
-
   }
 
 }

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/serialization/AbstractAdapterTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/serialization/AbstractAdapterTest.java
@@ -4,17 +4,33 @@ import edu.wpi.first.shuffleboard.api.data.DataTypes;
 
 import com.google.common.collect.ImmutableList;
 
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 public class AbstractAdapterTest<T> {
 
+  private static Collection<TypeAdapter> adapters;
   protected final TypeAdapter<T> adapter;
   protected final ImmutableList<TypeAdapter> requirements;
 
   public AbstractAdapterTest(TypeAdapter<T> adapter, TypeAdapter... requirements) {
     this.adapter = adapter;
     this.requirements = ImmutableList.copyOf(requirements);
+  }
+
+  @BeforeAll
+  public static void getOldAdapters() {
+    adapters = new ArrayList<>(Serializers.getAdapters());
+  }
+
+  @AfterAll
+  public static void resetAdapters() {
+    adapters.forEach(Serializers::add);
   }
 
   @BeforeEach


### PR DESCRIPTION
Recordings are saved incrementally, only modifying the existing recording file with new data, instead of reserializing all the recorded data points and rewriting the recording file from scratch.

This _significantly_ improves both the memory and CPU impact of data recording

Fixes #429 