### PR TITLE
Embed the startup time in log file names

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -23,6 +23,9 @@ import it.sauronsoftware.junique.JUnique;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.FileHandler;
 import java.util.logging.Handler;
@@ -199,7 +202,8 @@ public class Shuffleboard extends Application {
       globalLogger.removeHandler(handler);
     }
 
-    final Handler fileHandler = new FileHandler(Storage.getStorageDir() + "/shuffleboard.log");
+    String time = DateTimeFormatter.ofPattern("YYYY-MM-dd-HH.mm.ss", Locale.getDefault()).format(LocalDateTime.now());
+    final Handler fileHandler = new FileHandler(Storage.getStorageDir() + "/shuffleboard." + time + ".log");
 
     fileHandler.setLevel(Level.INFO);    // Only log INFO and above to disk
     globalLogger.setLevel(Level.CONFIG); // Log CONFIG and higher


### PR DESCRIPTION
Keeps old log files without overwriting them

Log files are named `shuffleboard.YYYY-MM-dd-HH.mm.ss.log`, eg `shuffleboard.2018-03-16-09.23.16.log`, embedding the time at which shuffleboard started in the log file name to make it easier to search for specific log files.

Fixes #431