### PR TITLE
Release opencv Mat after use to avoid memory leak

### DIFF
--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/recording/serialization/ImageConverter.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/recording/serialization/ImageConverter.java
@@ -23,7 +23,7 @@ public final class ImageConverter {
   private WritableImage image;
   private byte[] data;
   private ByteBuffer buffer;
-  private Mat converted = new Mat();
+  private final Mat converted = new Mat();
 
   /**
    * Convert a BGR-formatted OpenCV {@link Mat} into a JavaFX {@link Image}. JavaFX understands ARGB

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/recording/serialization/ImageConverter.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/recording/serialization/ImageConverter.java
@@ -89,6 +89,9 @@ public final class ImageConverter {
 
     // Grab the image data
     toRender.get(0, 0, data);
+    // Java may not realize how much memory this takes up, and won't garbage collect it,
+    // causing shuffleboard to eat more and more memory each frame.
+    toRender.release();
 
     image.getPixelWriter().setPixels(0, 0, width, height, PixelFormat.getByteRgbInstance(), buffer, width * channels);
 

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/recording/serialization/ImageConverter.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/recording/serialization/ImageConverter.java
@@ -30,12 +30,11 @@ public final class ImageConverter {
    * pixel data, so one way to turn a Mat into a JavaFX image is to shift around the bytes from the
    * Mat into an int array of pixels.
    *
-   * @param mat           An 8-bit OpenCV Mat containing an image with either 1 or 3 channels
-   * @param desiredHeight the desired height of the image
+   * @param mat An 8-bit OpenCV Mat containing an image with either 1 or 3 channels
    *
    * @return A JavaFX image, or null for empty
    */
-  public Image convert(Mat mat, int desiredHeight) {
+  public Image convert(Mat mat) {
 
     final int channels = mat.channels();
 
@@ -79,19 +78,6 @@ public final class ImageConverter {
     image.getPixelWriter().setPixels(0, 0, width, height, PixelFormat.getByteRgbInstance(), buffer, width * channels);
 
     return image;
-  }
-
-  /**
-   * Convert a BGR-formatted OpenCV {@link Mat} into a JavaFX {@link Image}. JavaFX understands ARGB
-   * pixel data, so one way to turn a Mat into a JavaFX image is to shift around the bytes from the
-   * Mat into an int array of pixels.
-   *
-   * @param mat An 8-bit OpenCV Mat containing an image with either 1 or 3 channels
-   *
-   * @return A JavaFX image, or null for empty
-   */
-  public Image convert(Mat mat) {
-    return convert(mat, mat.rows());
   }
 
 }


### PR DESCRIPTION
A new `Mat` gets created every time `ImageConverter.convert` gets called.  Now it gets released after the method is done.

On my laptop, this was causing shuffleboard to eat >5GB of memory after only a few minutes, when three camera streams were open at once.  I found that the Java heap was actually under a few hundred MB during this time.  My guess is that Java (at least, the OpenJDK implementation on my machine) didn't think it needed to garbage collect, since it wasn't running out of heap space for its own objects.  Thus it never collected the `Mat` objects that would get created each frame, so `finalize` never got called on them to call the C++ destructor.  In any case, this patch fixes it.