### PR TITLE
Add a preloader to notify users of the status of startup routines

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -156,6 +156,18 @@ public class MainWindowController {
             running -> running ? "Stop recording" : "Start recording"));
     FxUtils.bind(root.getStylesheets(), stylesheets);
 
+    log.info("Setting up plugins in the UI");
+    PluginLoader.getDefault().getLoadedPlugins().forEach(plugin -> {
+      plugin.loadedProperty().addListener((__, was, is) -> {
+        if (is) {
+          setup(plugin);
+        } else {
+          tearDown(plugin);
+        }
+      });
+      setup(plugin);
+    });
+    sourcesAccordion.getPanes().sort(Comparator.comparing(TitledPane::getText));
     PluginLoader.getDefault().getKnownPlugins().addListener((ListChangeListener<Plugin>) c -> {
       while (c.next()) {
         if (c.wasAdded()) {

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/PreloaderController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/PreloaderController.java
@@ -1,0 +1,38 @@
+package edu.wpi.first.shuffleboard.app;
+
+import edu.wpi.first.shuffleboard.api.util.FxUtils;
+
+import org.controlsfx.tools.Utils;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.control.ProgressBar;
+import javafx.scene.layout.Pane;
+
+public class PreloaderController {
+
+  @FXML
+  private Pane root;
+  @FXML
+  private Label versionLabel;
+  @FXML
+  private Label stateLabel;
+  @FXML
+  private ProgressBar progressBar;
+
+  @FXML
+  private void initialize() {
+    progressBar.setProgress(-1);
+    versionLabel.setText(Shuffleboard.getVersion());
+    FxUtils.setController(root, this);
+  }
+
+  public void setStateText(String text) {
+    stateLabel.setText(text + "...");
+  }
+
+  public void setProgress(double progress) {
+    progressBar.setProgress(Utils.clamp(0, progress, 1));
+  }
+
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -123,8 +123,6 @@ public class Shuffleboard extends Application {
     PluginLoader.getDefault().loadAllJarsFromDir(Storage.getPluginPath());
     notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading custom plugins", 0.75));
     PluginCache.getDefault().loadCache(PluginLoader.getDefault());
-    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading custom plugins", 0.875));
-    Thread.sleep(250); // wait to let the new status be visible before overwriting it
     notifyPreloader(new ShuffleboardPreloader.StateNotification("Starting up", 1));
     Thread.sleep(20); // small wait to let the status be visible - the preloader doesn't get notifications for a bit
   }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -85,7 +85,6 @@ public class Shuffleboard extends Application {
     logger.finer("Registering custom user themes from external dir");
     notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading custom themes", 0));
     Themes.getDefault().loadThemesFromDir();
-    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading custom themes", 1));
 
     logger.info("Build time: " + getBuildTime());
 
@@ -109,22 +108,22 @@ public class Shuffleboard extends Application {
       return;
     }
 
-    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading base plugin", 0));
+    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading base plugin", 0.125));
     PluginLoader.getDefault().load(new BasePlugin());
 
     Recorder.getInstance().start();
 
-    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading NetworkTables plugin", 0));
+    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading NetworkTables plugin", 0.25));
     PluginLoader.getDefault().load(new NetworkTablesPlugin());
-    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading CameraServer plugin", 0));
+    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading CameraServer plugin", 0.375));
     PluginLoader.getDefault().load(new CameraServerPlugin());
-    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading Powerup plugin", 0));
+    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading Powerup plugin", 0.5));
     PluginLoader.getDefault().load(new PowerupPlugin());
-    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading custom plugins", 0));
+    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading custom plugins", 0.625));
     PluginLoader.getDefault().loadAllJarsFromDir(Storage.getPluginPath());
-    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading custom plugins", 0.5));
+    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading custom plugins", 0.75));
     PluginCache.getDefault().loadCache(PluginLoader.getDefault());
-    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading custom plugins", 1));
+    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading custom plugins", 0.875));
     Thread.sleep(250); // wait to let the new status be visible before overwriting it
     notifyPreloader(new ShuffleboardPreloader.StateNotification("Starting up", 1));
     Thread.sleep(20); // small wait to let the status be visible - the preloader doesn't get notifications for a bit

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/ShuffleboardPreloader.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/ShuffleboardPreloader.java
@@ -1,0 +1,91 @@
+package edu.wpi.first.shuffleboard.app;
+
+import edu.wpi.first.shuffleboard.api.util.FxUtils;
+import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
+
+import javafx.application.Preloader;
+import javafx.fxml.FXMLLoader;
+import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+
+/**
+ * The preloader for shuffleboard. This will display the progress of various startup routines until the main window
+ * appears.
+ */
+public class ShuffleboardPreloader extends Preloader {
+
+  private Stage preloaderStage;
+  private PreloaderController controller;
+
+  @Override
+  public void start(Stage stage) throws Exception {
+    preloaderStage = stage;
+
+    Pane preloaderPane = FXMLLoader.load(PreloaderController.class.getResource("Preloader.fxml"));
+    controller = FxUtils.getController(preloaderPane);
+
+    Scene scene = new Scene(preloaderPane);
+    scene.getStylesheets().setAll(AppPreferences.getInstance().getTheme().getStyleSheets());
+    stage.setScene(scene);
+    stage.initStyle(StageStyle.UNDECORATED);
+    stage.show();
+  }
+
+  @Override
+  public void handleApplicationNotification(PreloaderNotification info) {
+    if (info instanceof StateNotification) {
+      StateNotification notification = (StateNotification) info;
+      controller.setStateText(notification.getState());
+      controller.setProgress(notification.getProgress());
+    }
+  }
+
+  @Override
+  public void handleStateChangeNotification(StateChangeNotification info) {
+    if (info.getType() == StateChangeNotification.Type.BEFORE_START) {
+      preloaderStage.close();
+    }
+  }
+
+  /**
+   * A notification for the progress of a state in the preloader.
+   */
+  public static final class StateNotification implements PreloaderNotification {
+
+    private final String state;
+    private final double progress;
+
+    /**
+     * Creates a new state notification.
+     *
+     * @param state    the state
+     * @param progress the progress of the state, in the range [0, 1]
+     */
+    public StateNotification(String state, double progress) {
+      this.state = state;
+      this.progress = progress;
+    }
+
+    /**
+     * Gets the state.
+     */
+    public String getState() {
+      return state;
+    }
+
+    /**
+     * Gets the progress.
+     */
+    public double getProgress() {
+      return progress;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("StateNotification(state='%s', progress=%s)", state, progress);
+    }
+  }
+
+}

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/Preloader.fxml
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/Preloader.fxml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.ProgressBar?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.layout.VBox?>
+<BorderPane xmlns="http://javafx.com/javafx/8.0.121" xmlns:fx="http://javafx.com/fxml/1"
+            fx:controller="edu.wpi.first.shuffleboard.app.PreloaderController"
+            fx:id="root"
+            prefWidth="480.0" prefHeight="240.0">
+    <center>
+        <VBox alignment="CENTER_LEFT" styleClass="shuffleboard-dialog-header">
+            <padding>
+                <Insets topRightBottomLeft="32"/>
+            </padding>
+            <Label text="WPILib Shuffleboard" styleClass="shuffleboard-dialog-header-title"/>
+            <Label fx:id="versionLabel" styleClass="shuffleboard-dialog-header-subtitle"/>
+        </VBox>
+    </center>
+    <bottom>
+        <VBox>
+            <Label fx:id="stateLabel" alignment="CENTER" maxWidth="Infinity" textAlignment="CENTER"/>
+            <ProgressBar fx:id="progressBar" maxWidth="Infinity" maxHeight="6"/>
+        </VBox>
+    </bottom>
+</BorderPane>


### PR DESCRIPTION
This should help with #444 by letting users and CSAs know where Shuffleboard is during its startup sequence (it's already logged, but this is a better UX)

# Screenshot
![image](https://user-images.githubusercontent.com/6320992/37610610-70ce03a0-2b76-11e8-8108-0cdba3714602.png)
