### PR TITLE
Fix delimiting in composite networktable sources

### DIFF
--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
@@ -32,7 +32,7 @@ import javafx.beans.value.ChangeListener;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "NetworkTables",
-    version = "1.0.0",
+    version = "1.0.1",
     summary = "Provides sources and widgets for NetworkTables"
 )
 public class NetworkTablesPlugin extends Plugin {

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/CompositeNetworkTableSource.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/CompositeNetworkTableSource.java
@@ -39,7 +39,7 @@ public class CompositeNetworkTableSource<D extends ComplexData<D>> extends Netwo
   public CompositeNetworkTableSource(String tableName, ComplexDataType<D> dataType) {
     super(tableName, dataType);
     this.dataType = dataType;
-    String path = NetworkTable.normalizeKey(tableName, false) + '/';
+    String path = NetworkTable.normalizeKey(tableName, false);
     NetworkTable table = NetworkTableInstance.getDefault().getTable(path);
     setData(dataType.getDefaultValue());
 


### PR DESCRIPTION
Was updating entries like "/a/b//property1" with two slashes. NetworkTables does not normalize to remove consecutive slashes
Fixes #447