### PR TITLE
Load main FXML in init()

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -204,8 +204,6 @@ public class MainWindowController {
           .collect(joining(this::generateSeparatorLabel));
       connectionIndicatorArea.getChildren().setAll(collect);
     });
-
-    setUpPluginsStage();
   }
 
   private Label generateSeparatorLabel() {
@@ -596,6 +594,9 @@ public class MainWindowController {
 
   @FXML
   private void showPlugins() {
+    if (pluginStage == null) {
+      setUpPluginsStage();
+    }
     if (pluginStage.getOwner() == null) {
       pluginStage.initOwner(root.getScene().getWindow());
     }

--- a/integ_test/src/test/java/edu/wpi/first/shuffleboard/app/ShuffleboardLaunchTest.java
+++ b/integ_test/src/test/java/edu/wpi/first/shuffleboard/app/ShuffleboardLaunchTest.java
@@ -10,6 +10,7 @@ public class ShuffleboardLaunchTest extends ApplicationTest {
   @Override
   public void start(Stage stage) throws Exception {
     final Shuffleboard shuffleboard = new Shuffleboard();
+    shuffleboard.init();
     shuffleboard.start(stage);
   }
 


### PR DESCRIPTION
Avoids long downtimes when FXML loading/initialization takes a while, since that would happen in start() before the main stage was shown