### PR TITLE
Fix plugin dependencies comparing versions in the wrong order

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoader.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoader.java
@@ -378,7 +378,7 @@ public class PluginLoader {
         .filter(d -> d.group().equals(description.group()))
         .filter(d -> d.name().equals(description.name()))
         .map(d -> Version.parse(d.minVersion()))
-        .anyMatch(v -> isCompatible(v, Version.parse(description.version())));
+        .anyMatch(v -> isCompatible(Version.parse(description.version()), v));
   }
 
   /**


### PR DESCRIPTION
Plugins could be unloaded without unloading their dependents first. Wasn't noticed before because plugins never changed their versions