### PR TITLE
Allow right-clicking on entries in source trees to create new tabs

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -291,11 +291,10 @@ public class MainWindowController {
 
           ContextMenu menu = new ContextMenu();
           if (source.getDataType().isComplex()) {
-            String id = source.getId();
             menu.getItems().add(FxUtils.menuItem("Create tab", __ -> {
               DashboardTab newTab = dashboard.addNewTab();
               newTab.setTitle(entry.getViewName());
-              newTab.setSourcePrefix(id);
+              newTab.setSourcePrefix(source.getId() + "/");
               newTab.setAutoPopulate(true);
               dashboard.getSelectionModel().select(newTab);
             }));

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -74,6 +74,7 @@ import javafx.scene.control.ContextMenu;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
+import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.control.SplitPane;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
@@ -284,14 +285,27 @@ public class MainWindowController {
             return;
           }
 
-          DataSource<?> source = selectedItem.getValue().get();
+          SourceEntry entry = selectedItem.getValue();
+          DataSource<?> source = entry.get();
           List<String> componentNames = Components.getDefault().componentNamesForSource(source);
-          if (componentNames.isEmpty()) {
-            // No known components that can show this data
-            return;
-          }
 
           ContextMenu menu = new ContextMenu();
+          if (source.getDataType().isComplex()) {
+            String id = source.getId();
+            menu.getItems().add(FxUtils.menuItem("Create tab", __ -> {
+              DashboardTab newTab = dashboard.addNewTab();
+              newTab.setTitle(entry.getViewName());
+              newTab.setSourcePrefix(id);
+              newTab.setAutoPopulate(true);
+              dashboard.getSelectionModel().select(newTab);
+            }));
+            if (!componentNames.isEmpty()) {
+              menu.getItems().add(new SeparatorMenuItem());
+            }
+          } else if (componentNames.isEmpty()) {
+            // Can't create a tab, and no components can display the source
+            return;
+          }
           componentNames.stream()
               .map(name -> createShowAsMenuItem(name, source))
               .forEach(menu.getItems()::add);

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
@@ -292,9 +292,15 @@ public class DashboardTab extends Tab implements HandledTab, Populatable {
           .ifPresent(c -> {
             // Remove redundant source name information from the title, if necessary
             String sourcePrefix = getSourcePrefix();
-            sourcePrefix = sourcePrefix.endsWith("/") ? sourcePrefix : sourcePrefix + "/";
-            if (!"/".equals(sourcePrefix) && c.getTitle().startsWith(sourcePrefix)) {
-              c.setTitle(c.getTitle().substring(sourcePrefix.length()));
+            sourcePrefix = source.getType().removeProtocol(sourcePrefix);
+            sourcePrefix = NetworkTable.normalizeKey(sourcePrefix, false);
+            String title = c.getTitle();
+            if (!"/".equals(sourcePrefix) && !sourcePrefix.isEmpty()) {
+              if (title.startsWith(sourcePrefix)) {
+                c.setTitle(title.substring(sourcePrefix.length()));
+              } else if (title.equals(sourcePrefix)) {
+                c.setTitle(NetworkTable.basenameKey(sourcePrefix));
+              }
             }
             getWidgetPane().addComponent(c);
             if (c instanceof Populatable) {


### PR DESCRIPTION
e.g. right click on /LiveWindow/Elevator creates a new tab "Elevator" that autopopulates with data from network_tables:///LiveWindow/Elevator