### PR TITLE
Do not display metadata in source trees

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/DataSourceUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/DataSourceUtils.java
@@ -1,0 +1,33 @@
+package edu.wpi.first.shuffleboard.api.sources;
+
+import java.util.regex.Pattern;
+
+public final class DataSourceUtils {
+
+  private static final Pattern oldMetadataPattern = Pattern.compile("(^|/)~\\w+~($|/)");
+  private static final Pattern newMetadataPattern = Pattern.compile("(^|/)\\.");
+
+  private DataSourceUtils() {
+    throw new UnsupportedOperationException("This is a utility class!");
+  }
+
+  /**
+   * Checks if the given source URI is metadata, eg matches the format "~METADATA~" or ".metadata", or has any parent
+   * that matches either of those formats.
+   */
+  public static boolean isMetadata(String sourceUri) {
+    return newMetadataPattern.matcher(sourceUri).find() // Check new metadata first, since that's most likely
+        || oldMetadataPattern.matcher(sourceUri).find();
+  }
+
+  /**
+   * Checks if the given source URI is not metadata, eg does not match either "~METADATA~" or ".metadata".
+   * <br>Shorthand for {@code !isMetadata(sourceUri)}.
+   *
+   * @see #isMetadata(String)
+   */
+  public static boolean isNotMetadata(String sourceUri) {
+    return !isMetadata(sourceUri);
+  }
+
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/NetworkTableUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/NetworkTableUtils.java
@@ -8,8 +8,6 @@ import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
 
-import java.util.regex.Pattern;
-
 /**
  * Utility class for working with network tables.
  */
@@ -20,9 +18,6 @@ public final class NetworkTableUtils {
    */
   public static final NetworkTableInstance inst = NetworkTableInstance.getDefault();
   public static final NetworkTable rootTable = inst.getTable("");
-
-  private static final Pattern oldMetadataPattern = Pattern.compile("(^|/)~\\w+~($|/)");
-  private static final Pattern newMetadataPattern = Pattern.compile("(^|/)\\.");
 
   private NetworkTableUtils() {
     throw new UnsupportedOperationException("This is a utility class!");
@@ -51,14 +46,6 @@ public final class NetworkTableUtils {
    */
   public static boolean isDelete(int flags) {
     return BitUtils.flagMatches(flags, EntryListenerFlags.kDelete);
-  }
-
-  /**
-   * Checks if the given key is metadata, eg matches the format "~METADATA~" or ".metadata"
-   */
-  public static boolean isMetadata(String key) {
-    return oldMetadataPattern.matcher(key).find()
-        || newMetadataPattern.matcher(key).find();
   }
 
   /**

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/DataSourceUtilsTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/DataSourceUtilsTest.java
@@ -1,0 +1,33 @@
+package edu.wpi.first.shuffleboard.api.sources;
+
+import edu.wpi.first.shuffleboard.api.util.UtilityClassTest;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DataSourceUtilsTest extends UtilityClassTest<DataSourceUtils> {
+
+  @ParameterizedTest
+  @CsvSource({"false, /key",
+                 "false, /metadata",
+                 "false, /~metadata",
+                 "false, /metadata~",
+                 "true, /~metadata~",
+                 "false, /METADATA",
+                 "false, /~METADATA",
+                 "false, /METADATA~",
+                 "true, /~METADATA~",
+                 "true, /.metadata",
+                 "true, /~METADATA~/someOtherValue",
+                 "true, /.metadata/someOtherValue",
+                 "false, /my.key.with.dots",
+                 "false, /my~key~with~tildes~",
+                 "false, /~my~keywithtildes",
+                 "false, /~metadata~with~tildes~"})
+  public void isMetaDataTest(boolean expectedResult, String key) {
+    assertEquals(expectedResult, DataSourceUtils.isMetadata(key));
+  }
+
+}

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/util/NetworkTableUtilsTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/util/NetworkTableUtilsTest.java
@@ -2,7 +2,6 @@ package edu.wpi.first.shuffleboard.api.util;
 
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.stream.Stream;
@@ -10,28 +9,6 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class NetworkTableUtilsTest extends UtilityClassTest<NetworkTableUtils> {
-
-
-  @ParameterizedTest
-  @CsvSource({"false, /key",
-                 "false, /metadata",
-                 "false, /~metadata",
-                 "false, /metadata~",
-                 "true, /~metadata~",
-                 "false, /METADATA",
-                 "false, /~METADATA",
-                 "false, /METADATA~",
-                 "true, /~METADATA~",
-                 "true, /.metadata",
-                 "true, /~METADATA~/someOtherValue",
-                 "true, /.metadata/someOtherValue",
-                 "false, /my.key.with.dots",
-                 "false, /my~key~with~tildes~",
-                 "false, /~my~keywithtildes",
-                 "false, /~metadata~with~tildes~"})
-  public void isMetaDataTest(boolean expectedResult, String key) {
-    assertEquals(expectedResult, NetworkTableUtils.isMetadata(key));
-  }
 
   private static Stream<Arguments> concatArguments() {
     return Stream.of(

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -9,6 +9,7 @@ import edu.wpi.first.shuffleboard.api.plugin.Plugin;
 import edu.wpi.first.shuffleboard.api.prefs.FlushableProperty;
 import edu.wpi.first.shuffleboard.api.sources.ConnectionStatus;
 import edu.wpi.first.shuffleboard.api.sources.DataSource;
+import edu.wpi.first.shuffleboard.api.sources.DataSourceUtils;
 import edu.wpi.first.shuffleboard.api.sources.SourceEntry;
 import edu.wpi.first.shuffleboard.api.sources.SourceType;
 import edu.wpi.first.shuffleboard.api.sources.SourceTypes;
@@ -300,13 +301,16 @@ public class MainWindowController {
         });
         sourceType.getAvailableSources().addListener((MapChangeListener<String, Object>) change -> {
           SourceEntry entry = sourceType.createSourceEntryForUri(change.getKey());
-          if (change.wasAdded()) {
-            tree.updateEntry(entry);
-          } else if (change.wasRemoved()) {
-            tree.removeEntry(entry);
+          if (DataSourceUtils.isNotMetadata(entry.getName())) {
+            if (change.wasAdded()) {
+              tree.updateEntry(entry);
+            } else if (change.wasRemoved()) {
+              tree.removeEntry(entry);
+            }
           }
         });
         sourceType.getAvailableSourceUris().stream()
+            .filter(DataSourceUtils::isNotMetadata)
             .map(sourceType::createSourceEntryForUri)
             .forEach(tree::updateEntry);
         TitledPane titledPane = new TitledPane(sourceType.getName(), tree);

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
@@ -5,12 +5,12 @@ import edu.wpi.first.shuffleboard.api.components.ExtendedPropertySheet;
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
 import edu.wpi.first.shuffleboard.api.prefs.FlushableProperty;
 import edu.wpi.first.shuffleboard.api.sources.DataSource;
+import edu.wpi.first.shuffleboard.api.sources.DataSourceUtils;
 import edu.wpi.first.shuffleboard.api.sources.SourceType;
 import edu.wpi.first.shuffleboard.api.sources.SourceTypes;
 import edu.wpi.first.shuffleboard.api.tab.TabInfo;
 import edu.wpi.first.shuffleboard.api.util.Debouncer;
 import edu.wpi.first.shuffleboard.api.util.FxUtils;
-import edu.wpi.first.shuffleboard.api.util.NetworkTableUtils;
 import edu.wpi.first.shuffleboard.api.util.TypeUtils;
 import edu.wpi.first.shuffleboard.api.widget.Component;
 import edu.wpi.first.shuffleboard.api.widget.ComponentContainer;
@@ -251,7 +251,7 @@ public class DashboardTab extends Tab implements HandledTab, Populatable {
         && isAutoPopulate()
         && !getSourcePrefix().isEmpty()
         && type.dataTypeForSource(DataTypes.getDefault(), sourceId) != DataTypes.Map
-        && !NetworkTableUtils.isMetadata(sourceId)
+        && DataSourceUtils.isNotMetadata(sourceId)
         && (name.startsWith(getSourcePrefix()) || sourceId.startsWith(getSourcePrefix()));
   }
 

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/SubsystemLayout.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/SubsystemLayout.java
@@ -5,8 +5,8 @@ import edu.wpi.first.shuffleboard.api.data.DataType;
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
 import edu.wpi.first.shuffleboard.api.data.IncompatibleSourceException;
 import edu.wpi.first.shuffleboard.api.sources.DataSource;
+import edu.wpi.first.shuffleboard.api.sources.DataSourceUtils;
 import edu.wpi.first.shuffleboard.api.sources.SourceTypes;
-import edu.wpi.first.shuffleboard.api.util.NetworkTableUtils;
 import edu.wpi.first.shuffleboard.api.util.TypeUtils;
 import edu.wpi.first.shuffleboard.api.widget.Component;
 import edu.wpi.first.shuffleboard.api.widget.Components;
@@ -41,7 +41,7 @@ public class SubsystemLayout extends ListLayout implements Populatable, Sourced 
         && !getSource().getId().equals(sourceId)
         && sourceId.startsWith(getSource().getId())
         && dataType != DataTypes.Map
-        && !NetworkTableUtils.isMetadata(sourceId);
+        && DataSourceUtils.isNotMetadata(sourceId);
   }
 
   @Override

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/RobotPreferencesWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/RobotPreferencesWidget.java
@@ -1,8 +1,8 @@
 package edu.wpi.first.shuffleboard.plugin.base.widget;
 
 import edu.wpi.first.shuffleboard.api.components.ExtendedPropertySheet;
+import edu.wpi.first.shuffleboard.api.sources.DataSourceUtils;
 import edu.wpi.first.shuffleboard.api.util.AlphanumComparator;
-import edu.wpi.first.shuffleboard.api.util.NetworkTableUtils;
 import edu.wpi.first.shuffleboard.api.widget.Description;
 import edu.wpi.first.shuffleboard.api.widget.ParametrizedController;
 import edu.wpi.first.shuffleboard.api.widget.SimpleAnnotatedWidget;
@@ -55,10 +55,9 @@ public class RobotPreferencesWidget extends SimpleAnnotatedWidget<RobotPreferenc
             .forEach(wrapperProperties::remove);
       }
       updated.forEach((key, value) -> {
-        if (NetworkTableUtils.isMetadata(key)) {
-          return;
+        if (DataSourceUtils.isNotMetadata(key)) {
+          wrapperProperties.computeIfAbsent(key, k -> generateWrapper(k, value)).setValue(value);
         }
-        wrapperProperties.computeIfAbsent(key, k -> generateWrapper(k, value)).setValue(value);
       });
     });
 

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTableTreeWidget.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTableTreeWidget.java
@@ -3,6 +3,7 @@ package edu.wpi.first.shuffleboard.plugin.networktables;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.shuffleboard.api.components.SourceTreeTable;
 import edu.wpi.first.shuffleboard.api.data.MapData;
+import edu.wpi.first.shuffleboard.api.sources.DataSourceUtils;
 import edu.wpi.first.shuffleboard.api.sources.SourceEntry;
 import edu.wpi.first.shuffleboard.api.widget.Description;
 import edu.wpi.first.shuffleboard.api.widget.SimpleAnnotatedWidget;
@@ -48,9 +49,12 @@ public class NetworkTableTreeWidget extends SimpleAnnotatedWidget<MapData> {
       }
 
       newData.changesFrom(oldData)
-          .forEach((key, value) ->
+          .forEach((key, value) -> {
+            if (DataSourceUtils.isNotMetadata(key)) {
               tree.updateEntry(new NetworkTableSourceEntry(
-                  NetworkTable.normalizeKey(key), value)));
+                  NetworkTable.normalizeKey(key), value));
+            }
+          });
     });
   }
 


### PR DESCRIPTION
Move metadata detection to DataSourceUtils, since it doesn't belong with NetworkTable utilities