### PR TITLE
Fix encoders reported as "Encoder" not being handled correctly

### DIFF
--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/EncoderWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/EncoderWidget.java
@@ -4,6 +4,8 @@ import edu.wpi.first.shuffleboard.api.widget.Description;
 import edu.wpi.first.shuffleboard.api.widget.ParametrizedController;
 import edu.wpi.first.shuffleboard.api.widget.SimpleAnnotatedWidget;
 import edu.wpi.first.shuffleboard.plugin.base.data.EncoderData;
+import edu.wpi.first.shuffleboard.plugin.base.data.types.EncoderType;
+import edu.wpi.first.shuffleboard.plugin.base.data.types.QuadratureEncoderType;
 
 import org.fxmisc.easybind.EasyBind;
 
@@ -11,7 +13,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.Pane;
 
-@Description(name = "Encoder", dataTypes = {EncoderData.class})
+@Description(name = "Encoder", dataTypes = {EncoderType.class, QuadratureEncoderType.class})
 @ParametrizedController("Encoder.fxml")
 public class EncoderWidget extends SimpleAnnotatedWidget<EncoderData> {
 


### PR DESCRIPTION
Only encoders reported as "Quadrature Encoder" used to work correctly