### PR TITLE
Fix layout unwrapping not doing anything

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
@@ -579,7 +579,8 @@ public class WidgetPaneController {
       // Layout unwrapping
       if (tile instanceof LayoutTile) {
         widgetPaneActions.addAction("Unwrap", () -> {
-          if (selector.getSelectedTiles().stream().allMatch(t -> t instanceof LayoutTile)) {
+          if (selector.areTilesSelected()
+              && selector.getSelectedTiles().stream().allMatch(t -> t instanceof LayoutTile)) {
             selector.getSelectedTiles().forEach(t -> unwrapLayout((LayoutTile) t));
           } else {
             unwrapLayout(tile);


### PR DESCRIPTION
Caused by not properly checking if any tiles are selected before unwrapping all (i.e. no) selected layouts.