### PR TITLE
Fix dragging components from a nested container

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/dnd/DataFormats.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/dnd/DataFormats.java
@@ -4,6 +4,7 @@ import edu.wpi.first.shuffleboard.api.util.GridPoint;
 
 import java.io.Serializable;
 import java.util.Set;
+import java.util.UUID;
 
 import javafx.scene.input.DataFormat;
 
@@ -91,6 +92,28 @@ public final class DataFormats {
 
     public GridPoint getLocalDragPoint() {
       return localDragPoint;
+    }
+  }
+
+  /**
+   * Holds the information about a tileless component.
+   */
+  public static final class TilelessComponentData implements Serializable {
+
+    private final UUID parentId;
+    private final UUID componentId;
+
+    public TilelessComponentData(UUID parentId, UUID componentId) {
+      this.parentId = parentId;
+      this.componentId = componentId;
+    }
+
+    public UUID getParentId() {
+      return parentId;
+    }
+
+    public UUID getComponentId() {
+      return componentId;
     }
   }
 

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/dnd/DragUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/dnd/DragUtils.java
@@ -1,0 +1,30 @@
+package edu.wpi.first.shuffleboard.api.dnd;
+
+import javafx.scene.input.DataFormat;
+import javafx.scene.input.Dragboard;
+
+/**
+ * Utility class for dealing with various drag and drop operations.
+ */
+public final class DragUtils {
+
+  private DragUtils() {
+    throw new UnsupportedOperationException("This is a utility class!");
+  }
+
+  /**
+   * Gets data from a dragboard for the given format, casting it as necessary.
+   *
+   * @param dragboard the dragboard to get data from
+   * @param format    the data format to get the data for
+   * @param <T>       the expected type of the data
+   *
+   * @return the data for the given data format, or <tt>null</tt> if no such data is present in the dragboard
+   *
+   * @throws ClassCastException if the content in the dragboard for the data format is not of type <tt>T</tt>
+   */
+  public static <T> T getData(Dragboard dragboard, DataFormat format) {
+    return (T) dragboard.getContent(format);
+  }
+
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Components.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Components.java
@@ -244,7 +244,7 @@ public class Components extends Registry<ComponentType> {
    * @param component the component to set
    */
   private void setId(Component component) {
-    allActiveComponents.put(component, UUID.randomUUID());
+    allActiveComponents.putIfAbsent(component, UUID.randomUUID());
   }
 
   public Optional<Type> javaTypeFor(String name) {

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/LayoutBase.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/LayoutBase.java
@@ -232,11 +232,15 @@ public abstract class LayoutBase implements Layout {
     private final Property<LabelPosition> labelPosition =
         new SimpleObjectProperty<>(this, "labelPosition", LabelPosition.BOTTOM);
     private final Property<Component> child = new SimpleObjectProperty<>(this, "child", null);
+    private final Layout layout;
 
     /**
      * Creates a new empty container.
+     *
+     * @param layout the layout containing this container
      */
-    public ChildContainer() {
+    public ChildContainer(Layout layout) {
+      this.layout = layout;
       setMaxWidth(Double.POSITIVE_INFINITY);
       getStyleClass().add("layout-stack");
       label.getStyleClass().add("layout-label");
@@ -256,9 +260,10 @@ public abstract class LayoutBase implements Layout {
       set(getLabelSide(), label);
       setOnDragDetected(e -> {
         Component child = getChild();
-        UUID uuid = Components.getDefault().uuidForComponent(child);
+        UUID parentId = Components.getDefault().uuidForComponent(this.layout);
+        UUID childId = Components.getDefault().uuidForComponent(child);
         ClipboardContent clipboardContent = new ClipboardContent();
-        clipboardContent.put(DataFormats.tilelessComponent, uuid);
+        clipboardContent.put(DataFormats.tilelessComponent, new DataFormats.TilelessComponentData(parentId, childId));
         Dragboard dragboard = this.startDragAndDrop(TransferMode.MOVE);
         dragboard.setContent(clipboardContent);
         WritableImage preview =
@@ -277,10 +282,11 @@ public abstract class LayoutBase implements Layout {
     /**
      * Creates a container for the given component.
      *
-     * @param child the component to be contained
+     * @param child  the component to be contained
+     * @param layout the layout containing this container
      */
-    public ChildContainer(Component child) {
-      this();
+    public ChildContainer(Component child, Layout layout) {
+      this(layout);
       setChild(child);
     }
 

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/widget/ChildContainerTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/widget/ChildContainerTest.java
@@ -28,7 +28,7 @@ public class ChildContainerTest extends ApplicationTest {
 
   @Test
   public void testTitleUpdates() {
-    ChildContainer container = new ChildContainer();
+    ChildContainer container = new ChildContainer(null);
     MockWidget firstChild = new MockWidget();
     MockWidget secondChild = new MockWidget();
     firstChild.setTitle("First child");
@@ -45,7 +45,7 @@ public class ChildContainerTest extends ApplicationTest {
 
   @Test
   public void testMoveLabel() {
-    ChildContainer container = new ChildContainer();
+    ChildContainer container = new ChildContainer(null);
     Node label = container.getBottom();
 
     container.setLabelSide(LayoutBase.LabelPosition.TOP);

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/GridLayout.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/GridLayout.java
@@ -252,7 +252,7 @@ public final class GridLayout extends LayoutBase {
     if (panes.containsKey(component)) {
       return panes.get(component);
     }
-    ChildContainer pane = new ChildContainer(component);
+    ChildContainer pane = new ChildContainer(component, this);
     pane.labelPositionProperty().bindBidirectional(this.labelPositionProperty());
     GridPane.setHgrow(pane, Priority.ALWAYS);
     GridPane.setVgrow(pane, Priority.ALWAYS);

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/ListLayout.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/ListLayout.java
@@ -38,7 +38,7 @@ public class ListLayout extends LayoutBase {
     if (panes.containsKey(component)) {
       return panes.get(component);
     }
-    ChildContainer pane = new ChildContainer(component);
+    ChildContainer pane = new ChildContainer(component, this);
     pane.labelPositionProperty().bindBidirectional(this.labelPositionProperty());
     ActionList.registerSupplier(pane, () -> actionsForComponent(component));
     panes.put(component, pane);


### PR DESCRIPTION
For example, given a hierarchy of `root > layout > layout > widget`, dragging the widget into the root pane would not properly clean up its parent layout