### PR TITLE
Refactor large classes to reduce complexity and adhere more to SOLID principles

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/FxUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/FxUtils.java
@@ -27,6 +27,8 @@ import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
+import javafx.stage.Window;
+import javafx.stage.WindowEvent;
 
 import static java.util.Objects.requireNonNull;
 
@@ -222,6 +224,16 @@ public final class FxUtils {
       throw new IllegalArgumentException("FXML controller class has no @ParametrizedController: " + controllerClass);
     }
     return FXMLLoader.load(controllerClass.getResource(annotation.value()));
+  }
+
+  /**
+   * Fires a close request on a window. This is useful to call on the main application window to allow shutdown
+   * listeners to run, since they are not run when <tt>System.exit()</tt> or <tt>Platform.exit()</tt> are called.
+   *
+   * @param window the window to request to close
+   */
+  public static void requestClose(Window window) {
+    window.fireEvent(new WindowEvent(window, WindowEvent.WINDOW_CLOSE_REQUEST));
   }
 
 }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/ConnectionIndicatorsController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/ConnectionIndicatorsController.java
@@ -1,0 +1,79 @@
+package edu.wpi.first.shuffleboard.app;
+
+import edu.wpi.first.shuffleboard.api.sources.ConnectionStatus;
+import edu.wpi.first.shuffleboard.api.sources.SourceType;
+import edu.wpi.first.shuffleboard.api.sources.SourceTypes;
+import edu.wpi.first.shuffleboard.api.sources.UiHints;
+
+import org.fxmisc.easybind.EasyBind;
+
+import java.util.List;
+
+import javafx.collections.ListChangeListener;
+import javafx.css.PseudoClass;
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Pane;
+
+import static edu.wpi.first.shuffleboard.api.util.ListUtils.joining;
+
+/**
+ * Controller for the connection indicators in the bottom-right corner of the application window.
+ */
+public final class ConnectionIndicatorsController {
+
+  @FXML
+  private Pane root;
+
+  private final ListChangeListener<SourceType> updateWhenSourcesChange =
+      change -> generateConnectionIndicators(change.getList());
+
+  @FXML
+  private void initialize() {
+    generateConnectionIndicators(SourceTypes.getDefault().getItems());
+    SourceTypes.getDefault().getItems().addListener(updateWhenSourcesChange);
+  }
+
+  private void generateConnectionIndicators(List<? extends SourceType> sourceTypes) {
+    root.getChildren().setAll(
+        sourceTypes.stream()
+            .filter(s -> !optOutOfConnectionIndicator(s))
+            .map(this::generateConnectionLabel)
+            .collect(joining(this::generateSeparatorLabel)));
+  }
+
+  private Label generateSeparatorLabel() {
+    Label label = new Label(" | ");
+    label.getStyleClass().add("connection-indicator-separator");
+    return label;
+  }
+
+  /**
+   * Checks if a source type has opted out of displaying a connection indicator.
+   */
+  private boolean optOutOfConnectionIndicator(SourceType sourceType) {
+    Class<? extends SourceType> clazz = sourceType.getClass();
+    UiHints hints = clazz.getAnnotation(UiHints.class);
+    return hints != null && !hints.showConnectionIndicator();
+  }
+
+  private Label generateConnectionLabel(SourceType sourceType) {
+    Label label = new Label();
+    label.getStyleClass().add("connection-indicator");
+    label.textProperty().bind(
+        EasyBind.monadic(sourceType.connectionStatusProperty())
+            .map(ConnectionStatus::isConnected)
+            .map(connected -> sourceType.getName() + ": " + (connected ? "connected" : "not connected")));
+    sourceType.connectionStatusProperty().addListener((__, old, status) -> {
+      updateConnectionLabel(label, status.isConnected());
+    });
+    updateConnectionLabel(label, sourceType.getConnectionStatus().isConnected());
+    return label;
+  }
+
+  private void updateConnectionLabel(Label label, boolean connected) {
+    label.pseudoClassStateChanged(PseudoClass.getPseudoClass("connected"), connected);
+    label.pseudoClassStateChanged(PseudoClass.getPseudoClass("disconnected"), !connected);
+  }
+
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/LeftDrawerController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/LeftDrawerController.java
@@ -1,0 +1,117 @@
+package edu.wpi.first.shuffleboard.app;
+
+import edu.wpi.first.shuffleboard.api.plugin.Plugin;
+import edu.wpi.first.shuffleboard.api.sources.SourceEntry;
+import edu.wpi.first.shuffleboard.api.util.FxUtils;
+import edu.wpi.first.shuffleboard.api.widget.Component;
+import edu.wpi.first.shuffleboard.api.widget.Components;
+import edu.wpi.first.shuffleboard.app.components.InteractiveSourceTree;
+import edu.wpi.first.shuffleboard.app.components.WidgetGallery;
+import edu.wpi.first.shuffleboard.app.plugin.PluginLoader;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+
+import java.util.Comparator;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
+import javafx.fxml.FXML;
+import javafx.scene.control.Accordion;
+import javafx.scene.control.TitledPane;
+import javafx.scene.layout.Pane;
+
+public class LeftDrawerController {
+
+  @FXML
+  private Pane root;
+  @FXML
+  private Accordion sourcesAccordion;
+  @FXML
+  private WidgetGallery widgetGallery;
+
+  private final Multimap<Plugin, TitledPane> sourcePanes = ArrayListMultimap.create();
+
+  // TODO inject these
+  private Consumer<Component> addComponentToActivePane;
+  private Consumer<SourceEntry> createTabForSource;
+
+  @FXML
+  private void initialize() {
+    PluginLoader.getDefault().getLoadedPlugins().forEach(plugin -> {
+      listenToPluginChanges(plugin);
+      setup(plugin);
+    });
+    sourcesAccordion.getPanes().sort(Comparator.comparing(TitledPane::getText));
+    PluginLoader.getDefault().getKnownPlugins().addListener((ListChangeListener<Plugin>) c -> {
+      while (c.next()) {
+        if (c.wasAdded()) {
+          c.getAddedSubList().forEach(plugin -> {
+            listenToPluginChanges(plugin);
+            setup(plugin);
+          });
+        }
+        sourcesAccordion.getPanes().sort(Comparator.comparing(TitledPane::getText));
+      }
+    });
+    FxUtils.setController(root, this);
+  }
+
+  private void listenToPluginChanges(Plugin plugin) {
+    plugin.loadedProperty().addListener((__, was, is) -> {
+      if (is) {
+        setup(plugin);
+      } else {
+        tearDown(plugin);
+      }
+    });
+  }
+
+  /**
+   * Sets up UI components to represent the sources that a plugin defines.
+   */
+  private void setup(Plugin plugin) {
+    FxUtils.runOnFxThread(() -> {
+      plugin.getSourceTypes().forEach(sourceType -> {
+        InteractiveSourceTree tree =
+            new InteractiveSourceTree(sourceType, addComponentToActivePane, createTabForSource);
+
+        TitledPane titledPane = new TitledPane(sourceType.getName(), tree);
+        sourcePanes.put(plugin, titledPane);
+        sourcesAccordion.getPanes().add(titledPane);
+        FXCollections.sort(sourcesAccordion.getPanes(), Comparator.comparing(TitledPane::getText));
+        if (sourcesAccordion.getExpandedPane() == null) {
+          sourcesAccordion.setExpandedPane(titledPane);
+        }
+      });
+
+      // Add widgets to the gallery as well
+      widgetGallery.setWidgets(Components.getDefault().allWidgets().collect(Collectors.toList()));
+    });
+  }
+
+  /**
+   * Removes all traces from a plugin from the left drawer. Source trees will be removed and all widgets
+   * defined by the plugin will be removed from the gallery.
+   */
+  private void tearDown(Plugin plugin) {
+    // Remove the source panes
+    sourcesAccordion.getPanes().removeAll(sourcePanes.removeAll(plugin));
+    FXCollections.sort(sourcesAccordion.getPanes(), Comparator.comparing(TitledPane::getText));
+
+    // Remove widgets from the gallery
+    widgetGallery.setWidgets(Components.getDefault().allWidgets().collect(Collectors.toList()));
+  }
+
+  // TODO inject at initialization
+  public void setAddComponentToActivePane(Consumer<Component> addComponentToActivePane) {
+    this.addComponentToActivePane = addComponentToActivePane;
+  }
+
+  // TODO inject at initialization
+  public void setCreateTabForSource(Consumer<SourceEntry> createTabForSource) {
+    this.createTabForSource = createTabForSource;
+  }
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Loggers.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Loggers.java
@@ -1,0 +1,66 @@
+package edu.wpi.first.shuffleboard.app;
+
+import edu.wpi.first.shuffleboard.api.util.Storage;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
+import java.util.logging.FileHandler;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+
+/**
+ * Helper class for setting up the application loggers.
+ */
+final class Loggers {
+
+  private Loggers() {
+    throw new UnsupportedOperationException("This is a utility class");
+  }
+
+  /**
+   * Sets up loggers to print to stdout (rather than stderr) and log to ~/Shuffleboard/shuffleboard.log
+   */
+  static void setupLoggers() throws IOException {
+    //Set up the global level logger. This handles IO for all loggers.
+    final Logger globalLogger = LogManager.getLogManager().getLogger("");
+
+    // Remove the default handlers that stream to System.err
+    for (Handler handler : globalLogger.getHandlers()) {
+      globalLogger.removeHandler(handler);
+    }
+
+    String time = DateTimeFormatter.ofPattern("YYYY-MM-dd-HH.mm.ss", Locale.getDefault()).format(LocalDateTime.now());
+    final Handler fileHandler = new FileHandler(Storage.getStorageDir() + "/shuffleboard." + time + ".log");
+
+    fileHandler.setLevel(Level.INFO);    // Only log INFO and above to disk
+    globalLogger.setLevel(Level.CONFIG); // Log CONFIG and higher
+
+    // We need to stream to System.out instead of System.err
+    final StreamHandler sh = new StreamHandler(System.out, new SimpleFormatter()) {
+      @Override
+      public synchronized void publish(final LogRecord record) { // NOPMD this is the same signature as the superclass
+        super.publish(record);
+        // For some reason this doesn't happen automatically.
+        // This will ensure we get all of the logs printed to the console immediately instead of at shutdown
+        flush();
+      }
+    };
+    sh.setLevel(Level.CONFIG); // Log CONFIG and higher to stdout
+
+    globalLogger.addHandler(sh);
+    globalLogger.addHandler(fileHandler);
+    fileHandler.setFormatter(new SimpleFormatter()); //log in text, not xml
+
+    globalLogger.config("Configuration done."); //Log that we are done setting up the logger
+    globalLogger.config("Shuffleboard app version: " + Shuffleboard.getVersion());
+    globalLogger.config("Running from " + Shuffleboard.getRunningLocation());
+  }
+
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -22,6 +22,9 @@ import edu.wpi.first.shuffleboard.app.components.DashboardTab;
 import edu.wpi.first.shuffleboard.app.components.DashboardTabPane;
 import edu.wpi.first.shuffleboard.app.components.InteractiveSourceTree;
 import edu.wpi.first.shuffleboard.app.components.WidgetGallery;
+import edu.wpi.first.shuffleboard.app.dialogs.AboutDialog;
+import edu.wpi.first.shuffleboard.app.dialogs.ExportRecordingDialog;
+import edu.wpi.first.shuffleboard.app.dialogs.PluginDialog;
 import edu.wpi.first.shuffleboard.app.json.JsonBuilder;
 import edu.wpi.first.shuffleboard.app.plugin.PluginLoader;
 import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
@@ -115,17 +118,14 @@ public class MainWindowController {
   @FXML
   private HBox connectionIndicatorArea;
 
+  private final PluginDialog pluginDialog = new PluginDialog();
+  private final AboutDialog aboutDialog = new AboutDialog();
+  private final ExportRecordingDialog exportRecordingDialog = new ExportRecordingDialog();
   // Use lazy initialization to reduce load time for the main window
-  private final LazyInit<Pane> pluginPane = LazyInit.of(() -> FxUtils.load(PluginPaneController.class));
   private final LazyInit<Pane> downloadPane = LazyInit.of(() -> FxUtils.load(DownloadDialogController.class));
   private final LazyInit<Pane> restartPromptPane =
       LazyInit.of(() -> FXMLLoader.load(MainWindowController.class.getResource("RestartPrompt.fxml")));
-  private final LazyInit<Pane> aboutPane = LazyInit.of(() -> FxUtils.load(AboutDialogController.class));
-  private final LazyInit<Pane> exportRecordingPane =
-      LazyInit.of(() -> FxUtils.load(ConvertRecordingPaneController.class));
-  private Stage pluginStage;
   private Stage downloadStage;
-  private Stage exportRecordingStage;
 
   private File currentFile = null;
 
@@ -232,22 +232,6 @@ public class MainWindowController {
   private void updateConnectionLabel(Label label, boolean connected) {
     label.pseudoClassStateChanged(PseudoClass.getPseudoClass("connected"), connected);
     label.pseudoClassStateChanged(PseudoClass.getPseudoClass("disconnected"), !connected);
-  }
-
-  private void setUpPluginsStage() {
-    pluginStage = new Stage();
-    pluginStage.initModality(Modality.WINDOW_MODAL);
-    pluginStage.addEventHandler(KeyEvent.KEY_PRESSED, e -> {
-      if (e.getCode() == KeyCode.ESCAPE) {
-        pluginStage.close();
-      }
-    });
-    pluginStage.setScene(new Scene(pluginPane.get()));
-    pluginStage.sizeToScene();
-    pluginStage.setMinWidth(675);
-    pluginStage.setMinHeight(325);
-    pluginStage.setTitle("Loaded Plugins");
-    EasyBind.listBind(pluginPane.get().getStylesheets(), root.getStylesheets());
   }
 
   /**
@@ -494,15 +478,7 @@ public class MainWindowController {
 
   @FXML
   private void exportRecordings() {
-    if (exportRecordingStage == null) {
-      exportRecordingStage = new Stage();
-      exportRecordingStage.setTitle("Export Recording Files");
-      exportRecordingStage.setScene(new Scene(exportRecordingPane.get()));
-      exportRecordingStage.setResizable(false);
-      FxUtils.bind(exportRecordingStage.getScene().getStylesheets(), stylesheets);
-      exportRecordingStage.initModality(Modality.APPLICATION_MODAL);
-    }
-    exportRecordingStage.show();
+    exportRecordingDialog.show();
   }
 
   @FXML
@@ -526,23 +502,12 @@ public class MainWindowController {
 
   @FXML
   private void showPlugins() {
-    if (pluginStage == null) {
-      setUpPluginsStage();
-    }
-    if (pluginStage.getOwner() == null) {
-      pluginStage.initOwner(root.getScene().getWindow());
-    }
-    pluginStage.show();
+    pluginDialog.show();
   }
 
   @FXML
   private void showAboutDialog() {
-    ShuffleboardDialog dialog = new ShuffleboardDialog(aboutPane.get(), true);
-    dialog.setHeaderText("WPILib Shuffleboard");
-    dialog.setSubheaderText(Shuffleboard.getVersion());
-    FxUtils.bind(dialog.getDialogPane().getStylesheets(), stylesheets);
-    Platform.runLater(dialog.getDialogPane()::requestFocus);
-    dialog.showAndWait();
+    aboutDialog.show();
   }
 
   private void setUpDialogStage(Stage stage, Pane rootNode) {

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -1,10 +1,6 @@
 package edu.wpi.first.shuffleboard.app;
 
 import edu.wpi.first.shuffleboard.api.plugin.Plugin;
-import edu.wpi.first.shuffleboard.api.sources.ConnectionStatus;
-import edu.wpi.first.shuffleboard.api.sources.SourceType;
-import edu.wpi.first.shuffleboard.api.sources.SourceTypes;
-import edu.wpi.first.shuffleboard.api.sources.UiHints;
 import edu.wpi.first.shuffleboard.api.sources.recording.Recorder;
 import edu.wpi.first.shuffleboard.api.tab.TabInfo;
 import edu.wpi.first.shuffleboard.api.theme.Theme;
@@ -38,14 +34,10 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import javafx.application.Platform;
-import javafx.beans.InvalidationListener;
 import javafx.beans.value.ObservableValue;
 import javafx.collections.ListChangeListener;
-import javafx.collections.ObservableList;
-import javafx.css.PseudoClass;
 import javafx.fxml.FXML;
 import javafx.scene.control.Alert;
-import javafx.scene.control.Label;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.SplitPane;
 import javafx.scene.control.Tab;
@@ -54,13 +46,9 @@ import javafx.scene.layout.HBox;
 import javafx.scene.layout.Pane;
 import javafx.stage.FileChooser;
 
-import static edu.wpi.first.shuffleboard.api.util.ListUtils.joining;
-
-
 /**
  * Controller for the main UI window.
  */
-@SuppressWarnings("PMD.GodClass") // TODO refactor this class
 public class MainWindowController {
 
   private static final Logger log = Logger.getLogger(MainWindowController.class.getName());
@@ -125,11 +113,6 @@ public class MainWindowController {
       }
     });
 
-    generateConnectionIndicators(SourceTypes.getDefault().getItems());
-    SourceTypes.getDefault().getItems().addListener((InvalidationListener) items -> {
-      generateConnectionIndicators((ObservableList<SourceType>) items);
-    });
-
     setLeftDrawerCallbacks();
   }
 
@@ -145,48 +128,6 @@ public class MainWindowController {
     LeftDrawerController leftDrawerController = FxUtils.getController(leftDrawer);
     leftDrawerController.setAddComponentToActivePane(dashboard::addComponentToActivePane);
     leftDrawerController.setCreateTabForSource(dashboard::createTabForSource);
-  }
-
-  private void generateConnectionIndicators(List<SourceType> sourceTypes) {
-    connectionIndicatorArea.getChildren().setAll(
-        sourceTypes.stream()
-            .filter(s -> !optOutOfConnectionIndicator(s))
-            .map(this::generateConnectionLabel)
-            .collect(joining(this::generateSeparatorLabel)));
-  }
-
-  private Label generateSeparatorLabel() {
-    Label label = new Label(" | ");
-    label.getStyleClass().add("connection-indicator-separator");
-    return label;
-  }
-
-  /**
-   * Checks if a source type has opted out of displaying a connection indicator.
-   */
-  private boolean optOutOfConnectionIndicator(SourceType sourceType) {
-    Class<? extends SourceType> clazz = sourceType.getClass();
-    UiHints hints = clazz.getAnnotation(UiHints.class);
-    return hints != null && !hints.showConnectionIndicator();
-  }
-
-  private Label generateConnectionLabel(SourceType sourceType) {
-    Label label = new Label();
-    label.getStyleClass().add("connection-indicator");
-    label.textProperty().bind(
-        EasyBind.monadic(sourceType.connectionStatusProperty())
-            .map(ConnectionStatus::isConnected)
-            .map(connected -> sourceType.getName() + ": " + (connected ? "connected" : "not connected")));
-    sourceType.connectionStatusProperty().addListener((__, old, status) -> {
-      updateConnectionLabel(label, status.isConnected());
-    });
-    updateConnectionLabel(label, sourceType.getConnectionStatus().isConnected());
-    return label;
-  }
-
-  private void updateConnectionLabel(Label label, boolean connected) {
-    label.pseudoClassStateChanged(PseudoClass.getPseudoClass("connected"), connected);
-    label.pseudoClassStateChanged(PseudoClass.getPseudoClass("disconnected"), !connected);
   }
 
   /**

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -210,6 +210,7 @@ public class MainWindowController {
    */
   @FXML
   public void newLayout() {
+    saveFileHandler.clear();
     double[] dividerPositions = centerSplitPane.getDividerPositions();
     List<TabInfo> tabInfo = TabInfoRegistry.getDefault().getItems();
     if (tabInfo.isEmpty()) {

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/SaveFileHandler.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/SaveFileHandler.java
@@ -121,4 +121,11 @@ public final class SaveFileHandler {
     return dashboardData;
   }
 
+  /**
+   * Clears the current file status.
+   */
+  public void clear() {
+    currentFile = null;
+  }
+
 }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/SaveFileHandler.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/SaveFileHandler.java
@@ -1,0 +1,124 @@
+package edu.wpi.first.shuffleboard.app;
+
+import edu.wpi.first.shuffleboard.api.util.Storage;
+import edu.wpi.first.shuffleboard.app.json.JsonBuilder;
+import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
+
+import com.google.common.io.Files;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.Charset;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import javafx.stage.FileChooser;
+
+/**
+ * Helper class for saving and loading Shuffleboard save files.
+ */
+public final class SaveFileHandler {
+
+  private static final Logger log = Logger.getLogger(SaveFileHandler.class.getName());
+
+  private File currentFile = null;
+
+  /**
+   * Saves dashboard data. If no save file has been specified, then the user will be prompted to choose a save file.
+   *
+   * @param data the data to save
+   *
+   * @throws IOException if the data could not be saved
+   */
+  public void save(DashboardData data) throws IOException {
+    if (currentFile == null) {
+      saveAs(data);
+    } else {
+      saveFile(currentFile, data);
+    }
+  }
+
+  /**
+   * Saves dashboard data, prompting the user to specify the file to save to.
+   *
+   * @param data the data to save
+   *
+   * @throws IOException if the data could not be saved
+   */
+  public void saveAs(DashboardData data) throws IOException {
+    FileChooser chooser = new FileChooser();
+    chooser.getExtensionFilters().setAll(
+        new FileChooser.ExtensionFilter("Shuffleboard Save File (.json)", "*.json"));
+    if (currentFile == null) {
+      chooser.setInitialDirectory(Storage.getStorageDir());
+      chooser.setInitialFileName("shuffleboard.json");
+    } else {
+      chooser.setInitialDirectory(currentFile.getAbsoluteFile().getParentFile());
+      chooser.setInitialFileName(currentFile.getName());
+    }
+
+    Optional.ofNullable(chooser.showSaveDialog(null))
+        .ifPresent(file -> saveFile(file, data));
+  }
+
+  private void saveFile(File file, DashboardData data) {
+    try {
+      Writer writer = Files.newWriter(file, Charset.forName("UTF-8"));
+
+      JsonBuilder.forSaveFile().toJson(data, writer);
+      writer.flush();
+    } catch (IOException | RuntimeException e) {
+      log.log(Level.WARNING, "Couldn't save", e);
+      return;
+    }
+
+    currentFile = file;
+    AppPreferences.getInstance().setSaveFile(currentFile);
+  }
+
+  /**
+   * Prompts the user to choose a save file to load, then returns the contents. Returns null if no file was selected.
+   *
+   * @return the data in the file the user selected, or null if the user cancelled the load
+   *
+   * @throws IOException if the user-selected file could not be read
+   */
+  public DashboardData load() throws IOException {
+    FileChooser chooser = new FileChooser();
+    chooser.setInitialDirectory(Storage.getStorageDir());
+    chooser.getExtensionFilters().setAll(
+        new FileChooser.ExtensionFilter("Shuffleboard Save File (.json)", "*.json"));
+
+    final File selected = chooser.showOpenDialog(null);
+
+    return load(selected);
+  }
+
+  /**
+   * Loads dashboard data from a specific file.
+   *
+   * @param file the file to aod data from
+   *
+   * @return the data stored in the file
+   *
+   * @throws IOException if the file could not be read
+   */
+  public DashboardData load(File file) throws IOException {
+    if (file == null) {
+      return null;
+    }
+    Reader reader = Files.newReader(file, Charset.forName("UTF-8"));
+
+    DashboardData dashboardData = JsonBuilder.forSaveFile().fromJson(reader, DashboardData.class);
+    if (dashboardData == null) {
+      throw new IOException("Save file could not be read: " + file);
+    }
+    currentFile = file;
+    AppPreferences.getInstance().setSaveFile(file);
+    return dashboardData;
+  }
+
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -147,7 +147,9 @@ public class Shuffleboard extends Application {
       File lastSaveFile = AppPreferences.getInstance().getSaveFile();
       if (AppPreferences.getInstance().isAutoLoadLastSaveFile() && lastSaveFile != null && lastSaveFile.exists()) {
         try {
-          mainWindowController.load(lastSaveFile);
+          // TODO inject?
+          DashboardData load = new SaveFileHandler().load(lastSaveFile);
+          mainWindowController.setDashboard(load);
         } catch (RuntimeException | IOException e) {
           logger.log(Level.WARNING, "Could not load the last save file", e);
           mainWindowController.newLayout();

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -28,18 +28,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.util.Locale;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.FileHandler;
-import java.util.logging.Handler;
 import java.util.logging.Level;
-import java.util.logging.LogManager;
-import java.util.logging.LogRecord;
 import java.util.logging.Logger;
-import java.util.logging.SimpleFormatter;
-import java.util.logging.StreamHandler;
 
 import javafx.application.Application;
 import javafx.application.Platform;
@@ -79,8 +70,7 @@ public class Shuffleboard extends Application {
       throw alreadyLockedException;
     }
 
-    // Set up the loggers
-    setupLoggers();
+    Loggers.setupLoggers();
 
     // Install SVG image loaders so SVGs can be used like any other image
     SvgImageLoaderFactory.install();
@@ -144,7 +134,7 @@ public class Shuffleboard extends Application {
   }
 
   @Override
-  public void start(Stage primaryStage) throws IOException {
+  public void start(Stage primaryStage) {
     // Set up the application thread to log exceptions instead of using printStackTrace()
     // Must be called in start() because init() is run on the main thread, not the FX application thread
     Thread.currentThread().setUncaughtExceptionHandler(Shuffleboard::uncaughtException);
@@ -211,45 +201,6 @@ public class Shuffleboard extends Application {
     logger.info("Running shutdown hooks");
     ShutdownHooks.runAllHooks();
     logger.info("Shutting down");
-  }
-
-  /**
-   * Sets up loggers to print to stdout (rather than stderr) and log to ~/Shuffleboard/shuffleboard.log
-   */
-  private void setupLoggers() throws IOException {
-    //Set up the global level logger. This handles IO for all loggers.
-    final Logger globalLogger = LogManager.getLogManager().getLogger("");
-
-    // Remove the default handlers that stream to System.err
-    for (Handler handler : globalLogger.getHandlers()) {
-      globalLogger.removeHandler(handler);
-    }
-
-    String time = DateTimeFormatter.ofPattern("YYYY-MM-dd-HH.mm.ss", Locale.getDefault()).format(LocalDateTime.now());
-    final Handler fileHandler = new FileHandler(Storage.getStorageDir() + "/shuffleboard." + time + ".log");
-
-    fileHandler.setLevel(Level.INFO);    // Only log INFO and above to disk
-    globalLogger.setLevel(Level.CONFIG); // Log CONFIG and higher
-
-    // We need to stream to System.out instead of System.err
-    final StreamHandler sh = new StreamHandler(System.out, new SimpleFormatter()) {
-      @Override
-      public synchronized void publish(final LogRecord record) { // NOPMD this is the same signature as the superclass
-        super.publish(record);
-        // For some reason this doesn't happen automatically.
-        // This will ensure we get all of the logs printed to the console immediately instead of at shutdown
-        flush();
-      }
-    };
-    sh.setLevel(Level.CONFIG); // Log CONFIG and higher to stdout
-
-    globalLogger.addHandler(sh);
-    globalLogger.addHandler(fileHandler);
-    fileHandler.setFormatter(new SimpleFormatter()); //log in text, not xml
-
-    globalLogger.config("Configuration done."); //Log that we are done setting up the logger
-    globalLogger.config("Shuffleboard app version: " + getVersion());
-    globalLogger.config("Running from " + getRunningLocation());
   }
 
   /**

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/TileDropHandler.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/TileDropHandler.java
@@ -1,0 +1,217 @@
+package edu.wpi.first.shuffleboard.app;
+
+import edu.wpi.first.shuffleboard.api.dnd.DataFormats;
+import edu.wpi.first.shuffleboard.api.sources.DataSource;
+import edu.wpi.first.shuffleboard.api.sources.SourceEntry;
+import edu.wpi.first.shuffleboard.api.util.TypeUtils;
+import edu.wpi.first.shuffleboard.api.widget.Component;
+import edu.wpi.first.shuffleboard.api.widget.Components;
+import edu.wpi.first.shuffleboard.api.widget.Layout;
+import edu.wpi.first.shuffleboard.api.widget.Sourced;
+import edu.wpi.first.shuffleboard.app.components.LayoutTile;
+import edu.wpi.first.shuffleboard.app.components.Tile;
+import edu.wpi.first.shuffleboard.app.components.WidgetPane;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import javafx.event.EventHandler;
+import javafx.geometry.Point2D;
+import javafx.scene.input.DragEvent;
+import javafx.scene.input.Dragboard;
+
+/**
+ * Helper class for handling dropping various types of data onto a tile.
+ */
+final class TileDropHandler implements EventHandler<DragEvent> {
+
+  private final WidgetPane pane;
+  private final Tile<?> tile;
+
+  TileDropHandler(WidgetPane pane, Tile<?> tile) {
+    this.pane = pane;
+    this.tile = tile;
+  }
+
+  @Override
+  public void handle(DragEvent event) {
+    final Dragboard dragboard = event.getDragboard();
+    final Point2D eventPos = screenPos(event); // NOPMD
+
+    // Dragging a source onto a tile
+    if (dragboard.hasContent(DataFormats.source) && tile.getContent() instanceof Sourced) {
+      SourceEntry entry = (SourceEntry) dragboard.getContent(DataFormats.source);
+      dropSourceOnTile(entry);
+      event.consume();
+
+      return;
+    }
+
+    // Moving a layout tile around
+    if (dragboard.hasContent(DataFormats.singleTile) && tile instanceof LayoutTile) {
+      DataFormats.TileData data = (DataFormats.TileData) event.getDragboard().getContent(DataFormats.singleTile);
+
+      if (tile.getId().equals(data.getId())) {
+        return;
+      }
+      dropSingleTileOntoLayout(data, eventPos);
+      event.consume();
+
+      return;
+    }
+
+    // Dropping multiple tiles onto a layout
+    if (dragboard.hasContent(DataFormats.multipleTiles) && tile instanceof LayoutTile) {
+      DataFormats.MultipleTileData data =
+          (DataFormats.MultipleTileData) event.getDragboard().getContent(DataFormats.multipleTiles);
+      if (data.getTileIds().contains(tile.getId())) {
+        return;
+      }
+      dropTilesOntoLayout(data, eventPos);
+      event.consume();
+    }
+
+    // Dragging a widget from the gallery
+    if (dragboard.hasContent(DataFormats.widgetType) && tile instanceof LayoutTile) {
+      String widgetType = (String) dragboard.getContent(DataFormats.widgetType);
+
+      dropGalleryWidgetOntoLayout(widgetType, eventPos);
+      event.consume();
+
+      return;
+    }
+
+    // Dragging a source from the sources tree
+    if (dragboard.hasContent(DataFormats.source) && tile instanceof LayoutTile) {
+      SourceEntry entry = (SourceEntry) dragboard.getContent(DataFormats.source);
+
+      dropSourceOntoLayout((Layout) tile.getContent(), entry, eventPos);
+      event.consume();
+
+      return;
+    }
+
+    // Dragging a component out of a layout
+    if (dragboard.hasContent(DataFormats.tilelessComponent)) {
+      UUID componentId = (UUID) dragboard.getContent(DataFormats.tilelessComponent);
+      dropComponentOutOfLayout(componentId, eventPos);
+      event.consume();
+
+      return;
+    }
+  }
+
+  /**
+   * Drops a component that was dragged out of a layout onto the tile, if it contains a layout.
+   *
+   * @param componentId the ID of the component being dragged
+   * @param screenPos   the screen coordinates where the component was dropped
+   */
+  private void dropComponentOutOfLayout(UUID componentId, Point2D screenPos) {
+    Optional<Component> component = Components.getDefault().getByUuid(componentId);
+    Optional<LayoutTile> parent = pane.getTiles().stream()
+        .flatMap(TypeUtils.castStream(LayoutTile.class))
+        .filter(t -> t.getContent().getChildren().contains(component.orElse(null)))
+        .findFirst();
+    component.ifPresent(c -> {
+      if (tile.getContent() instanceof Layout) {
+        parent.ifPresent(t -> t.getContent().removeChild(c));
+        add((Layout) tile.getContent(), c, screenPos);
+      } else {
+        ((Tile) tile).setContent(c);
+      }
+    });
+  }
+
+  /**
+   * Drops a data source onto the tile, if it contains a layout.
+   *
+   * @param layout    the layout contained in the tile
+   * @param entry     the source entry being dragged
+   * @param screenPos the screen coordinates where the source was dropped
+   */
+  private void dropSourceOntoLayout(Layout layout, SourceEntry entry, Point2D screenPos) {
+    DataSource<?> source = entry.get();
+    Components.getDefault().pickComponentNameFor(entry.get().getDataType())
+        .flatMap(name -> Components.getDefault().createWidget(name, source))
+        .ifPresent(w -> add(layout, w, screenPos));
+  }
+
+  /**
+   * Drops a widget from the gallery onto the tile, if it contains a layout.
+   *
+   * @param widgetType the type of the widget that is being dragged
+   * @param screenPos  the screen coordinates where the widget was dropped
+   */
+  private void dropGalleryWidgetOntoLayout(String widgetType, Point2D screenPos) {
+    Components.getDefault().createWidget(widgetType).ifPresent(widget -> {
+      add((Layout) tile.getContent(), widget, screenPos);
+    });
+  }
+
+  /**
+   * Drops multiple tiles onto the tile, if it contains a layout.
+   *
+   * @param data      the data for the tiles being dropped
+   * @param screenPos the screen coordinates where the tiles were dropped
+   */
+  private void dropTilesOntoLayout(DataFormats.MultipleTileData data, Point2D screenPos) {
+    data.getTileIds().stream()
+        .map(id -> pane.tileMatching(t -> t.getId().equals(id)))
+        .flatMap(TypeUtils.optionalStream())
+        .forEach(t -> {
+          Component content = pane.removeTile(t);
+          add((Layout) tile.getContent(), content, screenPos);
+        });
+  }
+
+  /**
+   * Drops a data source onto the tile, if it does <i>not</i> contain a layout.
+   *
+   * @param entry the source being dragged
+   */
+  private void dropSourceOnTile(SourceEntry entry) {
+    DataSource source = entry.get();
+    Sourced sourced = (Sourced) tile.getContent();
+    sourced.addSource(source);
+  }
+
+  /**
+   * Drops a single tile onto the tile, if it contains a layout.
+   *
+   * @param data      the data for the tile being dragged
+   * @param screenPos the screen coordinates where the tile was dropped
+   */
+  private void dropSingleTileOntoLayout(DataFormats.TileData data, Point2D screenPos) {
+    pane.tileMatching(t -> t.getId().equals(data.getId()))
+        .ifPresent(t -> {
+          Component content = pane.removeTile(t);
+          add((Layout) tile.getContent(), content, screenPos);
+        });
+  }
+
+  /**
+   * Stores the screen position of a drag event in a Point2D object for easy encapsulation.
+   *
+   * @param event the drag event
+   *
+   * @return a point containing the screen coordinates of the drag event
+   */
+  private static Point2D screenPos(DragEvent event) {
+    return new Point2D(event.getScreenX(), event.getScreenY());
+  }
+
+  /**
+   * Adds a component to a layout at the given screen coordinates. The screen position is translated to layout-local
+   * coordinates.
+   *
+   * @param layout    the layout to add to
+   * @param component the component to add
+   * @param screenPos the screen position of the drop
+   */
+  private static void add(Layout layout, Component component, Point2D screenPos) {
+    Point2D point = layout.getView().screenToLocal(screenPos);
+    layout.addChild(component, point.getX(), point.getY());
+  }
+
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/TileMover.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/TileMover.java
@@ -1,0 +1,140 @@
+package edu.wpi.first.shuffleboard.app;
+
+import edu.wpi.first.shuffleboard.api.util.TypeUtils;
+import edu.wpi.first.shuffleboard.api.widget.TileSize;
+import edu.wpi.first.shuffleboard.app.components.Tile;
+import edu.wpi.first.shuffleboard.app.components.TileLayout;
+import edu.wpi.first.shuffleboard.app.components.WidgetPane;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import javafx.scene.layout.GridPane;
+
+/**
+ * Helper class for shrinking and moving tiles around to attempt to keep them all in the bounds of their widget pane.
+ */
+public class TileMover {
+
+  private final WidgetPane pane;
+
+  public TileMover(WidgetPane pane) {
+    this.pane = pane;
+  }
+
+  public enum Direction {
+    HORIZONTAL {
+      @Override
+      int importantDim(TileSize size) {
+        return size.getWidth();
+      }
+    },
+    VERTICAL {
+      @Override
+      int importantDim(TileSize size) {
+        return size.getHeight();
+      }
+    };
+
+    abstract int importantDim(TileSize size);
+  }
+
+  private static TileSize shrinkLeft(TileSize size) {
+    return new TileSize(Math.max(1, size.getWidth() - 1), size.getHeight());
+  }
+
+  private static TileSize shrinkUp(TileSize size) {
+    return new TileSize(size.getWidth(), Math.max(1, size.getHeight() - 1));
+  }
+
+  private static TileLayout moveLeft(TileLayout layout) {
+    return layout.withCol(layout.origin.col - 1);
+  }
+
+  private static TileLayout moveUp(TileLayout layout) {
+    return layout.withRow(layout.origin.row - 1);
+  }
+
+  /**
+   * Collapses or moves the given tile in the given direction by up to <tt>count</tt> rows or columns. Tiles will be
+   * moved to fill empty spaces, then the rightmost/bottommost tiles will be shrunk until they reach their minimum size,
+   * which is content-dependent.
+   *
+   * @param tile      the tile to adjust
+   * @param count     the desired number of rows or columns by which the tile should be adjusted
+   * @param direction the direction in which the tile should be shrunk or moved.
+   */
+  public void collapseTile(Tile tile, int count, Direction direction) {
+    for (int i = 0; i < count; i++) {
+      Optional<Runnable> move;
+      if (direction == Direction.HORIZONTAL) {
+        move = collapseTile(tile, TileMover::moveLeft, TileMover::shrinkLeft, direction);
+      } else {
+        move = collapseTile(tile, TileMover::moveUp, TileMover::shrinkUp, direction);
+      }
+      if (move.isPresent()) {
+        move.get().run();
+      } else {
+        // Can't move any further, bail
+        break;
+      }
+    }
+  }
+
+  /**
+   * Creates a {@link Runnable} that will move or shrink the given tile, as well as moving or shrinking any tiles
+   * in the way of moving it. If the tile cannot be shrunk or moved, returns an empty Optional.
+   *
+   * @param tile                 the tile to move
+   * @param targetLayoutFunction the function to use to set the origin for the target location
+   * @param shrink               the function to use to shrink the tile
+   */
+  private Optional<Runnable> collapseTile(Tile tile,
+                                          Function<TileLayout, TileLayout> targetLayoutFunction,
+                                          Function<TileSize, TileSize> shrink,
+                                          Direction direction) {
+    boolean left = direction == Direction.HORIZONTAL;
+    TileSize minSize = pane.round(tile.getContent().getView().getMinWidth(),
+        tile.getContent().getView().getMinHeight());
+    TileLayout layout = pane.getTileLayout(tile);
+    TileLayout targetLayout = targetLayoutFunction.apply(layout);
+    int importantDim = direction.importantDim(layout.size);
+    int minDim = direction.importantDim(minSize);
+    if (!pane.isOverlapping(targetLayout, n -> n == tile) && !targetLayout.origin.equals(layout.origin)) { // NOPMD
+      // Great, we can move it
+      return Optional.of(() -> {
+        GridPane.setColumnIndex(tile, targetLayout.origin.col);
+        GridPane.setRowIndex(tile, targetLayout.origin.row);
+      });
+    } else if (importantDim > minDim) {
+      // Shrink the tile
+      return Optional.of(() -> tile.setSize(shrink.apply(tile.getSize())));
+    } else if (!targetLayout.origin.equals(layout.origin)) { // NOPMD
+      // Try to move or shrink other tiles in the way, then move this one into the free space
+      int lower = left ? layout.origin.row : layout.origin.col;
+      int upper = lower + importantDim;
+      List<Optional<Runnable>> runs = IntStream.range(lower, upper)
+          .mapToObj(i -> left ? pane.tileAt(targetLayout.origin.col, i) : pane.tileAt(i, targetLayout.origin.row))
+          .flatMap(TypeUtils.optionalStream()) // guaranteed to be at least one tile
+          .distinct() // need to make sure we have no repeats, or n-row tiles will get moved n times
+          .filter(t -> tile != t)
+          .map(t -> collapseTile(t, targetLayoutFunction, shrink, direction)) // recursion here
+          .collect(Collectors.toList());
+      if (runs.stream().allMatch(Optional::isPresent)) {
+        return Optional.of(() -> {
+          runs.forEach(r -> r.get().run());
+          GridPane.setColumnIndex(tile, targetLayout.origin.col);
+          GridPane.setRowIndex(tile, targetLayout.origin.row);
+        });
+      } else {
+        return Optional.empty();
+      }
+    } else {
+      return Optional.empty();
+    }
+  }
+
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/TileSelector.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/TileSelector.java
@@ -3,8 +3,10 @@ package edu.wpi.first.shuffleboard.app;
 import edu.wpi.first.shuffleboard.app.components.Tile;
 import edu.wpi.first.shuffleboard.app.components.WidgetPane;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.WeakHashMap;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableSet;
@@ -29,10 +31,16 @@ public final class TileSelector {
 
   private final ObservableSet<Tile<?>> selectedTiles = FXCollections.observableSet();
 
+  private static final Map<WidgetPane, TileSelector> selectors = new WeakHashMap<>();
+
+  public static TileSelector forPane(WidgetPane pane) {
+    return selectors.computeIfAbsent(pane, TileSelector::new);
+  }
+
   /**
    * Creates a new tile selector.
    */
-  public TileSelector(WidgetPane pane) {
+  private TileSelector(WidgetPane pane) {
     this.pane = Objects.requireNonNull(pane, "Pane cannot be null");
 
     pane.getChildren().add(0, dragHighlightContainer);

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
@@ -5,8 +5,6 @@ import edu.wpi.first.shuffleboard.api.components.ExtendedPropertySheet;
 import edu.wpi.first.shuffleboard.api.data.DataType;
 import edu.wpi.first.shuffleboard.api.dnd.DataFormats;
 import edu.wpi.first.shuffleboard.api.sources.DataSource;
-import edu.wpi.first.shuffleboard.api.sources.DummySource;
-import edu.wpi.first.shuffleboard.api.sources.SourceEntry;
 import edu.wpi.first.shuffleboard.api.sources.SourceTypes;
 import edu.wpi.first.shuffleboard.api.util.FxUtils;
 import edu.wpi.first.shuffleboard.api.util.GridPoint;
@@ -18,7 +16,6 @@ import edu.wpi.first.shuffleboard.api.widget.Components;
 import edu.wpi.first.shuffleboard.api.widget.Layout;
 import edu.wpi.first.shuffleboard.api.widget.LayoutType;
 import edu.wpi.first.shuffleboard.api.widget.Sourced;
-import edu.wpi.first.shuffleboard.api.widget.TileSize;
 import edu.wpi.first.shuffleboard.api.widget.Widget;
 import edu.wpi.first.shuffleboard.app.components.LayoutTile;
 import edu.wpi.first.shuffleboard.app.components.Tile;
@@ -34,26 +31,21 @@ import org.fxmisc.easybind.EasyBind;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.WeakHashMap;
 import java.util.function.Function;
-import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import javafx.beans.binding.Binding;
 import javafx.collections.ListChangeListener;
-import javafx.css.PseudoClass;
 import javafx.fxml.FXML;
 import javafx.geometry.Point2D;
 import javafx.scene.Node;
@@ -68,13 +60,11 @@ import javafx.scene.control.SeparatorMenuItem;
 import javafx.scene.image.WritableImage;
 import javafx.scene.input.ClipboardContent;
 import javafx.scene.input.ContextMenuEvent;
-import javafx.scene.input.DragEvent;
 import javafx.scene.input.Dragboard;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.input.TransferMode;
 import javafx.scene.layout.BorderPane;
-import javafx.scene.layout.GridPane;
 import javafx.scene.layout.Region;
 import javafx.scene.paint.Color;
 
@@ -89,246 +79,30 @@ public class WidgetPaneController {
   @FXML
   private WidgetPane pane;
 
-  private final Map<Node, Boolean> tilesAlreadySetup = new WeakHashMap<>();
-  private final Map<Tile<?>, WidgetPane.Highlight> highlights = new WeakHashMap<>();
-
-  /**
-   * Memoizes the size of a tile that would be added when dropping a source or widget. Memoizing prevents calling
-   * potentially expensive component initialization code every time the mouse moves when previewing the location of a
-   * tile for a source or widget.
-   */
-  private TileSize tilePreviewSize = null;
+  private final Set<Node> tilesAlreadySetup = Collections.newSetFromMap(new WeakHashMap<>());
 
   private TileSelector selector;
-  private final Predicate<Node> ignoreMultiTileDrag =
-      n -> selector.getSelectedTiles().contains(n)
-          || n instanceof WidgetPane.Highlight;
+  private TileMover tileMover;
 
   @FXML
   private void initialize() {
+    selector = TileSelector.forPane(pane);
+    tileMover = new TileMover(pane);
+
     pane.getTiles().addListener((ListChangeListener<Tile>) changes -> {
       while (changes.next()) {
         changes.getAddedSubList().forEach(this::setupTile);
       }
     });
 
-    selector = new TileSelector(pane);
-
     // Add a context menu for pane-related actions
     pane.setOnContextMenuRequested(this::createPaneContextMenu);
 
-    // Handle being dragged over
-    pane.setOnDragOver(event -> {
-      event.acceptTransferModes(TransferMode.COPY_OR_MOVE);
-      GridPoint point = pane.pointAt(event.getX(), event.getY());
-      Dragboard dragboard = event.getDragboard();
-      boolean isSingleTile = dragboard.hasContent(DataFormats.singleTile);
-      boolean isManyTiles = dragboard.hasContent(DataFormats.multipleTiles);
-      boolean isSource = dragboard.hasContent(DataFormats.source);
-      boolean isWidget = dragboard.hasContent(DataFormats.widgetType);
-      boolean isTilelessComponent = dragboard.hasContent(DataFormats.tilelessComponent);
-
-      // preview the location of the tile if one is being dragged
-      if (isSingleTile) {
-        if (isLayoutTile(point)) {
-          if (((DataFormats.TileData) dragboard.getContent(DataFormats.singleTile)).getId()
-              .equals(pane.tileAt(point)
-                  .map(Node::getId)
-                  .orElse(null))) {
-            // Dragged a layout tile onto itself
-            event.consume();
-          } else {
-            // Dragged a tile onto a layout, let the layout handle the drag and drop
-            pane.setHighlight(false);
-            return;
-          }
-        }
-        pane.setHighlight(true);
-        pane.setHighlightPoint(point);
-        DataFormats.TileData data = (DataFormats.TileData) dragboard.getContent(DataFormats.singleTile);
-        pane.tileMatching(tile -> tile.getId().equals(data.getId()))
-            .ifPresent(tile -> previewTile(tile, point.subtract(data.getLocalDragPoint())));
-      } else if (isManyTiles) {
-        if (isLayoutTile(point)) {
-          // Dragged onto a layout tile, let it handle the drag and drop
-          highlights.forEach((t, h) -> pane.removeHighlight(h));
-          highlights.clear();
-          pane.setHighlight(false);
-          return;
-        }
-        DataFormats.MultipleTileData data = (DataFormats.MultipleTileData)
-            dragboard.getContent(DataFormats.multipleTiles);
-        int dx = point.col - data.getInitialPoint().col;
-        int dy = point.row - data.getInitialPoint().row;
-        boolean inBounds = data.getTileIds().stream()
-            .map(id -> pane.tileMatching(tile -> tile.getId().equals(id)))
-            .flatMap(TypeUtils.optionalStream())
-            .map(pane::getTileLayout)
-            .allMatch(layout -> layout.origin.col + dx >= 0 && layout.origin.row + dy >= 0);
-
-        if (inBounds) {
-          data.getTileIds().stream()
-              .map(id -> pane.tileMatching(t -> t.getId().equals(id)))
-              .flatMap(TypeUtils.optionalStream())
-              .forEach(tile -> {
-                TileLayout layout = pane.getTileLayout(tile);
-                int newCol = layout.origin.col + dx;
-                int newRow = layout.origin.row + dy;
-                WidgetPane.Highlight highlight = highlights.computeIfAbsent(tile, t -> pane.addHighlight());
-                highlight.setLocation(new GridPoint(newCol, newRow));
-                highlight.setSize(layout.size);
-                highlights.put(tile, highlight);
-                boolean open = pane.isOpen(highlight.getLocation(), highlight.getSize(), ignoreMultiTileDrag);
-                highlight.pseudoClassStateChanged(PseudoClass.getPseudoClass("colliding"), !open);
-              });
-        } else {
-          highlights.values().forEach(pane::removeHighlight);
-          highlights.clear();
-        }
-      } else if (isSource) {
-        if (!pane.isOpen(point, new TileSize(1, 1), n -> false)) {
-          // Dragged a source onto a tile, let the tile handle the drag and drop
-          pane.setHighlight(false);
-          return;
-        }
-        SourceEntry entry = (SourceEntry) dragboard.getContent(DataFormats.source);
-        DataSource source = entry.get();
-        Optional<String> componentName = Components.getDefault().pickComponentNameFor(source.getDataType());
-        Optional<DataSource<?>> dummySource = DummySource.forTypes(source.getDataType());
-        if (componentName.isPresent() && dummySource.isPresent()) {
-          if (tilePreviewSize == null) {
-            Components.getDefault().createComponent(componentName.get(), dummySource.get())
-                .map(pane::sizeOfWidget)
-                .ifPresent(size -> tilePreviewSize = size);
-          }
-          if (tilePreviewSize == null) {
-            pane.setHighlight(false);
-          } else {
-            pane.setHighlight(true);
-            pane.setHighlightPoint(point);
-            pane.setHighlightSize(tilePreviewSize);
-          }
-        }
-      } else if (isWidget) {
-        if (!pane.isOpen(point, new TileSize(1, 1), n -> false)) {
-          // Dragged a widget onto a tile, can't drop
-          pane.setHighlight(false);
-          return;
-        }
-        String componentType = (String) dragboard.getContent(DataFormats.widgetType);
-        if (tilePreviewSize == null) {
-          Components.getDefault().createComponent(componentType)
-              .map(pane::sizeOfWidget)
-              .ifPresent(size -> tilePreviewSize = size);
-        }
-        if (tilePreviewSize == null) {
-          pane.setHighlight(false);
-        } else {
-          pane.setHighlight(true);
-          pane.setHighlightPoint(point);
-          pane.setHighlightSize(tilePreviewSize);
-        }
-      } else if (isTilelessComponent) {
-        if (!pane.isOpen(point, new TileSize(1, 1), n -> false)) {
-          // Dragged a widget onto a tile, can't drop
-          pane.setHighlight(false);
-          return;
-        }
-        Optional<Component> component = Components.getDefault()
-            .getByUuid((UUID) dragboard.getContent(DataFormats.tilelessComponent));
-        if (tilePreviewSize == null) {
-          component.map(pane::sizeOfWidget)
-              .ifPresent(size -> tilePreviewSize = size);
-        }
-        if (tilePreviewSize == null) {
-          pane.setHighlight(false);
-        } else {
-          pane.setHighlight(true);
-          pane.setHighlightPoint(point);
-          pane.setHighlightSize(tilePreviewSize);
-        }
-      }
-
-      event.consume();
-    });
-
-    // Clean up widget drags when the drag exits the pane
-    pane.setOnDragDone(__ -> cleanupWidgetDrag());
-    pane.setOnDragExited(__ -> cleanupWidgetDrag());
-
-    // Handle dropping stuff onto the pane
-    pane.setOnDragDropped(event -> {
-      Dragboard dragboard = event.getDragboard();
-      GridPoint point = pane.pointAt(event.getX(), event.getY());
-      // Dropping a source from the sources tree
-      if (dragboard.hasContent(DataFormats.source)) {
-        SourceEntry entry = (SourceEntry) dragboard.getContent(DataFormats.source);
-        dropSource(entry.get(), point);
-      }
-
-      // Dropping a tile onto the pane after moving it around
-      if (dragboard.hasContent(DataFormats.singleTile)) {
-        DataFormats.TileData data = (DataFormats.TileData) dragboard.getContent(DataFormats.singleTile);
-        pane.tileMatching(tile -> tile.getId().equals(data.getId()))
-            .ifPresent(tile -> moveTile(tile, point.subtract(data.getLocalDragPoint())));
-      }
-
-      // Dropping multiple tiles after moving them around
-      if (dragboard.hasContent(DataFormats.multipleTiles)) {
-        DataFormats.MultipleTileData data = (DataFormats.MultipleTileData)
-            dragboard.getContent(DataFormats.multipleTiles);
-        int dx = point.col - data.getInitialPoint().col;
-        int dy = point.row - data.getInitialPoint().row;
-        boolean allMovable = data.getTileIds().stream()
-            .map(id -> pane.tileMatching(tile -> tile.getId().equals(id)))
-            .flatMap(TypeUtils.optionalStream())
-            .map(pane::getTileLayout)
-            .allMatch(layout -> {
-              return layout.origin.getCol() + dx >= 0
-                  && layout.origin.getRow() + dy >= 0
-                  && pane.isOpen(layout.origin.add(dx, dy), layout.size, ignoreMultiTileDrag);
-            });
-        if (allMovable) {
-          pane.getTiles().stream()
-              .filter(tile -> data.getTileIds().contains(tile.getId()))
-              .forEach(tile -> pane.moveNode(tile, pane.getTileLayout(tile).origin.add(dx, dy)));
-        }
-        highlights.values().forEach(pane::removeHighlight);
-        highlights.clear();
-      }
-
-      // Dropping a widget from the gallery
-      if (dragboard.hasContent(DataFormats.widgetType)) {
-        String componentType = (String) dragboard.getContent(DataFormats.widgetType);
-        Components.getDefault().createComponent(componentType).ifPresent(c -> {
-          TileSize size = pane.sizeOfWidget(c);
-          if (pane.isOpen(point, size, _t -> false)) {
-            Tile<?> tile = pane.addComponentToTile(c);
-            moveTile(tile, point);
-          }
-        });
-      }
-
-      // Dragging a component out of a layout
-      if (dragboard.hasContent(DataFormats.tilelessComponent)) {
-        UUID componentId = (UUID) dragboard.getContent(DataFormats.tilelessComponent);
-        Optional<Component> component = Components.getDefault().getByUuid(componentId);
-        Optional<LayoutTile> parent = pane.getTiles().stream()
-            .flatMap(TypeUtils.castStream(LayoutTile.class))
-            .filter(t -> t.getContent().getChildren().contains(component.orElse(null)))
-            .findFirst();
-        component.ifPresent(c -> {
-          parent.ifPresent(t -> t.getContent().removeChild(c));
-          pane.addComponent(c, point);
-        });
-        event.consume();
-
-        return;
-      }
-      cleanupWidgetDrag();
-      tilePreviewSize = null;
-      event.consume();
-    });
+    WidgetPaneDragHandler paneDragHandler = new WidgetPaneDragHandler(pane);
+    pane.setOnDragOver(paneDragHandler);
+    pane.setOnDragDone(paneDragHandler);
+    pane.setOnDragExited(paneDragHandler);
+    pane.setOnDragDropped(paneDragHandler);
 
     pane.parentProperty().addListener((__, old, parent) -> {
       if (parent instanceof Region) {
@@ -360,7 +134,7 @@ public class WidgetPaneController {
               final TileLayout layout = pane.getTileLayout(tile);
               return layout.origin.col + layout.size.getWidth() > newCount;
             })
-            .forEach(tile -> collapseTile(tile, oldCount - newCount, true));
+            .forEach(tile -> tileMover.collapseTile(tile, oldCount - newCount, TileMover.Direction.HORIZONTAL));
       }
     });
     pane.numRowsProperty().addListener((__, oldCount, newCount) -> {
@@ -374,7 +148,7 @@ public class WidgetPaneController {
               final TileLayout layout = pane.getTileLayout(tile);
               return layout.origin.row + layout.size.getHeight() > newCount;
             })
-            .forEach(tile -> collapseTile(tile, oldCount - newCount, false));
+            .forEach(tile -> tileMover.collapseTile(tile, oldCount - newCount, TileMover.Direction.VERTICAL));
       }
     });
 
@@ -382,36 +156,46 @@ public class WidgetPaneController {
     SourceTypes.getDefault().allAvailableSourceUris().addListener((ListChangeListener<String>) c -> {
       while (c.next()) {
         if (c.wasAdded()) {
-          SourcedRestorer restorer = new SourcedRestorer();
           // Restore sources for top-level Sourced objects
-          pane.getTiles().stream()
-              .map(Tile::getContent)
-              .flatMap(TypeUtils.castStream(Sourced.class))
-              .forEach(sourced -> restorer.restoreSourcesFor(
-                  sourced,
-                  c.getAddedSubList(),
-                  WidgetPaneController::destroyedSourceCouldNotBeRestored));
-
-          // Restore sources for all nested Sourced objects
-          pane.getTiles().stream()
-              .map(Tile::getContent)
-              .flatMap(TypeUtils.castStream(ComponentContainer.class))
-              .flatMap(ComponentContainer::allComponents)
-              .flatMap(TypeUtils.castStream(Sourced.class))
-              .forEach(sourced -> restorer.restoreSourcesFor(
-                  sourced,
-                  c.getAddedSubList(),
-                  WidgetPaneController::destroyedSourceCouldNotBeRestored));
+          SourcedRestorer restorer = new SourcedRestorer();
+          List<? extends String> addedUris = c.getAddedSubList();
+          restoreSources(restorer, addedUris);
         } else if (c.wasRemoved()) {
+          List<? extends String> removedUris = c.getRemoved();
           // Replace all removed sources with DestroyedSources
-          pane.getTiles().stream()
-              .map(Tile::getContent)
-              .flatMap(Component::allComponents)
-              .flatMap(TypeUtils.castStream(Sourced.class))
-              .forEach(s -> replaceWithDestroyedSource(s, c.getRemoved()));
+          removeSources(removedUris);
         }
       }
     });
+  }
+
+  private void restoreSources(SourcedRestorer restorer, List<? extends String> addedUris) {
+    pane.getTiles().stream()
+        .map(Tile::getContent)
+        .flatMap(TypeUtils.castStream(Sourced.class))
+        .forEach(sourced -> restorer.restoreSourcesFor(
+            sourced,
+            addedUris,
+            WidgetPaneController::destroyedSourceCouldNotBeRestored));
+
+    // Restore sources for all nested Sourced objects
+    pane.getTiles().stream()
+        .map(Tile::getContent)
+        .flatMap(TypeUtils.castStream(ComponentContainer.class))
+        .flatMap(ComponentContainer::allComponents)
+        .flatMap(TypeUtils.castStream(Sourced.class))
+        .forEach(sourced -> restorer.restoreSourcesFor(
+            sourced,
+            addedUris,
+            WidgetPaneController::destroyedSourceCouldNotBeRestored));
+  }
+
+  private void removeSources(List<? extends String> removedUris) {
+    pane.getTiles().stream()
+        .map(Tile::getContent)
+        .flatMap(Component::allComponents)
+        .flatMap(TypeUtils.castStream(Sourced.class))
+        .forEach(s -> replaceWithDestroyedSource(s, removedUris));
   }
 
   private void createPaneContextMenu(ContextMenuEvent e) {
@@ -438,13 +222,6 @@ public class WidgetPaneController {
     contextMenu.show(pane.getScene().getWindow(), e.getScreenX(), e.getScreenY());
   }
 
-  private boolean isLayoutTile(GridPoint point) {
-    return pane.tileAt(point)
-        .map(Tile::getContent)
-        .filter(c -> c instanceof Layout)
-        .isPresent();
-  }
-
   /**
    * Replaces removed sources with destroyed versions that can be restored later if they become
    * available again.
@@ -464,13 +241,6 @@ public class WidgetPaneController {
         }
       }
     });
-  }
-
-  /**
-   * Cleans up from dragging widgets around in the tile pane.
-   */
-  private void cleanupWidgetDrag() {
-    pane.setHighlight(false);
   }
 
   private void dragMultipleTiles(Set<Tile<?>> tiles, GridPoint initialPoint) {
@@ -502,43 +272,47 @@ public class WidgetPaneController {
     dragboard.setContent(content);
   }
 
-  /**
-   * Drops a widget into this pane at the given point.
-   *
-   * @param tile  the tile for the widget to drop
-   * @param point the point in the tile pane to drop the widget at
-   */
-  private void moveTile(Tile tile, GridPoint point) {
-    TileSize size = tile.getSize();
-    if (pane.isOpen(point, size, n -> n == tile)) {
-      pane.moveNode(tile, point);
+  private void startTileDrag(Tile<?> tile, MouseEvent event) {
+    if (TileDragResizer.makeResizable(pane, tile).isDragging()) {
+      // don't drag the widget while it's being resized
+      selector.deselectAll();
+      return;
     }
+    if (selector.isSelected(tile) && selector.getSelectedTiles().size() > 1) {
+      // Drag point is a point in the pane
+      Point2D localPoint = pane.screenToLocal(event.getScreenX(), event.getScreenY());
+      GridPoint dragPoint = pane.pointAt(localPoint.getX(), localPoint.getY());
+      dragMultipleTiles(selector.getSelectedTiles(), dragPoint);
+    } else {
+      selector.deselectAll();
+      // Drag point is a point on the tile
+      GridPoint dragPoint = new GridPoint(pane.roundWidthToNearestTile(event.getX()) - 1,
+          pane.roundHeightToNearestTile(event.getY()) - 1);
+      dragSingleTile(tile, dragPoint);
+    }
+    event.consume();
   }
 
-  /**
-   * Drops a data source into the tile pane at the given point. The source will be displayed
-   * with the default widget for its data type. If there is no default widget for that data,
-   * then no widget will be created.
-   *
-   * @param source the source to drop
-   * @param point  the point to place the widget for the source
-   */
-  private void dropSource(DataSource<?> source, GridPoint point) {
-    Components.getDefault().pickComponentNameFor(source.getDataType())
-        .flatMap(name -> Components.getDefault().createComponent(name, source))
-        .filter(widget -> pane.isOpen(point, pane.sizeOfWidget(widget), n -> widget == n))
-        .map(pane::addComponentToTile)
-        .ifPresent(tile -> pane.moveNode(tile, point));
+  private void mousePressOnTile(Tile<?> tile, MouseEvent e) {
+    if (e.isControlDown() && e.isPrimaryButtonDown()) {
+      if (selector.areTilesSelected()) {
+        selector.toggleSelect(tile);
+      } else {
+        selector.select(tile);
+      }
+    } else if (!selector.isSelected(tile)) {
+      selector.deselectAll();
+    }
   }
 
   /**
    * Sets up a tile with a context menu and lets it be dragged around.
    */
   private void setupTile(Tile tile) {
-    if (tilesAlreadySetup.get(tile) != null) {
+    if (tilesAlreadySetup.contains(tile)) {
       return;
     }
-    tilesAlreadySetup.put(tile, true);
+    tilesAlreadySetup.add(tile);
 
     tile.setOnContextMenuRequested(event -> {
       ContextMenu contextMenu = createContextMenu(event);
@@ -590,137 +364,11 @@ public class WidgetPaneController {
       return widgetPaneActions;
     });
 
-    TileDragResizer resizer = TileDragResizer.makeResizable(pane, tile);
+    tile.setOnDragDetected(event -> startTileDrag(tile, event));
 
-    tile.setOnDragDetected(event -> {
-      if (resizer.isDragging()) {
-        // don't drag the widget while it's being resized
-        selector.deselectAll();
-        return;
-      }
-      if (selector.isSelected(tile) && selector.getSelectedTiles().size() > 1) {
-        // Drag point is a point in the pane
-        Point2D localPoint = pane.screenToLocal(event.getScreenX(), event.getScreenY());
-        GridPoint dragPoint = pane.pointAt(localPoint.getX(), localPoint.getY());
-        dragMultipleTiles(selector.getSelectedTiles(), dragPoint);
-      } else {
-        selector.deselectAll();
-        // Drag point is a point on the tile
-        GridPoint dragPoint = new GridPoint(pane.roundWidthToNearestTile(event.getX()) - 1,
-            pane.roundHeightToNearestTile(event.getY()) - 1);
-        dragSingleTile(tile, dragPoint);
-      }
-      event.consume();
-    });
+    tile.addEventHandler(MouseEvent.MOUSE_PRESSED, e -> mousePressOnTile(tile, e));
 
-    tile.addEventHandler(MouseEvent.MOUSE_PRESSED, e -> {
-      if (e.isControlDown() && e.isPrimaryButtonDown()) {
-        if (selector.areTilesSelected()) {
-          selector.toggleSelect(tile);
-        } else {
-          selector.select(tile);
-        }
-      } else if (!selector.isSelected(tile)) {
-        selector.deselectAll();
-      }
-    });
-
-    tile.setOnDragDropped(event -> {
-      Dragboard dragboard = event.getDragboard();
-      // Dragging a source onto a tile
-      if (dragboard.hasContent(DataFormats.source) && tile.getContent() instanceof Sourced) {
-        SourceEntry entry = (SourceEntry) dragboard.getContent(DataFormats.source);
-        DataSource source = entry.get();
-        Sourced sourced = (Sourced) tile.getContent();
-        sourced.addSource(source);
-        event.consume();
-
-        return;
-      }
-
-      // Moving a layout tile around
-      if (dragboard.hasContent(DataFormats.singleTile) && tile instanceof LayoutTile) {
-        DataFormats.TileData data = (DataFormats.TileData) event.getDragboard().getContent(DataFormats.singleTile);
-
-        if (tile.getId().equals(data.getId())) {
-          return;
-        }
-        pane.tileMatching(t -> t.getId().equals(data.getId()))
-            .ifPresent(t -> {
-              Component content = pane.removeTile(t);
-              add((Layout) tile.getContent(), content, event);
-            });
-        event.consume();
-
-        return;
-      }
-
-      // Dropping multiple tiles onto a layout
-      if (dragboard.hasContent(DataFormats.multipleTiles) && tile instanceof LayoutTile) {
-        DataFormats.MultipleTileData data =
-            (DataFormats.MultipleTileData) event.getDragboard().getContent(DataFormats.multipleTiles);
-        if (data.getTileIds().contains(tile.getId())) {
-          return;
-        }
-        data.getTileIds().stream()
-            .map(id -> pane.tileMatching(t -> t.getId().equals(id)))
-            .flatMap(TypeUtils.optionalStream())
-            .forEach(t -> {
-              Component content = pane.removeTile(t);
-              add((Layout) tile.getContent(), content, event);
-            });
-        event.consume();
-      }
-
-      // Dragging a widget from the gallery
-      if (dragboard.hasContent(DataFormats.widgetType) && tile instanceof LayoutTile) {
-        String widgetType = (String) dragboard.getContent(DataFormats.widgetType);
-
-        Components.getDefault().createWidget(widgetType).ifPresent(widget -> {
-          add((Layout) tile.getContent(), widget, event);
-        });
-        event.consume();
-
-        return;
-      }
-
-      // Dragging a source from the sources tree
-      if (dragboard.hasContent(DataFormats.source) && tile instanceof LayoutTile) {
-        SourceEntry entry = (SourceEntry) dragboard.getContent(DataFormats.source);
-
-        Layout container = ((LayoutTile) tile).getContent();
-        DataSource<?> source = entry.get();
-        Components.getDefault().componentNamesForSource(entry.get())
-            .stream()
-            .findAny()
-            .flatMap(name -> Components.getDefault().createWidget(name, source))
-            .ifPresent(w -> add(container, w, event));
-        event.consume();
-
-        return;
-      }
-
-      // Dragging a component out of a layout
-      if (dragboard.hasContent(DataFormats.tilelessComponent)) {
-        UUID componentId = (UUID) dragboard.getContent(DataFormats.tilelessComponent);
-        Optional<Component> component = Components.getDefault().getByUuid(componentId);
-        Optional<LayoutTile> parent = pane.getTiles().stream()
-            .flatMap(TypeUtils.castStream(LayoutTile.class))
-            .filter(t -> t.getContent().getChildren().contains(component.orElse(null)))
-            .findFirst();
-        component.ifPresent(c -> {
-          if (tile instanceof LayoutTile) {
-            parent.ifPresent(t -> t.getContent().removeChild(c));
-            add(((LayoutTile) tile).getContent(), c, event);
-          } else {
-            tile.setContent(c);
-          }
-        });
-        event.consume();
-
-        return;
-      }
-    });
+    tile.setOnDragDropped(new TileDropHandler(pane, tile));
   }
 
   private void removeTile(Tile<?> tile) {
@@ -730,11 +378,6 @@ public class WidgetPaneController {
           .flatMap(TypeUtils.castStream(Sourced.class))
           .forEach(Sourced::removeAllSources);
     }
-  }
-
-  private static void add(Layout layout, Component component, DragEvent event) {
-    Point2D point = layout.getView().screenToLocal(event.getScreenX(), event.getScreenY());
-    layout.addChild(component, point.getX(), point.getY());
   }
 
   private void unwrapLayout(Tile<? extends Layout> tile) {
@@ -751,18 +394,6 @@ public class WidgetPaneController {
       // No point in keeping the empty layout around, remove it
       pane.removeTile(tile);
     }
-  }
-
-  /**
-   * Previews the widget for the given tile.
-   *
-   * @param tile  the tile for the widget to preview
-   * @param point the point to preview the widget at
-   */
-  private void previewTile(Tile tile, GridPoint point) {
-    TileSize size = tile.getSize();
-    pane.setHighlightPoint(point);
-    pane.setHighlightSize(size);
   }
 
   /**
@@ -858,12 +489,27 @@ public class WidgetPaneController {
         .collect(toSet());
   }
 
+  private void changeAllWidgetTiles(String newWidgetName) {
+    selector.getSelectedTiles()
+        .stream()
+        .map(t -> (WidgetTile) t)
+        .forEach(t -> {
+          Components.getDefault()
+              .createWidget(newWidgetName, t.getContent().getSources())
+              .ifPresent(newWidget -> {
+                newWidget.setTitle(t.getContent().getTitle());
+                t.setContent(newWidget);
+              });
+        });
+    selector.deselectAll();
+  }
+
   /**
    * Creates all the menus needed for changing a widget to a different type.
    *
    * @param tile the tile for the widget to create the change menus for
    */
-  private ActionList createChangeMenusForWidget(WidgetTile tile) {
+  private ActionList createChangeMenusForWidget(Tile<Widget> tile) {
     Widget widget = tile.getContent();
     ActionList list = ActionList.withName("Show as...");
 
@@ -887,20 +533,7 @@ public class WidgetPaneController {
             .forEach(name -> list.addAction(
                 name,
                 name.equals(widget.getName()) ? new Label("✓") : null,
-                () -> {
-                  selector.getSelectedTiles()
-                      .stream()
-                      .map(t -> (WidgetTile) t)
-                      .forEach(t -> {
-                        Components.getDefault()
-                            .createWidget(name, t.getContent().getSources())
-                            .ifPresent(newWidget -> {
-                              newWidget.setTitle(t.getContent().getTitle());
-                              t.setContent(newWidget);
-                            });
-                      });
-                  selector.deselectAll();
-                }
+                () -> changeAllWidgetTiles(name)
             ));
         return list;
       } else {
@@ -949,79 +582,6 @@ public class WidgetPaneController {
     dialog.getDialogPane().getButtonTypes().addAll(ButtonType.CLOSE);
 
     dialog.showAndWait();
-  }
-
-  private void collapseTile(Tile tile, int count, boolean left) {
-    Function<TileLayout, TileLayout> moveLeft = l -> l.withCol(l.origin.col - 1);
-    Function<TileLayout, TileLayout> moveUp = l -> l.withRow(l.origin.row - 1);
-    Function<TileSize, TileSize> shrinkLeft = s -> new TileSize(Math.max(1, s.getWidth() - 1), s.getHeight());
-    Function<TileSize, TileSize> shrinkUp = s -> new TileSize(s.getWidth(), Math.max(1, s.getHeight() - 1));
-    for (int i = 0; i < count; i++) {
-      Optional<Runnable> move;
-      if (left) {
-        move = collapseTile(tile, moveLeft, shrinkLeft, true);
-      } else {
-        move = collapseTile(tile, moveUp, shrinkUp, false);
-      }
-      if (move.isPresent()) {
-        move.get().run();
-      } else {
-        // Can't move any further, bail
-        break;
-      }
-    }
-  }
-
-  /**
-   * Creates a {@link Runnable} that will move or shrink the given tile, as well as moving or shrinking any tiles
-   * in the way of moving it. If the tile cannot be shrunk or moved, returns an empty Optional.
-   *
-   * @param tile                 the tile to move
-   * @param targetLayoutFunction the function to use to set the origin for the target location
-   * @param shrink               the function to use to shrink the tile
-   */
-  private Optional<Runnable> collapseTile(Tile tile,
-                                          Function<TileLayout, TileLayout> targetLayoutFunction,
-                                          Function<TileSize, TileSize> shrink,
-                                          boolean left) {
-    TileSize minSize = pane.round(tile.getContent().getView().getMinWidth(),
-        tile.getContent().getView().getMinHeight());
-    TileLayout layout = pane.getTileLayout(tile);
-    TileLayout targetLayout = targetLayoutFunction.apply(layout);
-    int importantDim = left ? layout.size.getWidth() : layout.size.getHeight();
-    int minDim = left ? minSize.getWidth() : minSize.getHeight();
-    if (!pane.isOverlapping(targetLayout, n -> n == tile) && !targetLayout.origin.equals(layout.origin)) { // NOPMD
-      // Great, we can move it
-      return Optional.of(() -> {
-        GridPane.setColumnIndex(tile, targetLayout.origin.col);
-        GridPane.setRowIndex(tile, targetLayout.origin.row);
-      });
-    } else if (importantDim > minDim) {
-      // Shrink the tile
-      return Optional.of(() -> tile.setSize(shrink.apply(tile.getSize())));
-    } else if (!targetLayout.origin.equals(layout.origin)) { // NOPMD
-      // Try to move or shrink other tiles in the way, then move this one into the free space
-      int lower = left ? layout.origin.row : layout.origin.col;
-      int upper = lower + importantDim;
-      List<Optional<Runnable>> runs = IntStream.range(lower, upper)
-          .mapToObj(i -> left ? pane.tileAt(targetLayout.origin.col, i) : pane.tileAt(i, targetLayout.origin.row))
-          .flatMap(TypeUtils.optionalStream()) // guaranteed to be at least one tile
-          .distinct() // need to make sure we have no repeats, or n-row tiles will get moved n times
-          .filter(t -> tile != t)
-          .map(t -> collapseTile(t, targetLayoutFunction, shrink, left)) // recursion here
-          .collect(Collectors.toList());
-      if (runs.stream().allMatch(Optional::isPresent)) {
-        return Optional.of(() -> {
-          runs.forEach(r -> r.get().run());
-          GridPane.setColumnIndex(tile, targetLayout.origin.col);
-          GridPane.setRowIndex(tile, targetLayout.origin.row);
-        });
-      } else {
-        return Optional.empty();
-      }
-    } else {
-      return Optional.empty();
-    }
   }
 
   private static void destroyedSourceCouldNotBeRestored(DestroyedSource source, Throwable error) {

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneDragHandler.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneDragHandler.java
@@ -1,0 +1,381 @@
+package edu.wpi.first.shuffleboard.app;
+
+import edu.wpi.first.shuffleboard.api.dnd.DataFormats;
+import edu.wpi.first.shuffleboard.api.sources.DataSource;
+import edu.wpi.first.shuffleboard.api.sources.DummySource;
+import edu.wpi.first.shuffleboard.api.sources.SourceEntry;
+import edu.wpi.first.shuffleboard.api.util.GridPoint;
+import edu.wpi.first.shuffleboard.api.util.TypeUtils;
+import edu.wpi.first.shuffleboard.api.widget.Component;
+import edu.wpi.first.shuffleboard.api.widget.Components;
+import edu.wpi.first.shuffleboard.api.widget.Layout;
+import edu.wpi.first.shuffleboard.api.widget.TileSize;
+import edu.wpi.first.shuffleboard.app.components.LayoutTile;
+import edu.wpi.first.shuffleboard.app.components.Tile;
+import edu.wpi.first.shuffleboard.app.components.TileLayout;
+import edu.wpi.first.shuffleboard.app.components.WidgetPane;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.WeakHashMap;
+
+import javafx.css.PseudoClass;
+import javafx.event.EventHandler;
+import javafx.event.EventType;
+import javafx.scene.Node;
+import javafx.scene.input.DragEvent;
+import javafx.scene.input.Dragboard;
+import javafx.scene.input.TransferMode;
+
+/**
+ * Helper class for handling drag events on a widget pane.
+ */
+@SuppressWarnings("PMD.GodClass") // seriously?
+final class WidgetPaneDragHandler implements EventHandler<DragEvent> {
+
+  private final WidgetPane pane;
+  private final TileSelector selector;
+
+  /**
+   * Memoizes the size of a tile that would be added when dropping a source or widget. Memoizing prevents calling
+   * potentially expensive component initialization code every time the mouse moves when previewing the location of a
+   * tile for a source or widget.
+   */
+  private TileSize tilePreviewSize = null;
+
+  private final Map<Tile<?>, WidgetPane.Highlight> highlights = new WeakHashMap<>();
+
+  WidgetPaneDragHandler(WidgetPane pane) {
+    this.pane = pane;
+    this.selector = TileSelector.forPane(pane);
+  }
+
+  private boolean isLayoutTile(GridPoint point) {
+    return pane.tileAt(point)
+        .map(Tile::getContent)
+        .filter(c -> c instanceof Layout)
+        .isPresent();
+  }
+
+  @Override
+  public void handle(DragEvent event) {
+    EventType<DragEvent> eventType = event.getEventType();
+    if (eventType == DragEvent.DRAG_OVER) {
+      handleDragOver(event);
+    } else if (eventType == DragEvent.DRAG_DROPPED) {
+      handleDragDropped(event);
+    } else if (eventType == DragEvent.DRAG_DONE || eventType == DragEvent.DRAG_EXITED) {
+      cleanupWidgetDrag();
+    }
+  }
+
+  /**
+   * Handles a DRAG_OVER event on the widget pane.
+   *
+   * @param event the drag event.
+   */
+  private void handleDragOver(DragEvent event) {
+    event.acceptTransferModes(TransferMode.COPY_OR_MOVE);
+    GridPoint point = pane.pointAt(event.getX(), event.getY());
+    Dragboard dragboard = event.getDragboard();
+
+    // Preview the location of a single tile being dragged
+    if (dragboard.hasContent(DataFormats.singleTile) && !previewSingleTile(event, point, dragboard)) {
+      return;
+    }
+
+    // Preview the locations of multiple tiles being dragged
+    if (dragboard.hasContent(DataFormats.multipleTiles) && !previewManyTiles(point, dragboard)) {
+      return;
+    }
+    if (dragboard.hasContent(DataFormats.source) && !previewSource(point, dragboard)) {
+      return;
+    }
+    if (dragboard.hasContent(DataFormats.widgetType) && !previewGalleryWidget(point, dragboard)) {
+      return;
+    }
+    if (dragboard.hasContent(DataFormats.tilelessComponent) && !previewTilelessComponent(point, dragboard)) {
+      return;
+    }
+
+    event.consume();
+  }
+
+  private boolean previewTilelessComponent(GridPoint point, Dragboard dragboard) {
+    if (!pane.isOpen(point, new TileSize(1, 1), n -> false)) {
+      // Dragged a widget onto a tile, can't drop
+      pane.setHighlight(false);
+      return false;
+    }
+    Optional<Component> component = Components.getDefault()
+        .getByUuid((UUID) dragboard.getContent(DataFormats.tilelessComponent));
+    if (tilePreviewSize == null) {
+      component.map(pane::sizeOfWidget)
+          .ifPresent(size -> tilePreviewSize = size);
+    }
+    highlightPoint(point);
+    return true;
+  }
+
+  private boolean previewGalleryWidget(GridPoint point, Dragboard dragboard) {
+    if (!pane.isOpen(point, new TileSize(1, 1), n -> false)) {
+      // Dragged a widget onto a tile, can't drop
+      pane.setHighlight(false);
+      return false;
+    }
+    String componentType = (String) dragboard.getContent(DataFormats.widgetType);
+    if (tilePreviewSize == null) {
+      Components.getDefault().createComponent(componentType)
+          .map(pane::sizeOfWidget)
+          .ifPresent(size -> tilePreviewSize = size);
+    }
+    highlightPoint(point);
+    return true;
+  }
+
+  private boolean previewSource(GridPoint point, Dragboard dragboard) {
+    if (!pane.isOpen(point, new TileSize(1, 1), n -> false)) {
+      // Dragged a source onto a tile, let the tile handle the drag and drop
+      pane.setHighlight(false);
+      return false;
+    }
+    SourceEntry entry = (SourceEntry) dragboard.getContent(DataFormats.source);
+    DataSource source = entry.get();
+    Optional<String> componentName = Components.getDefault().pickComponentNameFor(source.getDataType());
+    Optional<DataSource<?>> dummySource = DummySource.forTypes(source.getDataType());
+    if (componentName.isPresent() && dummySource.isPresent()) {
+      if (tilePreviewSize == null) {
+        Components.getDefault().createComponent(componentName.get(), dummySource.get())
+            .map(pane::sizeOfWidget)
+            .ifPresent(size -> tilePreviewSize = size);
+      }
+      highlightPoint(point);
+    }
+    return true;
+  }
+
+  private boolean previewManyTiles(GridPoint point, Dragboard dragboard) {
+    if (isLayoutTile(point)) {
+      // Dragged onto a layout tile, let it handle the drag and drop
+      highlights.forEach((t, h) -> pane.removeHighlight(h));
+      highlights.clear();
+      pane.setHighlight(false);
+      return false;
+    }
+    DataFormats.MultipleTileData data = (DataFormats.MultipleTileData)
+        dragboard.getContent(DataFormats.multipleTiles);
+    int dx = point.col - data.getInitialPoint().col;
+    int dy = point.row - data.getInitialPoint().row;
+    boolean inBounds = data.getTileIds().stream()
+        .map(id -> pane.tileMatching(tile -> tile.getId().equals(id)))
+        .flatMap(TypeUtils.optionalStream())
+        .map(pane::getTileLayout)
+        .allMatch(layout -> layout.origin.col + dx >= 0 && layout.origin.row + dy >= 0);
+
+    if (inBounds) {
+      data.getTileIds().stream()
+          .map(id -> pane.tileMatching(t -> t.getId().equals(id)))
+          .flatMap(TypeUtils.optionalStream())
+          .map(tile -> createHighlight(tile, dx, dy))
+          .forEach(highlight -> {
+            boolean open = pane.isOpen(highlight.getLocation(), highlight.getSize(), this::ignoreIfDragArtifact);
+            highlight.pseudoClassStateChanged(PseudoClass.getPseudoClass("colliding"), !open);
+          });
+    } else {
+      highlights.values().forEach(pane::removeHighlight);
+      highlights.clear();
+    }
+    return true;
+  }
+
+  private WidgetPane.Highlight createHighlight(Tile<?> tile, int dx, int dy) {
+    TileLayout layout = pane.getTileLayout(tile);
+    int newCol = layout.origin.getCol() + dx;
+    int newRow = layout.origin.getRow() + dy;
+    WidgetPane.Highlight highlight = highlights.computeIfAbsent(tile, t -> pane.addHighlight());
+    highlight.setLocation(new GridPoint(newCol, newRow));
+    highlight.setSize(layout.size);
+    highlights.put(tile, highlight);
+    return highlight;
+  }
+
+  private boolean previewSingleTile(DragEvent event, GridPoint point, Dragboard dragboard) {
+    if (isLayoutTile(point)) {
+      if (((DataFormats.TileData) dragboard.getContent(DataFormats.singleTile)).getId()
+          .equals(pane.tileAt(point)
+              .map(Node::getId)
+              .orElse(null))) {
+        // Dragged a layout tile onto itself
+        event.consume();
+      } else {
+        // Dragged a tile onto a layout, let the layout handle the drag and drop
+        pane.setHighlight(false);
+        return false;
+      }
+    }
+    pane.setHighlight(true);
+    pane.setHighlightPoint(point);
+    DataFormats.TileData data = (DataFormats.TileData) dragboard.getContent(DataFormats.singleTile);
+    pane.tileMatching(tile -> tile.getId().equals(data.getId()))
+        .ifPresent(tile -> previewTile(tile, point.subtract(data.getLocalDragPoint())));
+    return true;
+  }
+
+  private void highlightPoint(GridPoint point) {
+    if (tilePreviewSize == null) {
+      pane.setHighlight(false);
+    } else {
+      pane.setHighlight(true);
+      pane.setHighlightPoint(point);
+      pane.setHighlightSize(tilePreviewSize);
+    }
+  }
+
+  /**
+   * Previews a tile at a specific point in the pane.
+   *
+   * @param tile  the tile to preview
+   * @param point the point to preview the tile at
+   */
+  private void previewTile(Tile<?> tile, GridPoint point) {
+    TileSize size = tile.getSize();
+    pane.setHighlightPoint(point);
+    pane.setHighlightSize(size);
+  }
+
+  /**
+   * Handles a DRAG_DROPPED event on the widget pane.
+   *
+   * @param event the drag event
+   */
+  private void handleDragDropped(DragEvent event) {
+    Dragboard dragboard = event.getDragboard();
+    GridPoint point = pane.pointAt(event.getX(), event.getY());
+
+    // Dropping a source from the sources tree
+    if (dragboard.hasContent(DataFormats.source)) {
+      SourceEntry entry = (SourceEntry) dragboard.getContent(DataFormats.source);
+      dropSource(entry.get(), point);
+    }
+
+    // Dropping a tile onto the pane after moving it around
+    if (dragboard.hasContent(DataFormats.singleTile)) {
+      dropSingleTile((DataFormats.TileData) dragboard.getContent(DataFormats.singleTile), point);
+    }
+
+    // Dropping multiple tiles after moving them around
+    if (dragboard.hasContent(DataFormats.multipleTiles)) {
+      dropManyTiles((DataFormats.MultipleTileData) dragboard.getContent(DataFormats.multipleTiles), point);
+    }
+
+    // Dropping a widget from the gallery
+    if (dragboard.hasContent(DataFormats.widgetType)) {
+      dropGalleryWidget((String) dragboard.getContent(DataFormats.widgetType), point);
+    }
+
+    // Dragging a component out of a layout
+    if (dragboard.hasContent(DataFormats.tilelessComponent)) {
+      dropTilelessComponent((UUID) dragboard.getContent(DataFormats.tilelessComponent), point);
+    }
+    cleanupWidgetDrag();
+    tilePreviewSize = null;
+    event.consume();
+  }
+
+  /**
+   * Drops a data source into the tile pane at the given point. The source will be displayed
+   * with the default widget for its data type. If there is no default widget for that data,
+   * then no widget will be created.
+   *
+   * @param source the source to drop
+   * @param point  the point to place the widget for the source
+   */
+  private void dropSource(DataSource<?> source, GridPoint point) {
+    Components.getDefault().pickComponentNameFor(source.getDataType())
+        .flatMap(name -> Components.getDefault().createComponent(name, source))
+        .filter(widget -> pane.isOpen(point, pane.sizeOfWidget(widget), n -> widget == n))
+        .map(pane::addComponentToTile)
+        .ifPresent(tile -> pane.moveNode(tile, point));
+  }
+
+  /**
+   * Drops a single tile onto the tile pane at the given point.
+   *
+   * @param data  the tile data for the tile being dropped
+   * @param point the point in the pane where the tile is being dropped
+   */
+  private void dropSingleTile(DataFormats.TileData data, GridPoint point) {
+    pane.tileMatching(tile -> tile.getId().equals(data.getId()))
+        .ifPresent(tile -> moveTile(tile, point.subtract(data.getLocalDragPoint())));
+  }
+
+  private void dropManyTiles(DataFormats.MultipleTileData data, GridPoint point) {
+    int dx = point.col - data.getInitialPoint().getCol();
+    int dy = point.row - data.getInitialPoint().getRow();
+    boolean allMovable = data.getTileIds().stream()
+        .map(id -> pane.tileMatching(tile -> tile.getId().equals(id)))
+        .flatMap(TypeUtils.optionalStream())
+        .map(pane::getTileLayout)
+        .allMatch(layout -> canMove(layout, dx, dy));
+    if (allMovable) {
+      pane.getTiles().stream()
+          .filter(tile -> data.getTileIds().contains(tile.getId()))
+          .forEach(tile -> pane.moveNode(tile, pane.getTileLayout(tile).origin.add(dx, dy)));
+    }
+    highlights.values().forEach(pane::removeHighlight);
+    highlights.clear();
+  }
+
+  private boolean canMove(TileLayout layout, int dx, int dy) {
+    GridPoint origin = layout.origin;
+    TileSize size = layout.size;
+    return origin.getCol() + dx >= 0
+        && origin.getRow() + dy >= 0
+        && pane.isOpen(origin.add(dx, dy), size, this::ignoreIfDragArtifact);
+  }
+
+  private void dropGalleryWidget(String componentType, GridPoint point) {
+    Components.getDefault().createComponent(componentType).ifPresent(c -> {
+      TileSize size = pane.sizeOfWidget(c);
+      if (pane.isOpen(point, size, _t -> false)) {
+        Tile<?> tile = pane.addComponentToTile(c);
+        moveTile(tile, point);
+      }
+    });
+  }
+
+  private void dropTilelessComponent(UUID componentId, GridPoint point) {
+    Optional<Component> component = Components.getDefault().getByUuid(componentId);
+    Optional<LayoutTile> parent = pane.getTiles().stream()
+        .flatMap(TypeUtils.castStream(LayoutTile.class))
+        .filter(t -> t.getContent().getChildren().contains(component.orElse(null)))
+        .findFirst();
+    component.ifPresent(c -> {
+      parent.ifPresent(t -> t.getContent().removeChild(c));
+      pane.addComponent(c, point);
+    });
+  }
+
+  /**
+   * Drops a widget into this pane at the given point.
+   *
+   * @param tile  the tile for the widget to drop
+   * @param point the point in the tile pane to drop the widget at
+   */
+  private void moveTile(Tile tile, GridPoint point) {
+    TileSize size = tile.getSize();
+    if (pane.isOpen(point, size, n -> n == tile)) {
+      pane.moveNode(tile, point);
+    }
+  }
+
+  private void cleanupWidgetDrag() {
+    pane.setHighlight(false);
+  }
+
+  private boolean ignoreIfDragArtifact(Node node) {
+    return selector.getSelectedTiles().contains(node)
+        || node instanceof WidgetPane.Highlight;
+  }
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
@@ -1,5 +1,7 @@
 package edu.wpi.first.shuffleboard.app.components;
 
+import edu.wpi.first.shuffleboard.api.sources.DataSource;
+import edu.wpi.first.shuffleboard.api.sources.SourceEntry;
 import edu.wpi.first.shuffleboard.api.tab.TabInfo;
 import edu.wpi.first.shuffleboard.api.util.TypeUtils;
 import edu.wpi.first.shuffleboard.api.widget.Component;
@@ -119,4 +121,20 @@ public class DashboardTabPane extends TabPane {
             .ifPresent(pane -> pane.selectWidgets(selector)));
   }
 
+  /**
+   * Creates a new tab to autopopulate with data in a complex data source, then selects that tab.
+   *
+   * @param entry the source entry to create a tab for
+   */
+  public void createTabForSource(SourceEntry entry) {
+    DataSource<?> source = entry.get();
+    if (!source.getDataType().isComplex()) {
+      throw new IllegalArgumentException("Data source does not provide complex data");
+    }
+    DashboardTab newTab = new DashboardTab(entry.getViewName());
+    getTabs().add(getTabs().size() - 1, newTab);
+    newTab.setSourcePrefix(source.getId() + "/");
+    newTab.setAutoPopulate(true);
+    getSelectionModel().select(newTab);
+  }
 }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/InteractiveSourceTree.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/InteractiveSourceTree.java
@@ -1,0 +1,141 @@
+package edu.wpi.first.shuffleboard.app.components;
+
+import edu.wpi.first.shuffleboard.api.components.SourceTreeTable;
+import edu.wpi.first.shuffleboard.api.dnd.DataFormats;
+import edu.wpi.first.shuffleboard.api.sources.DataSource;
+import edu.wpi.first.shuffleboard.api.sources.DataSourceUtils;
+import edu.wpi.first.shuffleboard.api.sources.SourceEntry;
+import edu.wpi.first.shuffleboard.api.sources.SourceType;
+import edu.wpi.first.shuffleboard.api.util.FxUtils;
+import edu.wpi.first.shuffleboard.api.widget.Component;
+import edu.wpi.first.shuffleboard.api.widget.Components;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import javafx.collections.FXCollections;
+import javafx.collections.MapChangeListener;
+import javafx.scene.control.ContextMenu;
+import javafx.scene.control.MenuItem;
+import javafx.scene.control.SeparatorMenuItem;
+import javafx.scene.control.TreeItem;
+import javafx.scene.control.TreeTableRow;
+import javafx.scene.input.ClipboardContent;
+import javafx.scene.input.Dragboard;
+import javafx.scene.input.TransferMode;
+
+/**
+ * An interactive source tree that allows user gestures. This encapsulates the logic used to drag sources from a tree
+ * into a widget pane, and handles context menus and updating when the available sources change.
+ */
+public final class InteractiveSourceTree extends SourceTreeTable<SourceEntry, Object> {
+
+  private final Consumer<Component> addComponentToActiveTab;
+  private SourceEntry selectedEntry; // NOPMD could be final - false positive. PMD doesn't seem to know what a lambda is
+
+  /**
+   * Creates a new interactive source tree.
+   *
+   * @param sourceType              the type of the sources the tree will contain
+   * @param addComponentToActiveTab a callback used to add a new component to the active tab. Used by the "Show as"
+   *                                context menu
+   * @param createTabForSource      a callback used to create and bring focus to a new tab to autopopulate with data
+   *                                in a complex data source
+   */
+  public InteractiveSourceTree(SourceType sourceType,
+                               Consumer<Component> addComponentToActiveTab,
+                               Consumer<SourceEntry> createTabForSource) {
+    super();
+    this.addComponentToActiveTab = addComponentToActiveTab;
+    setSourceType(sourceType);
+    setRoot(new TreeItem<>(sourceType.createRootSourceEntry()));
+    setShowRoot(false);
+    setSortPolicy(__ -> sortTree(getRoot()));
+    getSelectionModel().selectedItemProperty().addListener((__, oldItem, newItem) -> {
+      selectedEntry = newItem == null ? null : newItem.getValue();
+    });
+    setRowFactory(__ -> {
+      TreeTableRow<SourceEntry> row = new TreeTableRow<>();
+      makeSourceRowDraggable(row);
+      return row;
+    });
+
+    setOnContextMenuRequested(e -> {
+      TreeItem<SourceEntry> selectedItem = getSelectionModel().getSelectedItem();
+      if (selectedItem == null) {
+        return;
+      }
+
+      SourceEntry entry = selectedItem.getValue();
+      DataSource<?> source = entry.get();
+      List<String> componentNames = Components.getDefault().componentNamesForSource(source);
+
+      ContextMenu menu = new ContextMenu();
+      if (source.getDataType().isComplex()) {
+        menu.getItems().add(FxUtils.menuItem("Create tab", __ -> createTabForSource.accept(entry)));
+        if (!componentNames.isEmpty()) {
+          menu.getItems().add(new SeparatorMenuItem());
+        }
+      } else if (componentNames.isEmpty()) {
+        // Can't create a tab, and no components can display the source
+        return;
+      }
+      componentNames.stream()
+          .map(name -> createShowAsMenuItem(name, source))
+          .forEach(menu.getItems()::add);
+
+      menu.show(getScene().getWindow(), e.getScreenX(), e.getScreenY());
+    });
+    sourceType.getAvailableSources().addListener((MapChangeListener<String, Object>) change -> {
+      SourceEntry entry = sourceType.createSourceEntryForUri(change.getKey());
+      if (DataSourceUtils.isNotMetadata(entry.getName())) {
+        if (change.wasAdded()) {
+          updateEntry(entry);
+        } else if (change.wasRemoved()) {
+          removeEntry(entry);
+        }
+      }
+    });
+
+    // Update when the available sources chaneg
+    sourceType.getAvailableSourceUris().stream()
+        .filter(DataSourceUtils::isNotMetadata)
+        .map(sourceType::createSourceEntryForUri)
+        .forEach(this::updateEntry);
+  }
+
+  /**
+   * Sorts tree nodes recursively in order of branches before leaves, then alphabetically.
+   *
+   * @param root the root node to sort
+   */
+  private boolean sortTree(TreeItem<SourceEntry> root) {
+    if (!root.isLeaf()) {
+      FXCollections.sort(root.getChildren(),
+          branchesFirst.thenComparing(alphabetical));
+      root.getChildren().forEach(this::sortTree);
+    }
+    return true;
+  }
+
+  private void makeSourceRowDraggable(TreeTableRow<? extends SourceEntry> row) {
+    row.setOnDragDetected(event -> {
+      if (selectedEntry == null) {
+        return;
+      }
+      Dragboard dragboard = row.startDragAndDrop(TransferMode.COPY_OR_MOVE);
+      ClipboardContent content = new ClipboardContent();
+      content.put(DataFormats.source, selectedEntry);
+      dragboard.setContent(content);
+      event.consume();
+    });
+  }
+
+  private MenuItem createShowAsMenuItem(String componentName, DataSource<?> source) {
+    return FxUtils.menuItem("Show as: " + componentName, __ -> {
+      Components.getDefault().createComponent(componentName, source)
+          .ifPresent(addComponentToActiveTab);
+    });
+  }
+
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/AboutDialog.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/AboutDialog.java
@@ -1,0 +1,32 @@
+package edu.wpi.first.shuffleboard.app.dialogs;
+
+import edu.wpi.first.shuffleboard.api.components.ShuffleboardDialog;
+import edu.wpi.first.shuffleboard.api.util.FxUtils;
+import edu.wpi.first.shuffleboard.api.util.LazyInit;
+import edu.wpi.first.shuffleboard.app.AboutDialogController;
+import edu.wpi.first.shuffleboard.app.Shuffleboard;
+import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
+
+import javafx.application.Platform;
+import javafx.scene.layout.Pane;
+
+/**
+ * Dialog for displaying information about shuffleboard.
+ */
+public final class AboutDialog {
+
+  private final LazyInit<Pane> pane = LazyInit.of(() -> FxUtils.load(AboutDialogController.class));
+
+  /**
+   * Shows the about dialog.
+   */
+  public void show() {
+    ShuffleboardDialog dialog = new ShuffleboardDialog(pane.get(), true);
+    dialog.setHeaderText("WPILib Shuffleboard");
+    dialog.setSubheaderText(Shuffleboard.getVersion());
+    dialog.getDialogPane().getStylesheets().setAll(AppPreferences.getInstance().getTheme().getStyleSheets());
+    Platform.runLater(dialog.getDialogPane()::requestFocus);
+    dialog.showAndWait();
+  }
+
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/ExportRecordingDialog.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/ExportRecordingDialog.java
@@ -1,0 +1,42 @@
+package edu.wpi.first.shuffleboard.app.dialogs;
+
+import edu.wpi.first.shuffleboard.api.util.FxUtils;
+import edu.wpi.first.shuffleboard.api.util.LazyInit;
+import edu.wpi.first.shuffleboard.app.ConvertRecordingPaneController;
+import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
+
+import javafx.scene.Scene;
+import javafx.scene.layout.Pane;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+
+/**
+ * Dialog for allowing users to convert data recordings from the binary format to other formats.
+ */
+public final class ExportRecordingDialog {
+
+  private boolean initialized = false;
+  private final LazyInit<Pane> pane = LazyInit.of(() -> FxUtils.load(ConvertRecordingPaneController.class));
+  private Stage stage;
+
+  private void setup() {
+    stage = new Stage();
+    stage.setTitle("Export Recording Files");
+    stage.setScene(new Scene(pane.get()));
+    stage.setResizable(false);
+    pane.get().getStylesheets().setAll(AppPreferences.getInstance().getTheme().getStyleSheets());
+    stage.initModality(Modality.APPLICATION_MODAL);
+    initialized = true;
+  }
+
+  /**
+   * Shows the dialog.
+   */
+  public void show() {
+    if (!initialized) {
+      setup();
+    }
+    stage.show();
+  }
+
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/PluginDialog.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/PluginDialog.java
@@ -1,0 +1,53 @@
+package edu.wpi.first.shuffleboard.app.dialogs;
+
+import edu.wpi.first.shuffleboard.api.util.FxUtils;
+import edu.wpi.first.shuffleboard.api.util.LazyInit;
+import edu.wpi.first.shuffleboard.app.PluginPaneController;
+import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
+
+import javafx.scene.Scene;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Pane;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+
+/**
+ * Dialog for plugins controller.
+ */
+public final class PluginDialog {
+
+  private boolean initialized = false;
+
+  // Lazy init to avoid unnecessary loading if the dialog is never used
+  private final LazyInit<Pane> pane = LazyInit.of(() -> FxUtils.load(PluginPaneController.class));
+  private Stage stage;
+
+  private void setup() {
+    initialized = true;
+    stage = new Stage();
+    stage.initModality(Modality.WINDOW_MODAL);
+    stage.addEventHandler(KeyEvent.KEY_PRESSED, e -> {
+      if (e.getCode() == KeyCode.ESCAPE) {
+        stage.close();
+      }
+    });
+    stage.setScene(new Scene(pane.get()));
+    stage.sizeToScene();
+    stage.setMinWidth(675);
+    stage.setMinHeight(325);
+    stage.setTitle("Loaded Plugins");
+    pane.get().getStylesheets().setAll(AppPreferences.getInstance().getTheme().getStyleSheets());
+  }
+
+  /**
+   * Shows the plugin dialog.
+   */
+  public void show() {
+    if (!initialized) {
+      setup();
+    }
+    stage.show();
+  }
+
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/PrefsDialog.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/PrefsDialog.java
@@ -1,0 +1,85 @@
+package edu.wpi.first.shuffleboard.app.dialogs;
+
+import edu.wpi.first.shuffleboard.api.DashboardMode;
+import edu.wpi.first.shuffleboard.api.components.ExtendedPropertySheet;
+import edu.wpi.first.shuffleboard.api.components.ExtendedPropertySheet.PropertyItem;
+import edu.wpi.first.shuffleboard.api.plugin.Plugin;
+import edu.wpi.first.shuffleboard.api.prefs.FlushableProperty;
+import edu.wpi.first.shuffleboard.api.util.TypeUtils;
+import edu.wpi.first.shuffleboard.app.plugin.PluginLoader;
+import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
+
+import java.util.function.Function;
+import java.util.function.Predicate;
+
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
+import javafx.scene.layout.BorderPane;
+import javafx.stage.Modality;
+import javafx.stage.StageStyle;
+
+/**
+ * Dialog for editing application and plugin preferences.
+ */
+public final class PrefsDialog {
+
+  private static final String DIALOG_TITLE = "Shuffleboard Preferences";
+
+  private final TabPane tabs = new TabPane();
+  private final Predicate<Plugin> hasProperties = plugin -> !plugin.getProperties().isEmpty();
+  private final Function<Plugin, Tab> createTabForPlugin = this::createTabForPlugin;
+
+  public PrefsDialog() {
+    tabs.setTabClosingPolicy(TabPane.TabClosingPolicy.UNAVAILABLE);
+  }
+
+  /**
+   * Shows the preferences dialog.
+   */
+  public void show() {
+    tabs.getTabs().clear();
+    tabs.getTabs().add(new Tab("Application", new ExtendedPropertySheet(AppPreferences.getInstance().getProperties())));
+
+    PluginLoader.getDefault().getLoadedPlugins().stream()
+        .filter(hasProperties)
+        .map(createTabForPlugin)
+        .forEach(tabs.getTabs()::add);
+
+    Dialog<Boolean> dialog = createDialog();
+    if (dialog.showAndWait().orElse(false)) {
+      tabs.getTabs().stream()
+          .map(t -> (ExtendedPropertySheet) t.getContent())
+          .flatMap(p -> p.getItems().stream())
+          .flatMap(TypeUtils.castStream(PropertyItem.class))
+          .map(i -> (PropertyItem<?>) i) // due to castStream not working on generic types
+          .map(PropertyItem::getObservableValue)
+          .flatMap(TypeUtils.optionalStream())
+          .flatMap(TypeUtils.castStream(FlushableProperty.class))
+          .filter(FlushableProperty::isChanged)
+          .forEach(FlushableProperty::flush);
+    }
+  }
+
+  private Dialog<Boolean> createDialog() {
+    Dialog<Boolean> dialog = new Dialog<>();
+    dialog.getDialogPane().getStylesheets().setAll(AppPreferences.getInstance().getTheme().getStyleSheets());
+    dialog.getDialogPane().setContent(new BorderPane(tabs));
+    dialog.initModality(Modality.APPLICATION_MODAL);
+    dialog.initStyle(StageStyle.UTILITY);
+    dialog.getDialogPane().getButtonTypes().addAll(ButtonType.CANCEL, ButtonType.OK);
+    dialog.setTitle(DIALOG_TITLE);
+    dialog.setResizable(true);
+    dialog.setResultConverter(button -> !button.getButtonData().isCancelButton());
+    return dialog;
+  }
+
+  private Tab createTabForPlugin(Plugin plugin) {
+    Tab tab = new Tab(plugin.getName());
+    tab.setContent(new ExtendedPropertySheet(plugin.getProperties()));
+    tab.setDisable(DashboardMode.getCurrentMode() == DashboardMode.PLAYBACK);
+    return tab;
+  }
+
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/RestartPromptDialog.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/RestartPromptDialog.java
@@ -1,0 +1,41 @@
+package edu.wpi.first.shuffleboard.app.dialogs;
+
+import edu.wpi.first.shuffleboard.api.components.ShuffleboardDialog;
+import edu.wpi.first.shuffleboard.api.util.FxUtils;
+import edu.wpi.first.shuffleboard.api.util.LazyInit;
+import edu.wpi.first.shuffleboard.app.MainWindowController;
+import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
+
+import javafx.fxml.FXMLLoader;
+import javafx.scene.control.ButtonBar;
+import javafx.scene.control.ButtonType;
+import javafx.scene.layout.Pane;
+import javafx.stage.Window;
+
+/**
+ * Dialog for prompting the user to restart the application.
+ */
+public final class RestartPromptDialog {
+
+  private final LazyInit<Pane> pane
+      = LazyInit.of(() -> FXMLLoader.load(MainWindowController.class.getResource("RestartPrompt.fxml")));
+
+  /**
+   * Shows the restart prompt.
+   *
+   * @param primaryWindow the primary application window
+   */
+  public void show(Window primaryWindow) {
+    ShuffleboardDialog dialog = new ShuffleboardDialog(pane.get());
+    dialog.setHeaderText("Update Downloaded");
+    dialog.initOwner(primaryWindow);
+    dialog.getDialogPane().getStylesheets().setAll(AppPreferences.getInstance().getTheme().getStyleSheets());
+    ButtonType restartNow = new ButtonType("Restart now", ButtonBar.ButtonData.YES);
+    ButtonType later = new ButtonType("Later", ButtonBar.ButtonData.NO);
+    dialog.getDialogPane().getButtonTypes().addAll(restartNow, later);
+    dialog.showAndWait()
+        .filter(restartNow::equals)
+        .ifPresent(__ -> FxUtils.requestClose(primaryWindow));
+  }
+
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/UpdateDownloadDialog.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/UpdateDownloadDialog.java
@@ -1,0 +1,80 @@
+package edu.wpi.first.shuffleboard.app.dialogs;
+
+import edu.wpi.first.shuffleboard.api.util.FxUtils;
+import edu.wpi.first.shuffleboard.api.util.LazyInit;
+import edu.wpi.first.shuffleboard.app.DownloadDialogController;
+import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
+
+import javafx.scene.Scene;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Pane;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+
+/**
+ * Dialog for displaying download progress of an update.
+ */
+public final class UpdateDownloadDialog {
+
+  private boolean initialized = false;
+  private final LazyInit<Pane> downloadPane = LazyInit.of(() -> FxUtils.load(DownloadDialogController.class));
+  private Stage stage;
+
+  private void setup() {
+    stage = new Stage();
+    Pane pane = downloadPane.get();
+    stage.initModality(Modality.APPLICATION_MODAL);
+    stage.initStyle(StageStyle.UNDECORATED);
+    stage.setScene(new Scene(pane));
+    stage.getScene().getStylesheets().setAll(AppPreferences.getInstance().getTheme().getStyleSheets());
+    pane.addEventHandler(KeyEvent.KEY_PRESSED, event -> {
+      if (event.getCode() == KeyCode.ESCAPE) {
+        stage.close();
+      }
+    });
+    stage.focusedProperty().addListener((__, was, is) -> {
+      if (!is) {
+        stage.close();
+      }
+    });
+    initialized = true;
+  }
+
+  /**
+   * Shows the dialog.
+   */
+  public void show() {
+    if (!initialized) {
+      setup();
+    }
+    stage.show();
+  }
+
+  /**
+   * Closes the dialog.
+   */
+  public void close() {
+    stage.close();
+  }
+
+  /**
+   * Checks if the dialog is currently visible.
+   *
+   * @return true if the dialog is visible, false if not
+   */
+  public boolean isShowing() {
+    return stage != null && stage.isShowing();
+  }
+
+  /**
+   * Sets the current download progress.
+   * @param progress the current download progress, in the range [0, 1].
+   */
+  public void setDownloadProgress(double progress) {
+    DownloadDialogController controller = FxUtils.getController(downloadPane.get());
+    controller.setDownloadProgress(progress);
+  }
+
+}

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/ConnectionIndicators.fxml
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/ConnectionIndicators.fxml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.layout.HBox?>
+<HBox xmlns="http://javafx.com/javafx"
+      xmlns:fx="http://javafx.com/fxml"
+      fx:controller="edu.wpi.first.shuffleboard.app.ConnectionIndicatorsController"
+      spacing="2" alignment="CENTER"
+      styleClass="connection-indicator-area"
+      fx:id="root">
+
+</HBox>

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/LeftDrawer.fxml
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/LeftDrawer.fxml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import edu.wpi.first.shuffleboard.app.components.WidgetGallery?>
+<?import javafx.scene.control.Accordion?>
+<?import javafx.scene.control.ScrollPane?>
+<?import javafx.scene.control.Tab?>
+<?import javafx.scene.control.TabPane?>
+<?import javafx.scene.layout.StackPane?>
+<StackPane xmlns="http://javafx.com/javafx"
+           xmlns:fx="http://javafx.com/fxml"
+           fx:controller="edu.wpi.first.shuffleboard.app.LeftDrawerController"
+           fx:id="root">
+    <TabPane tabClosingPolicy="UNAVAILABLE" prefWidth="400">
+        <Tab text="Sources">
+            <ScrollPane fitToWidth="true" fitToHeight="true">
+                <Accordion fx:id="sourcesAccordion"/>
+            </ScrollPane>
+        </Tab>
+        <Tab text="Widgets">
+            <ScrollPane fitToWidth="true">
+                <WidgetGallery vgap="10" hgap="10" prefColumns="3" fx:id="widgetGallery"/>
+            </ScrollPane>
+        </Tab>
+    </TabPane>
+</StackPane>

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/MainWindow.fxml
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/MainWindow.fxml
@@ -49,18 +49,7 @@
         </Menu>
     </MenuBar>
     <SplitPane fx:id="centerSplitPane" dividerPositions="0.02">
-        <TabPane tabClosingPolicy="UNAVAILABLE" prefWidth="400">
-            <Tab text="Sources">
-                <ScrollPane fitToWidth="true" fitToHeight="true">
-                    <Accordion fx:id="sourcesAccordion"/>
-                </ScrollPane>
-            </Tab>
-            <Tab text="Widgets">
-                <ScrollPane fitToWidth="true">
-                    <WidgetGallery vgap="10" hgap="10" prefColumns="3" fx:id="widgetGallery"/>
-                </ScrollPane>
-            </Tab>
-        </TabPane>
+        <fx:include source="LeftDrawer.fxml" fx:id="leftDrawer"/>
         <DashboardTabPane fx:id="dashboard"/>
     </SplitPane>
     <VBox>

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/MainWindow.fxml
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/MainWindow.fxml
@@ -1,20 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <?import edu.wpi.first.shuffleboard.app.components.DashboardTabPane?>
-<?import edu.wpi.first.shuffleboard.app.components.WidgetGallery?>
+<?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Menu?>
 <?import javafx.scene.control.MenuBar?>
 <?import javafx.scene.control.MenuItem?>
-<?import javafx.scene.control.Tab?>
-<?import javafx.scene.control.TabPane?>
 <?import javafx.scene.control.SeparatorMenuItem?>
-<?import javafx.scene.control.ScrollPane?>
-<?import javafx.scene.control.Accordion?>
-<?import javafx.scene.layout.VBox?>
 <?import javafx.scene.control.SplitPane?>
 <?import javafx.scene.layout.BorderPane?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.geometry.Insets?>
+<?import javafx.scene.layout.VBox?>
 <VBox fx:id="root" maxHeight="Infinity" maxWidth="Infinity"
       xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="edu.wpi.first.shuffleboard.app.MainWindowController">
@@ -62,7 +56,7 @@
                 <fx:include source="PlaybackControls.fxml"/>
             </center>
             <right>
-                <HBox fx:id="connectionIndicatorArea" spacing="2" alignment="CENTER" styleClass="connection-indicator-area"/>
+                <fx:include source="ConnectionIndicators.fxml"/>
             </right>
         </BorderPane>
     </VBox>

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/TileMoverTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/TileMoverTest.java
@@ -1,0 +1,173 @@
+package edu.wpi.first.shuffleboard.app;
+
+import edu.wpi.first.shuffleboard.api.util.GridPoint;
+import edu.wpi.first.shuffleboard.api.widget.TileSize;
+import edu.wpi.first.shuffleboard.app.components.Tile;
+import edu.wpi.first.shuffleboard.app.components.WidgetPane;
+import edu.wpi.first.shuffleboard.app.components.WidgetTile;
+
+import org.junit.jupiter.api.Test;
+import org.testfx.framework.junit5.ApplicationTest;
+
+import javafx.stage.Stage;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+public class TileMoverTest extends ApplicationTest {
+
+  private static final TileSize ONE_BY_ONE = new TileSize(1, 1);
+  private static final TileSize TWO_BY_ONE = new TileSize(2, 1);
+  private static final TileSize ONE_BY_TWO = new TileSize(1, 2);
+  private WidgetPane pane;
+
+  @Override
+  public void start(Stage stage) {
+    pane = new WidgetPane();
+  }
+
+  @Test
+  public void testMoveLeftToFillGaps() {
+    // ||1|_|2|_|3|| -> ||1|2|3||
+    // given
+    pane.setNumColumns(5);
+    Tile<?> first = new WidgetTile(new MockWidget(), ONE_BY_ONE);
+    Tile<?> second = new WidgetTile(new MockWidget(), ONE_BY_ONE);
+    Tile<?> third = new WidgetTile(new MockWidget(), ONE_BY_ONE);
+    pane.addTile(first, new GridPoint(0, 0), ONE_BY_ONE);
+    pane.addTile(second, new GridPoint(2, 0), ONE_BY_ONE);
+    pane.addTile(third, new GridPoint(4, 0), ONE_BY_ONE);
+    waitForFxEvents();
+
+    // when
+    pane.setNumColumns(3);
+    waitForFxEvents();
+
+    // then
+    assertAll(
+        () -> assertEquals(new GridPoint(0, 0), pane.getTileLayout(first).origin),
+        () -> assertEquals(new GridPoint(1, 0), pane.getTileLayout(second).origin),
+        () -> assertEquals(new GridPoint(2, 0), pane.getTileLayout(third).origin)
+    );
+  }
+
+  @Test
+  public void testMoveUpToFillGaps() {
+    // given
+    pane.setNumRows(5);
+    Tile<?> first = new WidgetTile(new MockWidget(), ONE_BY_ONE);
+    Tile<?> second = new WidgetTile(new MockWidget(), ONE_BY_ONE);
+    Tile<?> third = new WidgetTile(new MockWidget(), ONE_BY_ONE);
+    pane.addTile(first, new GridPoint(0, 0), ONE_BY_ONE);
+    pane.addTile(second, new GridPoint(0, 2), ONE_BY_ONE);
+    pane.addTile(third, new GridPoint(0, 4), ONE_BY_ONE);
+    waitForFxEvents();
+
+    // when
+    pane.setNumRows(3);
+    waitForFxEvents();
+
+    // then
+    assertAll(
+        () -> assertEquals(new GridPoint(0, 0), pane.getTileLayout(first).origin),
+        () -> assertEquals(new GridPoint(0, 1), pane.getTileLayout(second).origin),
+        () -> assertEquals(new GridPoint(0, 2), pane.getTileLayout(third).origin)
+    );
+  }
+
+  @Test
+  public void testShrinkLeft() {
+    // ||1|1|2|2|| -> ||1|2||
+    // given
+    pane.setNumColumns(4);
+    Tile<?> first = new WidgetTile(new MockWidget(), TWO_BY_ONE);
+    Tile<?> second = new WidgetTile(new MockWidget(), TWO_BY_ONE);
+    pane.addTile(first, new GridPoint(0, 0), TWO_BY_ONE);
+    pane.addTile(second, new GridPoint(2, 0), TWO_BY_ONE);
+    waitForFxEvents();
+
+    // when
+    pane.setNumColumns(2);
+    waitForFxEvents();
+
+    // then
+    assertAll(
+        () -> assertEquals(new GridPoint(0, 0), pane.getTileLayout(first).origin),
+        () -> assertEquals(ONE_BY_ONE, pane.getTileLayout(first).size),
+        () -> assertEquals(new GridPoint(1, 0), pane.getTileLayout(second).origin),
+        () -> assertEquals(ONE_BY_ONE, pane.getTileLayout(second).size)
+    );
+  }
+
+  @Test
+  public void testShrinkUp() {
+    // given
+    pane.setNumRows(4);
+    Tile<?> first = new WidgetTile(new MockWidget(), ONE_BY_TWO);
+    Tile<?> second = new WidgetTile(new MockWidget(), ONE_BY_TWO);
+    pane.addTile(first, new GridPoint(0, 0), ONE_BY_TWO);
+    pane.addTile(second, new GridPoint(0, 2), ONE_BY_TWO);
+    waitForFxEvents();
+
+    // when
+    pane.setNumRows(2);
+    waitForFxEvents();
+
+    // then
+    assertAll(
+        () -> assertEquals(new GridPoint(0, 0), pane.getTileLayout(first).origin),
+        () -> assertEquals(ONE_BY_ONE, pane.getTileLayout(first).size),
+        () -> assertEquals(new GridPoint(0, 1), pane.getTileLayout(second).origin),
+        () -> assertEquals(ONE_BY_ONE, pane.getTileLayout(second).size)
+    );
+  }
+
+  @Test
+  public void testShrinkAndMoveLeft() {
+    // ||1|1|_|2|2|| -> ||1|1|2||
+    // given
+    pane.setNumColumns(5);
+    Tile<?> first = new WidgetTile(new MockWidget(), TWO_BY_ONE);
+    Tile<?> second = new WidgetTile(new MockWidget(), TWO_BY_ONE);
+    pane.addTile(first, new GridPoint(0, 0), TWO_BY_ONE);
+    pane.addTile(second, new GridPoint(3, 0), TWO_BY_ONE);
+    waitForFxEvents();
+
+    // when
+    pane.setNumColumns(3);
+    waitForFxEvents();
+
+    // then
+    assertAll(
+        () -> assertEquals(new GridPoint(0, 0), pane.getTileLayout(first).origin),
+        () -> assertEquals(TWO_BY_ONE, pane.getTileLayout(first).size),
+        () -> assertEquals(new GridPoint(2, 0), pane.getTileLayout(second).origin),
+        () -> assertEquals(ONE_BY_ONE, pane.getTileLayout(second).size)
+    );
+  }
+
+  @Test
+  public void testShrinkAndMoveUp() {
+    // given
+    pane.setNumRows(5);
+    Tile<?> first = new WidgetTile(new MockWidget(), ONE_BY_TWO);
+    Tile<?> second = new WidgetTile(new MockWidget(), ONE_BY_TWO);
+    pane.addTile(first, new GridPoint(0, 0), ONE_BY_TWO);
+    pane.addTile(second, new GridPoint(0, 3), ONE_BY_TWO);
+    waitForFxEvents();
+
+    // when
+    pane.setNumRows(3);
+    waitForFxEvents();
+
+    // then
+    assertAll(
+        () -> assertEquals(new GridPoint(0, 0), pane.getTileLayout(first).origin),
+        () -> assertEquals(ONE_BY_TWO, pane.getTileLayout(first).size),
+        () -> assertEquals(new GridPoint(0, 2), pane.getTileLayout(second).origin),
+        () -> assertEquals(ONE_BY_ONE, pane.getTileLayout(second).size)
+    );
+  }
+
+}

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/TileSelectorTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/TileSelectorTest.java
@@ -31,7 +31,7 @@ public class TileSelectorTest extends ApplicationTest {
   @Override
   public void start(Stage stage) {
     pane = new WidgetPane();
-    selector = new TileSelector(pane);
+    selector = TileSelector.forPane(pane);
     pane.setNumColumns(3);
     pane.setNumRows(2);
     firstTile = pane.addWidget(new MockWidget());

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/CameraServerSource.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/CameraServerSource.java
@@ -1,6 +1,5 @@
 package edu.wpi.first.shuffleboard.plugin.cameraserver.source;
 
-import edu.wpi.first.shuffleboard.api.DashboardMode;
 import edu.wpi.first.shuffleboard.api.properties.AsyncProperty;
 import edu.wpi.first.shuffleboard.api.properties.AtomicIntegerProperty;
 import edu.wpi.first.shuffleboard.api.sources.AbstractDataSource;
@@ -8,7 +7,6 @@ import edu.wpi.first.shuffleboard.api.sources.SourceType;
 import edu.wpi.first.shuffleboard.api.sources.Sources;
 import edu.wpi.first.shuffleboard.api.util.Debouncer;
 import edu.wpi.first.shuffleboard.api.util.EqualityUtils;
-import edu.wpi.first.shuffleboard.api.util.NetworkTableUtils;
 import edu.wpi.first.shuffleboard.api.util.ThreadUtils;
 import edu.wpi.first.shuffleboard.plugin.cameraserver.data.CameraServerData;
 import edu.wpi.first.shuffleboard.plugin.cameraserver.data.Resolution;
@@ -20,11 +18,8 @@ import edu.wpi.cscore.HttpCamera;
 import edu.wpi.cscore.VideoEvent;
 import edu.wpi.cscore.VideoException;
 import edu.wpi.cscore.VideoMode;
-import edu.wpi.first.networktables.EntryListenerFlags;
 import edu.wpi.first.networktables.NetworkTable;
-import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
-import edu.wpi.first.networktables.NetworkTableType;
 
 import org.opencv.core.Mat;
 
@@ -36,7 +31,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Stream;
 
 import javafx.application.Platform;
 import javafx.beans.InvalidationListener;
@@ -45,7 +39,6 @@ import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.Property;
 import javafx.beans.value.ChangeListener;
 
-@SuppressWarnings("PMD.GodClass")
 public final class CameraServerSource extends AbstractDataSource<CameraServerData> {
 
   private static final Logger log = Logger.getLogger(CameraServerSource.class.getName());
@@ -53,25 +46,21 @@ public final class CameraServerSource extends AbstractDataSource<CameraServerDat
   private static final Map<String, CameraServerSource> sources = new HashMap<>();
 
   private final NetworkTable cameraPublisherTable = NetworkTableInstance.getDefault().getTable("/CameraPublisher");
-  private final NetworkTableEntry streams;
-  private static final String STREAMS_KEY = "streams";
-  private static final String[] emptyStringArray = new String[0];
   private final int eventListenerId;
   private HttpCamera camera;
-  private final CvSink videoSink;
+  private CvSink videoSink; // NOPMD could be final - it can't due to how lambdas handle capturing final fields
   private final Mat image = new Mat();
 
   private final ExecutorService frameGrabberService = Executors.newSingleThreadExecutor(ThreadUtils::makeDaemonThread);
   private final BooleanBinding enabled = active.and(connected);
-  private int streamsListener;
-  private final ChangeListener<Boolean> enabledListener;
-  private Future<?> frameFuture = null;
-  private final ChangeListener<CameraServerData> recordingListener = (__, prev, cur) -> {
-    // TODO enable after fixing recording/playback bugs
-    //Recorder.getInstance().recordCurrentValue(this);
+  private final ChangeListener<Boolean> enabledListener =  (__, was, is) -> {
+    if (is) {
+      reEnable();
+    } else {
+      cancelFrameGrabber();
+    }
   };
-
-  private String[] streamUrls = null;
+  private Future<?> frameFuture = null;
 
   /**
    * The maximum supported resolution. Attempts to set the resolution higher than this will fail.
@@ -91,7 +80,24 @@ public final class CameraServerSource extends AbstractDataSource<CameraServerDat
           super.set(newValue);
         }
       };
+
+  private final StreamDiscoverer streamDiscoverer;
   private final CameraUrlGenerator urlGenerator = new CameraUrlGenerator(this);
+  private final ChangeListener<String[]> urlChangeListener =  (__, old, urls) -> {
+    if (urls.length == 0) {
+      setActive(false);
+    } else {
+      String[] parameterizedUrls = urlGenerator.generateUrls(urls);
+      if (camera == null) {
+        camera = new HttpCamera(getName(), parameterizedUrls);
+        videoSink.setSource(camera);
+        videoSink.setEnabled(true);
+      } else if (EqualityUtils.isDifferent(camera.getUrls(), parameterizedUrls)) {
+        setCameraUrls(parameterizedUrls);
+      }
+      setActive(true);
+    }
+  };
 
   // Needs to be debounced; quickly changing URLs can cause serious performance hits
   private final Debouncer urlUpdateDebouncer = new Debouncer(this::updateUrls, Duration.ofMillis(10));
@@ -138,54 +144,15 @@ public final class CameraServerSource extends AbstractDataSource<CameraServerDat
       }
     }, VideoEvent.Kind.kTelemetryUpdated.getValue(), true);
 
-    streams = cameraPublisherTable.getSubTable(name).getEntry(STREAMS_KEY);
-    streams.addListener(notification -> {
-      String[] arr = notification.getEntry().getStringArray(emptyStringArray);
-      if (camera != null) {
-        setActive(arr.length > 0);
-        setConnected(DashboardMode.getCurrentMode() != DashboardMode.PLAYBACK);
-      }
-    }, EntryListenerFlags.kNew | EntryListenerFlags.kUpdate | EntryListenerFlags.kImmediate);
-    streamUrls = removeCameraProtocols(streams.getStringArray(emptyStringArray));
+    streamDiscoverer = new StreamDiscoverer(cameraPublisherTable, name);
+    streamDiscoverer.urlsProperty().addListener(urlChangeListener);
+    String[] streamUrls = streamDiscoverer.getUrls();
     if (streamUrls.length > 0) {
       camera = new HttpCamera(name, urlGenerator.generateUrls(streamUrls));
       videoSink.setSource(camera);
       videoSink.setEnabled(true);
     }
 
-    connected.addListener((__, was, is) -> {
-      if (!is) {
-        // Only listen to changes in the streams when there's a connection
-        streams.removeListener(streamsListener);
-      }
-    });
-
-    enabledListener = (__, was, is) -> {
-      if (is) {
-        data.addListener(recordingListener);
-        frameFuture = frameGrabberService.submit(this::grabForever);
-        streamsListener = streams.addListener(entryNotification -> {
-          if (NetworkTableUtils.isDelete(entryNotification.flags)
-              || (entryNotification.getEntry().getType() != NetworkTableType.kStringArray)
-              || (entryNotification.value.getStringArray()).length == 0) {
-            setActive(false);
-          } else {
-            streamUrls = removeCameraProtocols(entryNotification.value.getStringArray());
-            String[] parameterizedUrls = urlGenerator.generateUrls(streamUrls);
-            if (camera == null) {
-              camera = new HttpCamera(name, parameterizedUrls);
-              videoSink.setSource(camera);
-            } else if (EqualityUtils.isDifferent(camera.getUrls(), parameterizedUrls)) {
-              setCameraUrls(parameterizedUrls);
-            }
-            setActive(true);
-          }
-        }, 0xFF);
-      } else {
-        data.removeListener(recordingListener);
-        cancelFrameGrabber();
-      }
-    };
     enabled.addListener(enabledListener);
     targetCompression.addListener(cameraUrlUpdater);
     targetFps.addListener(cameraUrlUpdater);
@@ -193,27 +160,20 @@ public final class CameraServerSource extends AbstractDataSource<CameraServerDat
     setActive(camera != null && camera.getUrls().length > 0);
   }
 
+  private void reEnable() {
+    frameFuture = frameGrabberService.submit(this::grabForever);
+    String[] streamUrls = streamDiscoverer.getUrls();
+    if (streamUrls.length == 0) {
+      setActive(false);
+    }
+    streamDiscoverer.urlsProperty().addListener(urlChangeListener);
+  }
+
   private void cancelFrameGrabber() {
     if (frameFuture != null) {
       frameFuture.cancel(true);
     }
-  }
-
-  /**
-   * Removes leading camera protocols from an array of stream URLs. These URLs are usually in the format
-   * {@code mjpg:http://...}, {@code ip:http://...}. This method will remove the leading {@code mjpg}.
-   *
-   * <p>This does not modify the existing array and returns a new array.
-   *
-   * @param streams an array of camera stream URLs to remove the
-   *
-   * @return the stream URLs without the leading camera protocols
-   */
-  private static String[] removeCameraProtocols(String... streams) {
-    return Stream.of(streams)
-        .map(url -> url.replaceFirst("^(mjpe?g|ip|usb):", ""))
-        .map(url -> url.replace("/?action=stream", "/stream.mjpg?"))
-        .toArray(String[]::new);
+    streamDiscoverer.urlsProperty().removeListener(urlChangeListener);
   }
 
   public static CameraServerSource forName(String name) {
@@ -273,7 +233,7 @@ public final class CameraServerSource extends AbstractDataSource<CameraServerDat
   public void close() {
     setActive(false);
     setConnected(false);
-    streams.removeListener(streamsListener);
+    streamDiscoverer.close();
     enabled.removeListener(enabledListener);
     CameraServerJNI.removeListener(eventListenerId);
     cancelFrameGrabber();
@@ -287,7 +247,7 @@ public final class CameraServerSource extends AbstractDataSource<CameraServerDat
 
   private void updateUrls() {
     if (camera != null) {
-      setCameraUrls(urlGenerator.generateUrls(streamUrls));
+      setCameraUrls(urlGenerator.generateUrls(streamDiscoverer.getUrls()));
     }
   }
 

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/StreamDiscoverer.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/StreamDiscoverer.java
@@ -1,0 +1,91 @@
+package edu.wpi.first.shuffleboard.plugin.cameraserver.source;
+
+import edu.wpi.first.shuffleboard.api.properties.AsyncProperty;
+import edu.wpi.first.shuffleboard.api.properties.AtomicProperty;
+import edu.wpi.first.shuffleboard.api.util.BitUtils;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import edu.wpi.first.networktables.EntryListenerFlags;
+import edu.wpi.first.networktables.EntryNotification;
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableType;
+
+import java.io.Closeable;
+import java.util.stream.Stream;
+
+import javafx.beans.property.ReadOnlyProperty;
+
+/**
+ * Discovers stream URLs for a specific cscore camera.
+ */
+public final class StreamDiscoverer implements Closeable {
+
+  private final NetworkTableEntry streams;
+  private static final String STREAMS_KEY = "streams";
+  private static final String[] emptyStringArray = new String[0];
+
+  private final AtomicProperty<String[]> urls = new AsyncProperty<>(this, "urls", emptyStringArray);
+  private final int listenerHandle;
+
+  /**
+   * Creates a new stream discoverer.
+   *
+   * @param publisherTable the root camera server publisher table
+   * @param cameraName     the name of the camera to discover streams for
+   */
+  public StreamDiscoverer(NetworkTable publisherTable, String cameraName) {
+    streams = publisherTable.getSubTable(cameraName).getEntry(STREAMS_KEY);
+
+    listenerHandle = streams.addListener(this::updateUrls,0xFF);
+  }
+
+  /**
+   * Removes leading camera protocols from an array of stream URLs. These URLs are usually in the format
+   * {@code mjpg:http://...}, {@code ip:http://...}. This method will remove the leading {@code mjpg}. This will also
+   * replace a trailing <tt>/?action=stream</tt> with <tt>/stream.mjpg?</tt> due to a bug in cscore not handling URL
+   * parameters correctly.
+   *
+   * <p>This does not modify the existing array and returns a new array.
+   *
+   * @param streams an array of camera stream URLs to remove the
+   *
+   * @return the stream URLs without the leading camera protocols
+   */
+  @VisibleForTesting
+  static String[] removeCameraProtocols(String... streams) {
+    return Stream.of(streams)
+        .map(url -> url.replaceFirst("^(mjpe?g|ip|usb):", ""))
+        .map(url -> url.replace("/?action=stream", "/stream.mjpg?"))
+        .toArray(String[]::new);
+  }
+
+  public String[] getUrls() {
+    return urls.getValue().clone(); // defensive copy
+  }
+
+  // read-only to prevent third parties from overwriting the URLs array
+  public ReadOnlyProperty<String[]> urlsProperty() {
+    return urls;
+  }
+
+  @Override
+  public void close() {
+    streams.removeListener(listenerHandle);
+    urls.setValue(emptyStringArray);
+  }
+
+  /**
+   * Updates the URLs from a NetworkTables entry notification.
+   */
+  private void updateUrls(EntryNotification notification) {
+    if (BitUtils.flagMatches(notification.flags, EntryListenerFlags.kDelete)
+        || notification.getEntry().getType() != NetworkTableType.kStringArray) {
+      urls.setValue(emptyStringArray);
+    } else {
+      String[] arr = notification.getEntry().getStringArray(emptyStringArray);
+      urls.setValue(removeCameraProtocols(arr));
+    }
+  }
+}

--- a/plugins/cameraserver/src/test/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/StreamDiscovererTest.java
+++ b/plugins/cameraserver/src/test/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/StreamDiscovererTest.java
@@ -1,0 +1,77 @@
+package edu.wpi.first.shuffleboard.plugin.cameraserver.source;
+
+import edu.wpi.first.networktables.NetworkTable;
+import edu.wpi.first.networktables.NetworkTableInstance;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.testfx.util.WaitForAsyncUtils.sleep;
+
+public class StreamDiscovererTest {
+
+  private final NetworkTableInstance ntInstance = NetworkTableInstance.create();
+  private final NetworkTable rootTable = ntInstance.getTable("CameraPublisher");
+
+  @Test
+  public void testArrayChanges() {
+    final StreamDiscoverer discoverer = new StreamDiscoverer(rootTable, "Camera");
+    String[] urls = {"foo", "bar"};
+    rootTable.getEntry("Camera/streams").setStringArray(urls);
+    waitForNtEvents();
+
+    assertArrayEquals(urls, discoverer.getUrls());
+  }
+
+  @Test
+  public void testInitiallyEmpty() {
+    final StreamDiscoverer discoverer = new StreamDiscoverer(rootTable, "Camera");
+
+    assertArrayEquals(new String[0], discoverer.getUrls(), "Initial URL array should be empty");
+  }
+
+  @Test
+  public void testEmptyWhenIncorrectType() {
+    StreamDiscoverer discoverer = new StreamDiscoverer(rootTable, "Camera");
+
+    rootTable.getEntry("Camera/streams").setDouble(12.34);
+    waitForNtEvents();
+
+    assertArrayEquals(new String[0], discoverer.getUrls());
+  }
+
+  @Test
+  public void testEmptyWhenTypeChanges() {
+    final StreamDiscoverer discoverer = new StreamDiscoverer(rootTable, "Camera");
+    String[] urls = {"foo", "bar"};
+    rootTable.getEntry("Camera/streams").setStringArray(urls);
+    waitForNtEvents();
+
+    rootTable.getEntry("Camera/streams").forceSetBoolean(false);
+    waitForNtEvents();
+
+    assertArrayEquals(new String[0], discoverer.getUrls());
+  }
+
+  @Test
+  public void testClose() {
+    final StreamDiscoverer discoverer = new StreamDiscoverer(rootTable, "Camera");
+    String[] urls = {"foo", "bar"};
+    rootTable.getEntry("Camera/streams").setStringArray(urls);
+    waitForNtEvents();
+
+    discoverer.close();
+
+    rootTable.getEntry("Camera/streams").setStringArray(new String[]{"bar", "foo"});
+    waitForNtEvents();
+
+    assertArrayEquals(new String[0], discoverer.getUrls());
+  }
+
+  private static void waitForNtEvents() {
+    sleep(100, TimeUnit.MILLISECONDS);
+  }
+
+}


### PR DESCRIPTION
This is a major refactor and changes a _lot_ of commonly modified files. This should be merged ASAP to avoid conflicts with future PRs.

### Current God classes

| Class | Needs to be refactored? |
---|---
Playback | No (it's not a complex class)
Serialization | Probably - raw byte utils could be split out
TilePane | No (it's not a complex class)
MainWindowController | Yes - over 750 lines!
WidgetPane | No - PMD is triggered by the many properties
WidgetPaneController | Yes - over _1000_ lines!
GraphWidget | Maybe - there's a lot of code to handle mutliple data sources
GridLayout | Maybe - it's long, but not very complex
CameraServerSource | Probably - frame reading could be split out

# Current improvements
- MainWindowController reduced from 761 lines to 351 and is no longer classified as a God class by PMD
  - Dialogs split into their own classes
  - File saving and loading split into its own class
  - Left drawer (source trees and widget gallery) split into its own FXML + controller
    - Interacting with source trees also split into its own class
  - Connection indicators split into its own FXML + controller
- WidgetPaneController reduced from 1038 lines to 594 (still a God class - there's more work to do!)
  - DnD over/onto the pane split into its own class (and by itself classified as a God class)
  - DnD over/onto individual times split into its own class
  - Automatic moving and resizing of tiles split into its own class

# TODO
- [ ] Address PMD God classes
    - [ ] Serialization
    - [x] MainWindowController
    - [ ] WidgetPaneController
    - [ ] GraphWidget
    - [ ] GridLayout
    - [x] CameraServerSource
- [ ] Use a DI framework instead of static singletons everywhere