### PR TITLE
Fix toggle switch backgrounds on dark themes

### DIFF
--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/dark.css
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/dark.css
@@ -120,14 +120,19 @@
  * Toggle switch                                                               *
  *                                                                             *
  ******************************************************************************/
+.tile .toggle-switch > .thumb-area {
+    -fx-background-color: -swatch-light-gray, -swatch-gray;
+}
+
 .toggle-switch > .thumb-area {
-    -fx-background-color: -swatch-gray;
+    -fx-background-color: -swatch-light-gray, -swatch-dark-gray;
 }
 
 .toggle-switch > .thumb {
     -fx-background-color: #AAAAAA;
 }
 
+.tile .toggle-switch:selected > .thumb-area,
 .toggle-switch:selected > .thumb-area {
     -fx-background-color: -swatch-500;
 }

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/midnight.css
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/midnight.css
@@ -147,7 +147,7 @@
 }
 
 .toggle-switch > .thumb-area {
-    -fx-background-color: -swatch-light-gray, -swatch-dark-gray;
+    -fx-background-color: derive(-swatch-light-gray, -25%), -swatch-dark-gray;
 }
 
 .toggle-switch > .thumb {

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/midnight.css
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/midnight.css
@@ -142,14 +142,19 @@
  * Toggle switch                                                               *
  *                                                                             *
  ******************************************************************************/
+.tile .toggle-switch > .thumb-area {
+    -fx-background-color: -swatch-light-gray, -swatch-gray;
+}
+
 .toggle-switch > .thumb-area {
-    -fx-background-color: -swatch-gray;
+    -fx-background-color: -swatch-light-gray, -swatch-dark-gray;
 }
 
 .toggle-switch > .thumb {
     -fx-background-color: #AAAAAA;
 }
 
+.tile .toggle-switch:selected > .thumb-area,
 .toggle-switch:selected > .thumb-area {
     -fx-background-color: -swatch-500;
 }


### PR DESCRIPTION
Make the track backgrounds visible on regular gray backgrounds, not just on tiles (which have dark gray backgrounds)

Gives the buttons a slight border as well, to match the design of the default style