### PR TITLE
Move tab close button to left side, keep selected index constant

### DIFF
--- a/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
+++ b/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
@@ -41,6 +41,16 @@
     -fx-border-color: transparent;
 }
 
+.tab-container {
+    /* Rotate the tab container to put the close button on the left-hand side */
+    -fx-rotate: 180;
+}
+
+.tab-container > * {
+    /* Re-rotate the contents to keep the text right-side up */
+    -fx-rotate: 180;
+}
+
 /*******************************************************************************
  *                                                                             *
  * Dashboard Tabs                                                              *

--- a/api/src/main/resources/edu/wpi/first/shuffleboard/api/material.css
+++ b/api/src/main/resources/edu/wpi/first/shuffleboard/api/material.css
@@ -742,7 +742,15 @@
     -fx-text-fill: white;
 }
 
-.tab:selected .tab-label {
+.tab .tab-label {
+    /*
+     * Set a border to the same color as the background to keep the label text in the same position
+     * when the tab is selected.
+     */
     -fx-border-width: 0 0 0.125em 0;
+    -fx-border-color: -swatch-500;
+}
+
+.tab:selected .tab-label {
     -fx-border-color: -fx-text-fill;
 }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
@@ -41,6 +41,7 @@ import javafx.collections.ListChangeListener;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
 import javafx.scene.control.Tab;
+import javafx.scene.control.TabPane;
 
 public class DashboardTab extends Tab implements HandledTab, Populatable {
 
@@ -114,6 +115,14 @@ public class DashboardTab extends Tab implements HandledTab, Populatable {
     MenuItem prefItem = FxUtils.menuItem("Preferences", __ -> showPrefsDialog());
     prefItem.setStyle("-fx-text-fill: black;");
     setContextMenu(new ContextMenu(prefItem));
+
+    setOnCloseRequest(e -> {
+      TabPane tabPane = getTabPane();
+      int index = tabPane.getTabs().indexOf(this);
+      // index + 1 for the next tab, since this tab has not yet been removed
+      // tabPane.getTabs().size() - 2 because -1 is the adder tab, which we do not want to select
+      tabPane.getSelectionModel().select(Math.min(index + 1, tabPane.getTabs().size() - 2));
+    });
   }
 
   /**

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
@@ -15,6 +15,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 
 import javafx.collections.ListChangeListener;
+import javafx.event.Event;
 import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 
@@ -100,7 +101,10 @@ public class DashboardTabPane extends TabPane {
    * Closes the currently selected tab.
    */
   public void closeCurrentTab() {
-    getTabs().remove(getSelectionModel().getSelectedItem());
+    Tab tab = getSelectionModel().getSelectedItem();
+    Event event = new Event(tab, tab, Tab.TAB_CLOSE_REQUEST_EVENT);
+    Event.fireEvent(tab, event);
+    getTabs().remove(tab);
   }
 
   /**

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPaneTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPaneTest.java
@@ -1,0 +1,55 @@
+package edu.wpi.first.shuffleboard.app.components;
+
+import org.junit.jupiter.api.Test;
+import org.testfx.framework.junit5.ApplicationTest;
+
+import javafx.application.Platform;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
+
+public class DashboardTabPaneTest extends ApplicationTest {
+
+  private DashboardTabPane tabPane;
+
+  @Override
+  public void start(Stage stage) {
+    tabPane = new DashboardTabPane();
+    stage.setScene(new Scene(tabPane));
+    stage.show();
+  }
+
+  @Test
+  public void testCloseTabKeepsSelectedIndex() {
+    // Add three tabs, select the second one, then close it
+    // The selected index should remain 1
+    Platform.runLater(() -> {
+      tabPane.addNewTab();
+      tabPane.addNewTab();
+      tabPane.addNewTab();
+      tabPane.getSelectionModel().select(1);
+      tabPane.closeCurrentTab();
+    });
+    waitForFxEvents();
+    assertEquals(1, tabPane.getSelectionModel().getSelectedIndex(), "Wrong selected tab index");
+  }
+
+  @Test
+  public void testCloseRightmostTabDecrementsIndex() {
+    // Add four tabs, select the fourth one, then close it
+    // The selected index should decrement from 3 to 2
+    Platform.runLater(() -> {
+      tabPane.addNewTab();
+      tabPane.addNewTab();
+      tabPane.addNewTab();
+      tabPane.addNewTab();
+      tabPane.getSelectionModel().select(3);
+      tabPane.closeCurrentTab();
+    });
+    waitForFxEvents();
+    assertEquals(2, tabPane.getSelectionModel().getSelectedIndex(), "Wrong selected tab index");
+  }
+
+}


### PR DESCRIPTION
Closes #45
Uses a CSS hack to rotate the tab container to flip the button, then rotates the contents to keep them right-side up

Maintains selected tab index when closing tabs. If the rightmost tab is closed, the previous tab will be selected

Video: https://www.youtube.com/watch?v=1tmzwI2SP3E