### PR TITLE
Fix multi-byte characters in strings in recordings

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -441,8 +441,8 @@ public final class Serialization {
   }
 
   /**
-   * Encodes a string as a big-endian byte array. The resulting array encodes the length of the string in the first
-   * four bytes, then the contents of the string.
+   * Encodes a string as a big-endian byte array. The resulting array encodes the number bytes that encode the string
+   * in a 4-byte int, followed by the encoded character bytes.
    */
   public static byte[] toByteArray(String string) {
     try {

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -348,7 +348,7 @@ public final class Serialization {
   public static int sizeOfStringArray(String[] array) { // NOPMD varargs
     int size = SIZE_OF_INT;
     for (String s : array) {
-      size += s.length() + SIZE_OF_INT;
+      size += toByteArray(s).length; // maintains UTF-8 encoding of multi-byte chars
     }
     return size;
   }
@@ -446,7 +446,8 @@ public final class Serialization {
    */
   public static byte[] toByteArray(String string) {
     try {
-      return Bytes.concat(toByteArray(string.length()), string.getBytes("UTF-8"));
+      byte[] bytes = string.getBytes("UTF-8");
+      return Bytes.concat(toByteArray(bytes.length), bytes);
     } catch (UnsupportedEncodingException e) {
       throw new AssertionError("UTF-8 is not supported (the JVM is not to spec!)", e);
     }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/serialization/StringAdapter.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/serialization/StringAdapter.java
@@ -3,8 +3,6 @@ package edu.wpi.first.shuffleboard.api.sources.recording.serialization;
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
 import edu.wpi.first.shuffleboard.api.sources.recording.Serialization;
 
-import com.google.common.primitives.Bytes;
-
 import java.io.UnsupportedEncodingException;
 
 public class StringAdapter extends TypeAdapter<String> {
@@ -15,11 +13,7 @@ public class StringAdapter extends TypeAdapter<String> {
 
   @Override
   public byte[] serialize(String value) {
-    try {
-      return Bytes.concat(Serialization.toByteArray(value.length()), value.getBytes("UTF-8"));
-    } catch (UnsupportedEncodingException e) {
-      throw new AssertionError("UTF-8 is not supported (the JVM is not to spec!)", e);
-    }
+    return Serialization.toByteArray(value);
   }
 
   @Override
@@ -42,7 +36,7 @@ public class StringAdapter extends TypeAdapter<String> {
 
   @Override
   public int getSerializedSize(String value) {
-    return Serialization.SIZE_OF_INT + value.length();
+    return serialize(value).length;
   }
 
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/serialization/StringArrayAdapter.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/serialization/StringArrayAdapter.java
@@ -3,8 +3,6 @@ package edu.wpi.first.shuffleboard.api.sources.recording.serialization;
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
 import edu.wpi.first.shuffleboard.api.sources.recording.Serialization;
 
-import java.util.Arrays;
-
 public class StringArrayAdapter extends TypeAdapter<String[]> {
 
   public StringArrayAdapter() {
@@ -16,7 +14,7 @@ public class StringArrayAdapter extends TypeAdapter<String[]> {
     if (data.length == 0) {
       return new byte[Serialization.SIZE_OF_INT];
     }
-    byte[] buf = new byte[getSerializedSize(data)];
+    byte[] buf = new byte[Serialization.sizeOfStringArray(data)];
 
     int pos = 0;
 
@@ -48,11 +46,7 @@ public class StringArrayAdapter extends TypeAdapter<String[]> {
 
   @Override
   public int getSerializedSize(String[] value) {
-    return Serialization.SIZE_OF_INT
-        + Arrays.stream(value)
-        .mapToInt(String::length)
-        .map(i -> i + Serialization.SIZE_OF_INT)
-        .sum();
+    return serialize(value).length;
   }
 
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/serialization/StringArrayAdapter.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/serialization/StringArrayAdapter.java
@@ -37,9 +37,9 @@ public class StringArrayAdapter extends TypeAdapter<String[]> {
     cursor += Serialization.SIZE_OF_INT;
     String[] stringArray = new String[length];
     for (int i = 0; i < length; i++) {
-      String string = Serialization.decode(array, cursor, DataTypes.String);
+      String string = Serialization.readString(array, cursor);
       stringArray[i] = string;
-      cursor += Serialization.SIZE_OF_INT + string.length();
+      cursor += Serialization.SIZE_OF_INT + Serialization.readInt(array, cursor);
     }
     return stringArray;
   }

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/SerializationTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/SerializationTest.java
@@ -13,7 +13,6 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@SuppressWarnings("PMD")
 public class SerializationTest {
 
   private static final byte[] fooBarBytes = new byte[]{
@@ -23,8 +22,7 @@ public class SerializationTest {
   };
 
   // Grinning emoji, four bytes
-  @SuppressWarnings("AvoidEscapedUnicodeCharacters")
-  private static final String grinningEmoji = "\uD83D\uDE01";
+  private static final String grinningEmoji = "😁";
 
   @Test
   public void testIntToBytes() {

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/SerializationTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/SerializationTest.java
@@ -22,6 +22,10 @@ public class SerializationTest {
       0, 0, 0, 3, 'b', 'a', 'r'  // "bar", encoded with length
   };
 
+  // Grinning emoji, four bytes
+  @SuppressWarnings("AvoidEscapedUnicodeCharacters")
+  private static final String grinningEmoji = "\uD83D\uDE01";
+
   @Test
   public void testIntToBytes() {
     final int val = 0x007F10FF;
@@ -89,6 +93,28 @@ public class SerializationTest {
     Serialization.updateRecordingSave(recording, file);
     final Recording loadedUpdate = Serialization.loadRecording(file);
     assertEquals(data, loadedUpdate.getData());
+  }
+
+  @Test
+  public void testMultiByteCharsInString() {
+    String string = grinningEmoji;
+    byte[] bytes = Serialization.toByteArray(string);
+    assertEquals(8, bytes.length);
+    String read = Serialization.readString(bytes, 0);
+    assertEquals(string, read);
+  }
+
+  @Test
+  public void testMultiByteCharsInStringArray() {
+    String[] strings = {
+        "®",
+        "©",
+        grinningEmoji
+    };
+    byte[] bytes = Serialization.toByteArray(strings);
+    assertEquals(24, bytes.length);
+    String[] read = Serialization.readStringArray(bytes, 0);
+    assertArrayEquals(strings, read);
   }
 
 }


### PR DESCRIPTION
All chars were assumed to be 1 byte, causing issues with characters outside ASCII

Fixes #487