### PR TITLE
Fix regression with context menus on interactive source trees

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/LeftDrawerController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/LeftDrawerController.java
@@ -76,7 +76,11 @@ public class LeftDrawerController {
     FxUtils.runOnFxThread(() -> {
       plugin.getSourceTypes().forEach(sourceType -> {
         InteractiveSourceTree tree =
-            new InteractiveSourceTree(sourceType, addComponentToActivePane, createTabForSource);
+            new InteractiveSourceTree(
+                sourceType,
+                t -> addComponentToActivePane.accept(t),
+                t -> createTabForSource.accept(t)
+            );
 
         TitledPane titledPane = new TitledPane(sourceType.getName(), tree);
         sourcePanes.put(plugin, titledPane);

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -159,6 +159,7 @@ public class MainWindowController {
     this.dashboard.getTabs().clear(); // Lets tabs get cleaned up (e.g. cancelling deferred autopopulation calls)
     this.dashboard = dashboard;
     centerSplitPane.getItems().add(dashboard);
+    setLeftDrawerCallbacks();
   }
 
   /**


### PR DESCRIPTION
When changing the dashboard (i.e. creating a new layout or loading a saved layout), callbacks would still reference the original dashboard instead of the newly loaded one