### PR TITLE
Update ntcore dependencies to 2018.4.+

### DIFF
--- a/api/api.gradle.kts
+++ b/api/api.gradle.kts
@@ -12,9 +12,9 @@ dependencies {
     api(group = "org.fxmisc.easybind", name = "easybind", version = "1.0.3")
     api(group = "org.controlsfx", name = "controlsfx", version = "8.40.14")
     api(group = "de.codecentric.centerdevice", name = "javafxsvg", version = "1.2.1")
-    api(group = "edu.wpi.first.ntcore", name = "ntcore-java", version = "4.+")
+    api(group = "edu.wpi.first.ntcore", name = "ntcore-java", version = "2018.4.+")
     api(group = "eu.hansolo", name = "Medusa", version = "7.9") // Note the capital 'M' -- lowercase is a much older version!
     api(group = "com.cedarsoft.commons", name = "version", version = "8.3.1")
-    implementation(group = "edu.wpi.first.wpiutil", name = "wpiutil-java", version = "3.+")
-    implementation(group = "edu.wpi.first.ntcore", name = "ntcore-jni", version = "4.+", classifier = "all")
+    implementation(group = "edu.wpi.first.wpiutil", name = "wpiutil-java", version = "2018.4.+")
+    implementation(group = "edu.wpi.first.ntcore", name = "ntcore-jni", version = "2018.4.+", classifier = "all")
 }


### PR DESCRIPTION
Updates to FRC Jenkins removed the previous artifacts from the `maven-metadata.xml` files used for version resolution