### PR TITLE
Allow recordings to be controlled via NetworkTables

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recorder.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recorder.java
@@ -38,7 +38,9 @@ public final class Recorder {
   private static final Recorder instance = new Recorder();
 
   private final BooleanProperty running = new AtomicBooleanProperty(this, "running", false);
-  private final StringProperty fileNameFormat = new SimpleStringProperty(this, "fileNameFormat", DEFAULT_RECORDING_FILE_NAME_FORMAT);
+  private final StringProperty fileNameFormat =
+      new SimpleStringProperty(this, "fileNameFormat", DEFAULT_RECORDING_FILE_NAME_FORMAT);
+  private String currentFileNameFormat = DEFAULT_RECORDING_FILE_NAME_FORMAT; // NOPMD - PMD can't handle lambdas
   private Instant startTime = null;
   private Recording recording = null;
   private File recordingFile;
@@ -50,6 +52,7 @@ public final class Recorder {
     // Save the recording at the start (get the initial values) and the stop
     running.addListener((__, wasRunning, isRunning) -> {
       try {
+        currentFileNameFormat = getFileNameFormat();
         saveToDisk();
       } catch (IOException e) {
         log.log(Level.WARNING, "Could not save to disk", e);
@@ -84,7 +87,7 @@ public final class Recorder {
       // Nothing to save
       return;
     }
-    Path file = Storage.createRecordingFilePath(startTime, getFileNameFormat());
+    Path file = Storage.createRecordingFilePath(startTime, currentFileNameFormat);
     if (recordingFile == null) {
       recordingFile = file.toFile();
     }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recorder.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recorder.java
@@ -23,6 +23,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
 
 /**
  * Records data from sources. Each source is responsible for calling {@link #recordCurrentValue} whenever its value
@@ -32,9 +34,11 @@ public final class Recorder {
 
   private static final Logger log = Logger.getLogger(Recorder.class.getName());
 
+  public static final String DEFAULT_RECORDING_FILE_NAME_FORMAT = "recording-${time}";
   private static final Recorder instance = new Recorder();
 
   private final BooleanProperty running = new AtomicBooleanProperty(this, "running", false);
+  private final StringProperty fileNameFormat = new SimpleStringProperty(this, "fileNameFormat", DEFAULT_RECORDING_FILE_NAME_FORMAT);
   private Instant startTime = null;
   private Recording recording = null;
   private File recordingFile;
@@ -80,7 +84,7 @@ public final class Recorder {
       // Nothing to save
       return;
     }
-    Path file = Storage.createRecordingFilePath(startTime);
+    Path file = Storage.createRecordingFilePath(startTime, getFileNameFormat());
     if (recordingFile == null) {
       recordingFile = file.toFile();
     }
@@ -186,5 +190,17 @@ public final class Recorder {
 
   public File getRecordingFile() {
     return recordingFile;
+  }
+
+  public String getFileNameFormat() {
+    return fileNameFormat.get();
+  }
+
+  public StringProperty fileNameFormatProperty() {
+    return fileNameFormat;
+  }
+
+  public void setFileNameFormat(String fileNameFormat) {
+    this.fileNameFormat.set(fileNameFormat);
   }
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/Storage.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/Storage.java
@@ -30,8 +30,6 @@ public final class Storage {
 
   private static final String BACKUPS_DIR = STORAGE_DIR + "/backups";
 
-  private static final String RECORDING_FILE_FORMAT = RECORDING_DIR + "/${date}/recording-${time}.sbr";
-
   private static final DateTimeFormatter dateFormatter = DateTimeFormatter.ISO_DATE;
   private static final DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH.mm.ss", Locale.getDefault());
 
@@ -41,6 +39,11 @@ public final class Storage {
   private static final String PLUGINS_DIR = STORAGE_DIR + "/plugins";
 
   private static final String PLUGIN_CACHE_FILE = PLUGINS_DIR + "/.plugincache";
+
+  /**
+   * The file extension for data recordings.
+   */
+  private static final String RECORDING_FILE_EXTENSION = ".sbr";
 
   private Storage() {
   }
@@ -116,10 +119,37 @@ public final class Storage {
    * @param startTime the time the recording started
    */
   public static Path createRecordingFilePath(Instant startTime) throws IOException {
+    return createRecordingFilePath(startTime, "recording-${time}");
+  }
+
+  /**
+   * Generates a path to a recording file based on when a recording started. The generated path will always be in the
+   * directory {@code /Shuffleboard/recordings/<date>}, where {@code date} is the date formatted by the ISO-8601 format.
+   * The recording file name will be the parsed output of the {@code fileNameFormat} parameter; this format supports the
+   * following variables to be injected:
+   *
+   * <table>
+   * <tr><th>String</th><th>Value</th></tr>
+   * <tr><td>{@code ${date}}</td><td>The ISO-8601 formatted string for the date of the {@code startTime}</td></tr>
+   * <tr><td>{@code ${time}}</td><td>The time of the {@code startTime} in a "HH.mm.ss" format</td></tr>
+   * </table>
+   *
+   * <p>For example, a file name format of {@code "practice-match-${time}"} results in paths such as
+   * {@code /Shuffleboard/recordings/2019-03-16/practice-match-13.05.15.sbr}.</p>
+   * <br>
+   * The default file name format is {@code "recording-${time}"}
+   * <p>Users are <b>strongly</b> encouraged to use the {@code ${time}} variable to make sure that recording files
+   * have unique names, or otherwise set a new file name format every time recording starts.</p>
+   *
+   * @param startTime      the time the recording started
+   * @param fileNameFormat a custom format for the name of the recording file
+   */
+  public static Path createRecordingFilePath(Instant startTime, String fileNameFormat) throws IOException {
     String date = dateFormatter.format(LocalDateTime.ofInstant(startTime, ZoneId.systemDefault()));
     String time = timeFormatter.format(LocalDateTime.ofInstant(startTime, ZoneId.systemDefault()));
 
-    Path file = Paths.get(RECORDING_FILE_FORMAT
+    String filePathFormat = RECORDING_DIR + "/${date}/" + fileNameFormat + RECORDING_FILE_EXTENSION;
+    Path file = Paths.get(filePathFormat
         .replace("${date}", date)
         .replace("${time}", time));
 

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -108,8 +108,6 @@ public class Shuffleboard extends Application {
     notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading base plugin", 0.125));
     PluginLoader.getDefault().load(new BasePlugin());
 
-    Recorder.getInstance().start();
-
     notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading NetworkTables plugin", 0.25));
     PluginLoader.getDefault().load(new NetworkTablesPlugin());
     notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading CameraServer plugin", 0.375));

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -1,7 +1,6 @@
 package edu.wpi.first.shuffleboard.app;
 
 import edu.wpi.first.shuffleboard.api.sources.recording.Converters;
-import edu.wpi.first.shuffleboard.api.sources.recording.Recorder;
 import edu.wpi.first.shuffleboard.api.theme.Themes;
 import edu.wpi.first.shuffleboard.api.util.ShutdownHooks;
 import edu.wpi.first.shuffleboard.api.util.Storage;

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/CameraServerPlugin.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/CameraServerPlugin.java
@@ -27,10 +27,10 @@ import java.util.logging.Logger;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "CameraServer",
-    version = "1.2.0",
+    version = "2.0.0",
     summary = "Provides sources and widgets for viewing CameraServer MJPEG streams"
 )
-@Requires(group = "edu.wpi.first.shuffleboard", name = "NetworkTables", minVersion = "1.0.0")
+@Requires(group = "edu.wpi.first.shuffleboard", name = "NetworkTables", minVersion = "2.0.0")
 public class CameraServerPlugin extends Plugin {
 
   private static final Logger log = Logger.getLogger(CameraServerPlugin.class.getName());

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/RecorderController.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/RecorderController.java
@@ -1,0 +1,91 @@
+package edu.wpi.first.shuffleboard.plugin.networktables;
+
+import edu.wpi.first.shuffleboard.api.DashboardMode;
+import edu.wpi.first.shuffleboard.api.sources.recording.Recorder;
+
+import edu.wpi.first.networktables.EntryListenerFlags;
+import edu.wpi.first.networktables.EntryNotification;
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
+
+/**
+ * Controls the {@link Recorder Shuffleboard data recorder} in response to changes in NetworkTables. Changes to the
+ * file name format entry will only take effect when the next recording starts, to avoid splitting data across multiple
+ * recording files.
+ */
+public final class RecorderController {
+
+  public static final String DEFAULT_RECORDING_ROOT_TABLE = "/Shuffleboard/.recording";
+  public static final String DEFAULT_START_STOP_KEY = DEFAULT_RECORDING_ROOT_TABLE + "/RecordData";
+  public static final String DEFAULT_FILE_NAME_FORMAT_KEY = DEFAULT_RECORDING_ROOT_TABLE + "/FileNameFormat";
+
+  private final NetworkTableEntry startStopControlEntry;
+  private final NetworkTableEntry fileNameFormatEntry;
+
+  private static final int updateFlags =
+      EntryListenerFlags.kImmediate
+          | EntryListenerFlags.kLocal
+          | EntryListenerFlags.kNew
+          | EntryListenerFlags.kDelete
+          | EntryListenerFlags.kUpdate;
+
+  private int listenerHandle = 0;
+
+  /**
+   * Creates a new recorder controller using the default entries {@link #DEFAULT_START_STOP_KEY} and
+   * {@link #DEFAULT_FILE_NAME_FORMAT_KEY}.
+   *
+   * @param ntInstance the NetworkTable instance to connect to
+   *
+   * @return a new recorder controller listening to the default entries
+   */
+  public static RecorderController createWithDefaultEntries(NetworkTableInstance ntInstance) {
+    return new RecorderController(ntInstance, DEFAULT_START_STOP_KEY, DEFAULT_FILE_NAME_FORMAT_KEY);
+  }
+
+  /**
+   * Creates a new recorder controller.
+   *
+   * @param ntInstance        the NetworkTable instance to connect to
+   * @param startStopKey      the key for the entry used to control the state of the recorder. The entry must contain
+   *                          boolean values for any action to be taken
+   * @param fileNameFormatKey the key for the entry used to control the file names of recording files. The entry must
+   *                          contain a String value for it to be used
+   */
+  public RecorderController(NetworkTableInstance ntInstance, String startStopKey, String fileNameFormatKey) {
+    this.startStopControlEntry = ntInstance.getEntry(startStopKey);
+    fileNameFormatEntry = ntInstance.getEntry(fileNameFormatKey);
+  }
+
+  /**
+   * Starts this controller. If the control entry is set, the recorder will immediately start if it is not already
+   * running.
+   */
+  public void start() {
+    listenerHandle = startStopControlEntry.addListener(this::updateControl, updateFlags);
+  }
+
+  /**
+   * Stops this controller. This does NOT stop the data recorder if it is running.
+   */
+  public void stop() {
+    startStopControlEntry.removeListener(listenerHandle);
+  }
+
+  /**
+   * Updates the state of the data recorder in response to a change to the networktable control entry. If the entry
+   * does not contain a boolean value, or if Shuffleboard is in data playback mode, this method will do nothing.
+   *
+   * @param event the network table event
+   */
+  private void updateControl(EntryNotification event) {
+    if (event.value.isBoolean() && !DashboardMode.inPlayback()) {
+      if (event.value.getBoolean()) {
+        Recorder.getInstance().setFileNameFormat(fileNameFormatEntry.getString(Recorder.DEFAULT_RECORDING_FILE_NAME_FORMAT));
+        Recorder.getInstance().start();
+      } else {
+        Recorder.getInstance().stop();
+      }
+    }
+  }
+}

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/RecorderController.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/RecorderController.java
@@ -81,7 +81,8 @@ public final class RecorderController {
   private void updateControl(EntryNotification event) {
     if (event.value.isBoolean() && !DashboardMode.inPlayback()) {
       if (event.value.getBoolean()) {
-        Recorder.getInstance().setFileNameFormat(fileNameFormatEntry.getString(Recorder.DEFAULT_RECORDING_FILE_NAME_FORMAT));
+        Recorder.getInstance().setFileNameFormat(
+            fileNameFormatEntry.getString(Recorder.DEFAULT_RECORDING_FILE_NAME_FORMAT));
         Recorder.getInstance().start();
       } else {
         Recorder.getInstance().stop();

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/RecorderController.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/RecorderController.java
@@ -21,6 +21,7 @@ public final class RecorderController {
 
   private final NetworkTableEntry startStopControlEntry;
   private final NetworkTableEntry fileNameFormatEntry;
+  private final Recorder recorder;
 
   private static final int updateFlags =
       EntryListenerFlags.kImmediate
@@ -40,7 +41,8 @@ public final class RecorderController {
    * @return a new recorder controller listening to the default entries
    */
   public static RecorderController createWithDefaultEntries(NetworkTableInstance ntInstance) {
-    return new RecorderController(ntInstance, DEFAULT_START_STOP_KEY, DEFAULT_FILE_NAME_FORMAT_KEY);
+    return new RecorderController(
+        ntInstance, DEFAULT_START_STOP_KEY, DEFAULT_FILE_NAME_FORMAT_KEY, Recorder.getInstance());
   }
 
   /**
@@ -51,10 +53,15 @@ public final class RecorderController {
    *                          boolean values for any action to be taken
    * @param fileNameFormatKey the key for the entry used to control the file names of recording files. The entry must
    *                          contain a String value for it to be used
+   * @param recorder          the recorder to control
    */
-  public RecorderController(NetworkTableInstance ntInstance, String startStopKey, String fileNameFormatKey) {
-    this.startStopControlEntry = ntInstance.getEntry(startStopKey);
+  public RecorderController(NetworkTableInstance ntInstance,
+                            String startStopKey,
+                            String fileNameFormatKey,
+                            Recorder recorder) {
+    startStopControlEntry = ntInstance.getEntry(startStopKey);
     fileNameFormatEntry = ntInstance.getEntry(fileNameFormatKey);
+    this.recorder = recorder;
   }
 
   /**
@@ -81,11 +88,10 @@ public final class RecorderController {
   private void updateControl(EntryNotification event) {
     if (event.value.isBoolean() && !DashboardMode.inPlayback()) {
       if (event.value.getBoolean()) {
-        Recorder.getInstance().setFileNameFormat(
-            fileNameFormatEntry.getString(Recorder.DEFAULT_RECORDING_FILE_NAME_FORMAT));
-        Recorder.getInstance().start();
+        recorder.setFileNameFormat(fileNameFormatEntry.getString(Recorder.DEFAULT_RECORDING_FILE_NAME_FORMAT));
+        recorder.start();
       } else {
-        Recorder.getInstance().stop();
+        recorder.stop();
       }
     }
   }

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGenerator.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGenerator.java
@@ -173,7 +173,7 @@ final class TabGenerator {
       // Not enough data
       return;
     }
-    if (NetworkTable.basenameKey(event.name).charAt(0) == '.') {
+    if (event.name.contains("/.") || event.name.charAt(0) == '.') {
       // Metadata changed; we don't need to worry about it
       return;
     }

--- a/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/RecorderControllerTest.java
+++ b/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/RecorderControllerTest.java
@@ -1,0 +1,98 @@
+package edu.wpi.first.shuffleboard.plugin.networktables;
+
+import edu.wpi.first.shuffleboard.api.DashboardMode;
+import edu.wpi.first.shuffleboard.api.sources.recording.Recorder;
+import edu.wpi.first.shuffleboard.plugin.networktables.util.NetworkTableUtils;
+
+import edu.wpi.first.networktables.NetworkTableInstance;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testfx.framework.junit5.ApplicationTest;
+
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class RecorderControllerTest extends ApplicationTest {
+
+  private static final Logger log = Logger.getLogger(RecorderControllerTest.class.getName());
+
+  private NetworkTableInstance ntInstance;
+  private Recorder recorder;
+  private RecorderController controller;
+
+  @BeforeEach
+  public void setup() {
+    ntInstance = NetworkTableInstance.create();
+    ntInstance.setUpdateRate(0.01);
+    recorder = Recorder.createDummyInstance();
+    controller = new RecorderController(
+        ntInstance,
+        RecorderController.DEFAULT_START_STOP_KEY,
+        RecorderController.DEFAULT_FILE_NAME_FORMAT_KEY,
+        recorder
+    );
+  }
+
+  @AfterEach
+  public void tearDownNetworktables() {
+    NetworkTableUtils.shutdown(ntInstance);
+    DashboardMode.setCurrentMode(DashboardMode.NORMAL);
+  }
+
+  @Test
+  public void testSetOnStartup() {
+    final String format = "already-set-when-connected-${time}";
+    ntInstance.getEntry(RecorderController.DEFAULT_START_STOP_KEY).setBoolean(true);
+    ntInstance.getEntry(RecorderController.DEFAULT_FILE_NAME_FORMAT_KEY).setString(format);
+    controller.start();
+    sleep(20, TimeUnit.MILLISECONDS); // wait for nt events
+    assertAll(
+        () -> assertTrue(recorder.isRunning(), "Recorder should be running"),
+        () -> assertEquals(format, recorder.getFileNameFormat(), "File name format should have been set")
+    );
+  }
+
+  @Test
+  public void testStartWhenEntryUpdates() {
+    controller.start();
+    ntInstance.getEntry(RecorderController.DEFAULT_START_STOP_KEY).setBoolean(true);
+    sleep(20, TimeUnit.MILLISECONDS);
+    assertTrue(recorder.isRunning(), "Recorder should have been started");
+  }
+
+  @Test
+  public void testNoUpdatesWhenNotRunning() {
+    controller.start();
+    controller.stop();
+    sleep(20, TimeUnit.MILLISECONDS);
+    ntInstance.getEntry(RecorderController.DEFAULT_START_STOP_KEY).setBoolean(true);
+    assertFalse(recorder.isRunning(), "Recording should not be running");
+  }
+
+  @Test
+  public void testStopsRecorder() {
+    controller.start();
+    ntInstance.getEntry(RecorderController.DEFAULT_START_STOP_KEY).setBoolean(true);
+    sleep(20, TimeUnit.MILLISECONDS);
+    assertTrue(recorder.isRunning());
+    ntInstance.getEntry(RecorderController.DEFAULT_START_STOP_KEY).setBoolean(false);
+    sleep(20, TimeUnit.MILLISECONDS);
+    assertFalse(recorder.isRunning(), "Recorder should have been stopped");
+  }
+
+  @Test
+  public void testDoNothingIfInPlayBack() {
+    controller.start();
+    DashboardMode.setCurrentMode(DashboardMode.PLAYBACK);
+    ntInstance.getEntry(RecorderController.DEFAULT_START_STOP_KEY).setBoolean(true);
+    sleep(20, TimeUnit.MILLISECONDS);
+    assertFalse(recorder.isRunning(), "Recorder should not have been started");
+  }
+}


### PR DESCRIPTION
| Key| Type | Effect |
|---|---|---|
| `/Shuffleboard/.reccording/RecordData` | `boolean` | Set to `true` to start recording (if not already running), or `false` to stop recording
| `/Shuffleboard/.recording/FileNameFormat` | `String` | Format for the file name for recordings. Recordings are still stored in `~/Shuffleboard/recordings/<date>`

Recording is changed to be _inactive_ by default. Users must either start recording manually through the UI, or set the `RecordData` entry to `true` from their robot program or OutlineViewer. Support in WPILib is planned for after wpilibsuite/allwpilib#1022 is merged

Custom plugins can set the recording file name format with `Recorder.getInstance().setFileNameFormat`.  
Setting the file name format while the recorder is running will have no effect on the current recording, but the next recording will use the new format.

Closes #360 
Closes #382