### PR TITLE
Make source trees filterable

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/FilterableTreeItem.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/FilterableTreeItem.java
@@ -1,0 +1,114 @@
+package edu.wpi.first.shuffleboard.api.components;
+
+import edu.wpi.first.shuffleboard.api.sources.SourceEntry;
+import edu.wpi.first.shuffleboard.api.util.TypeUtils;
+
+import org.fxmisc.easybind.EasyBind;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.function.Predicate;
+
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
+import javafx.collections.transformation.SortedList;
+import javafx.scene.control.TreeItem;
+
+public class FilterableTreeItem<T extends SourceEntry> extends TreeItem<T> {
+
+  private static final Comparator<TreeItem<? extends SourceEntry>> comparator =
+      SourceTreeTable.branchesFirst
+          .thenComparing(SourceTreeTable.alphabetical);
+
+  private final Predicate<TreeItem<T>> always = item -> {
+    if (item instanceof FilterableTreeItem) {
+      ((FilterableTreeItem<T>) item).setPredicate(TreeItemPredicate.always());
+    }
+    return true;
+  };
+
+  private final ObservableList<TreeItem<T>> sourceList = FXCollections.observableArrayList();
+  private final List<TreeItem<T>> sourceCopy = new ArrayList<>();
+  private final FilteredList<TreeItem<T>> filteredList = new FilteredList<>(sourceList);
+  private final SortedList<TreeItem<T>> sortedList = new SortedList<>(filteredList, comparator);
+
+  private final ObjectProperty<TreeItemPredicate<T>> predicate = new SimpleObjectProperty<>(TreeItemPredicate.always());
+
+  @SuppressWarnings("JavadocMethod")
+  public FilterableTreeItem(T value) {
+    super(value);
+    EasyBind.listBind(sourceCopy, sourceList);
+    sortedList.setComparator(comparator);
+    filteredList.predicateProperty().bind(
+        EasyBind.monadic(predicate)
+            .map(this::createListFilter)
+            .orElse(always));
+
+    setHiddenFieldChildren(sortedList);
+  }
+
+  protected void setHiddenFieldChildren(ObservableList<TreeItem<T>> list) {
+    try {
+      Field children = TreeItem.class.getDeclaredField("children");
+      Field childrenListener = TreeItem.class.getDeclaredField("childrenListener");
+      children.setAccessible(true);
+      childrenListener.setAccessible(true);
+      children.set(this, list);
+      list.addListener((ListChangeListener<? super TreeItem<T>>) childrenListener.get(this));
+    } catch (ReflectiveOperationException e) {
+      throw new AssertionError("Could not modify internal fields", e);
+    }
+  }
+
+  public final ObservableList<TreeItem<T>> getAllChildren() {
+    return sourceList;
+  }
+
+  public final TreeItemPredicate<T> getPredicate() {
+    return predicate.get();
+  }
+
+  public final ObjectProperty<TreeItemPredicate<T>> predicateProperty() {
+    return predicate;
+  }
+
+  public final void setPredicate(TreeItemPredicate<T> predicate) {
+    this.predicate.set(predicate);
+  }
+
+  /**
+   * Recursively sorts all children of this item. Children are sorted by branches first, then alphanumerically.
+   */
+  public void sortChildren() {
+    // Forces the list to re-sort
+    sortedList.setComparator(null);
+    sortedList.setComparator(comparator);
+    sourceList.stream()
+        .flatMap(TypeUtils.castStream(FilterableTreeItem.class))
+        .forEach(FilterableTreeItem::sortChildren);
+  }
+
+  protected Predicate<TreeItem<T>> createListFilter(TreeItemPredicate<T> predicate) {
+    if (predicate == TreeItemPredicate.ALWAYS) {
+      return always;
+    }
+    return child -> {
+      if (child instanceof FilterableTreeItem) {
+        ((FilterableTreeItem<T>) child).setPredicate(predicate);
+      }
+      if (predicate == null) {
+        return true;
+      }
+      if (!child.getChildren().isEmpty()) {
+        return true;
+      }
+      return predicate.test(child.getParent(), child.getValue());
+    };
+  }
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/SourceTreeTable.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/SourceTreeTable.java
@@ -6,8 +6,6 @@ import edu.wpi.first.shuffleboard.api.sources.SourceType;
 import edu.wpi.first.shuffleboard.api.util.AlphanumComparator;
 import edu.wpi.first.shuffleboard.api.util.EqualityUtils;
 
-import org.fxmisc.easybind.EasyBind;
-
 import java.util.Comparator;
 import java.util.List;
 
@@ -56,11 +54,7 @@ public class SourceTreeTable<S extends SourceEntry, V> extends TreeTableView<S> 
         f -> new ReadOnlyStringWrapper(getEntryForCellData(f).getViewName()));
     valueColumn.setCellValueFactory(
         f -> new ReadOnlyObjectWrapper(getEntryForCellData(f).getValueView()));
-    Label placeholder = new Label();
-    placeholder.textProperty().bind(EasyBind.monadic(sourceType)
-        .map(SourceType::getName)
-        .map(n -> "No data available. Is there a connection to " + n + "?")
-        .orElse("No data available. Is the source connected?"));
+    Label placeholder = new Label("No data available");
     setPlaceholder(placeholder);
 
     getColumns().addAll(keyColumn, valueColumn);
@@ -94,8 +88,8 @@ public class SourceTreeTable<S extends SourceEntry, V> extends TreeTableView<S> 
     final SourceType sourceType = getSourceType();
     String name = entry.getName();
     List<String> hierarchy = DataSourceUtils.getHierarchy(name);
-    TreeItem<S> current = getRoot();
-    TreeItem<S> parent = current;
+    FilterableTreeItem<S> current = (FilterableTreeItem<S>) getRoot();
+    FilterableTreeItem<S> parent = current;
     boolean structureChanged = false;
 
     // Get the appropriate node for the value, creating branches as needed
@@ -103,10 +97,10 @@ public class SourceTreeTable<S extends SourceEntry, V> extends TreeTableView<S> 
     for (int i = 1; i < hierarchy.size(); i++) {
       String path = hierarchy.get(i);
       parent = current;
-      TreeItem<S> found = null;
-      for (TreeItem<S> item : current.getChildren()) {
+      FilterableTreeItem<S> found = null;
+      for (TreeItem<S> item : current.getAllChildren()) {
         if (item.getValue().getName().equals(path)) {
-          found = item;
+          found = (FilterableTreeItem<S>) item;
           break;
         }
       }
@@ -117,9 +111,9 @@ public class SourceTreeTable<S extends SourceEntry, V> extends TreeTableView<S> 
       } else if (!deleted && i < hierarchy.size() - 1 && current == null) {
         // It's a branch (subtable); expand it
         S newEntry = (S) sourceType.createSourceEntryForUri(sourceType.toUri(path));
-        current = new TreeItem<>(newEntry);
+        current = new FilterableTreeItem<>(newEntry);
         current.setExpanded(true);
-        parent.getChildren().add(current);
+        parent.getAllChildren().add(current);
         structureChanged = true;
       }
     }
@@ -127,15 +121,15 @@ public class SourceTreeTable<S extends SourceEntry, V> extends TreeTableView<S> 
     // Remove, update, or create the value node as needed
     if (deleted) {
       if (current != null) {
-        parent.getChildren().remove(current);
+        parent.getAllChildren().remove(current);
 
         // Remove empty subtrees
-        if (parent.getChildren().isEmpty()) {
-          TreeItem<S> item = parent.getParent();
+        if (parent.getAllChildren().isEmpty()) {
+          FilterableTreeItem<S> item = (FilterableTreeItem<S>) parent.getParent();
           while (item != null) {
-            item.getChildren().remove(parent);
+            item.getAllChildren().remove(parent);
             parent = item;
-            item = item.getParent();
+            item = (FilterableTreeItem<S>) item.getParent();
           }
         }
         structureChanged = true;
@@ -143,9 +137,9 @@ public class SourceTreeTable<S extends SourceEntry, V> extends TreeTableView<S> 
     } else {
       if (current == null) {
         // Newly added value, create a tree item for it
-        current = new TreeItem<>(entry);
+        current = new FilterableTreeItem<>(entry);
         current.setExpanded(true);
-        parent.getChildren().add(current);
+        parent.getAllChildren().add(current);
         structureChanged = true;
       } else if (EqualityUtils.isDifferent(current.getValue().getValue(), entry.getValue())) {
         // The value updated, so just update the existing node
@@ -153,12 +147,11 @@ public class SourceTreeTable<S extends SourceEntry, V> extends TreeTableView<S> 
       }
     }
     if (structureChanged) {
-      sort();
+      ((FilterableTreeItem<S>) getRoot()).sortChildren();
     }
   }
 
-  protected static <T> T getEntryForCellData(
-      TreeTableColumn.CellDataFeatures<T, ?> features) {
+  protected static <T> T getEntryForCellData(TreeTableColumn.CellDataFeatures<T, ?> features) {
     return features.getValue().getValue();
   }
 

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/TreeItemPredicate.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/TreeItemPredicate.java
@@ -1,0 +1,28 @@
+package edu.wpi.first.shuffleboard.api.components;
+
+import java.util.function.Predicate;
+
+import javafx.scene.control.TreeItem;
+
+@FunctionalInterface
+public interface TreeItemPredicate<T> {
+
+  TreeItemPredicate ALWAYS = (parent, value) -> true;
+
+  TreeItemPredicate NEVER = (parent, value) -> false;
+
+  boolean test(TreeItem<T> parent, T value);
+
+  static <T> TreeItemPredicate<T> always() {
+    return ALWAYS;
+  }
+
+  static <T> TreeItemPredicate<T> never() {
+    return NEVER;
+  }
+
+  static <T> TreeItemPredicate<T> fromPredicate(Predicate<? super T> predicate) {
+    return (parent, value) -> predicate.test(value);
+  }
+
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/StringUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/StringUtils.java
@@ -1,0 +1,56 @@
+package edu.wpi.first.shuffleboard.api.util;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+public final class StringUtils {
+
+  private StringUtils() {
+    throw new UnsupportedOperationException("This is a utility class!");
+  }
+
+  /**
+   * Checks if the base string contains the test string, ignoring uppercase/lowercase differences (using the American
+   * English definitions of "upper" and "lower" case).
+   *
+   * @param base the base text to search in
+   * @param test the string to search for
+   *
+   * @return true if {@code base} contains {@code test}, ignoring case differences
+   */
+  public static boolean containsIgnoreCase(String base, String test) {
+    return base.toLowerCase(Locale.US).contains(test.toLowerCase(Locale.US));
+  }
+
+  /**
+   * Generates a string representation of any object. This supports {@code null}, primitives, arrays, primitive arrays,
+   * and multi-dimensioned arrays of any type.
+   */
+  public static String deepToString(Object object) {
+    if (object == null) {
+      return "null";
+    }
+    if (object instanceof Object[]) {
+      return Arrays.deepToString((Object[]) object);
+    } else if (object instanceof byte[]) {
+      return Arrays.toString((byte[]) object);
+    } else if (object instanceof char[]) {
+      return Arrays.toString((char[]) object);
+    } else if (object instanceof short[]) {
+      return Arrays.toString((short[]) object);
+    } else if (object instanceof int[]) {
+      return Arrays.toString((int[]) object);
+    } else if (object instanceof long[]) {
+      return Arrays.toString((long[]) object);
+    } else if (object instanceof float[]) {
+      return Arrays.toString((float[]) object);
+    } else if (object instanceof double[]) {
+      return Arrays.toString((double[]) object);
+    } else if (object instanceof boolean[]) {
+      return Arrays.toString((boolean[]) object);
+    } else {
+      return object.toString();
+    }
+  }
+
+}

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/components/SourceTreeTableTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/components/SourceTreeTableTest.java
@@ -22,7 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class SourceTreeTableTest extends ApplicationTest {
 
   private final SourceType sourceType = new MockSourceType();
-  private final TreeItem<SourceEntry> root = new TreeItem<>(sourceType.createRootSourceEntry());
+  private final TreeItem<SourceEntry> root = new FilterableTreeItem<>(sourceType.createRootSourceEntry());
   private SourceTreeTable<SourceEntry, ?> tree;
 
   @Override

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/util/StringUtilsTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/util/StringUtilsTest.java
@@ -1,0 +1,47 @@
+package edu.wpi.first.shuffleboard.api.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class StringUtilsTest {
+
+  @ParameterizedTest()
+  @MethodSource("deepToStringArgs")
+  public void testDeepToString(Object object, String expected) {
+    assertEquals(expected, StringUtils.deepToString(object));
+  }
+
+  public static Stream<Arguments> deepToStringArgs() {
+    return Stream.of(
+        Arguments.of(null, "null"),
+        Arguments.of("a string", "a string"),
+        Arguments.of(1, "1"),
+        Arguments.of(1.234, "1.234"),
+        Arguments.of(new int[]{1, 2, 3}, "[1, 2, 3]"),
+        Arguments.of(new double[]{0, 10}, "[0.0, 10.0]"),
+        Arguments.of(new long[][]{{1, 2, 3}, {4, 5, 6}}, "[[1, 2, 3], [4, 5, 6]]"),
+        Arguments.of(new boolean[][][]{{{true}, {false}}, {{true}}}, "[[[true], [false]], [[true]]]")
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("containsArgs")
+  public void testContainsIgnoreCase(String base, String test, boolean expectedResult) {
+    assertEquals(expectedResult, StringUtils.containsIgnoreCase(base, test));
+  }
+
+  public static Stream<Arguments> containsArgs() {
+    return Stream.of(
+        Arguments.of("", "", true),
+        Arguments.of("lower", "low", true),
+        Arguments.of("UPPER", "ppe", true),
+        Arguments.of("lower", "OW", true)
+    );
+  }
+
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/InteractiveSourceTree.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/InteractiveSourceTree.java
@@ -1,5 +1,6 @@
 package edu.wpi.first.shuffleboard.app.components;
 
+import edu.wpi.first.shuffleboard.api.components.FilterableTreeItem;
 import edu.wpi.first.shuffleboard.api.components.SourceTreeTable;
 import edu.wpi.first.shuffleboard.api.dnd.DataFormats;
 import edu.wpi.first.shuffleboard.api.sources.DataSource;
@@ -13,7 +14,6 @@ import edu.wpi.first.shuffleboard.api.widget.Components;
 import java.util.List;
 import java.util.function.Consumer;
 
-import javafx.collections.FXCollections;
 import javafx.collections.MapChangeListener;
 import javafx.scene.control.ContextMenu;
 import javafx.scene.control.MenuItem;
@@ -48,9 +48,8 @@ public final class InteractiveSourceTree extends SourceTreeTable<SourceEntry, Ob
     super();
     this.addComponentToActiveTab = addComponentToActiveTab;
     setSourceType(sourceType);
-    setRoot(new TreeItem<>(sourceType.createRootSourceEntry()));
+    setRoot(new FilterableTreeItem<>(sourceType.createRootSourceEntry()));
     setShowRoot(false);
-    setSortPolicy(__ -> sortTree(getRoot()));
     getSelectionModel().selectedItemProperty().addListener((__, oldItem, newItem) -> {
       selectedEntry = newItem == null ? null : newItem.getValue();
     });
@@ -104,20 +103,6 @@ public final class InteractiveSourceTree extends SourceTreeTable<SourceEntry, Ob
         .forEach(this::updateEntry);
   }
 
-  /**
-   * Sorts tree nodes recursively in order of branches before leaves, then alphabetically.
-   *
-   * @param root the root node to sort
-   */
-  private boolean sortTree(TreeItem<SourceEntry> root) {
-    if (!root.isLeaf()) {
-      FXCollections.sort(root.getChildren(),
-          branchesFirst.thenComparing(alphabetical));
-      root.getChildren().forEach(this::sortTree);
-    }
-    return true;
-  }
-
   private void makeSourceRowDraggable(TreeTableRow<? extends SourceEntry> row) {
     row.setOnDragDetected(event -> {
       if (selectedEntry == null) {
@@ -136,6 +121,10 @@ public final class InteractiveSourceTree extends SourceTreeTable<SourceEntry, Ob
       Components.getDefault().createComponent(componentName, source)
           .ifPresent(addComponentToActiveTab);
     });
+  }
+
+  public FilterableTreeItem<SourceEntry> getFilterableRoot() {
+    return (FilterableTreeItem<SourceEntry>) super.getRoot();
   }
 
 }


### PR DESCRIPTION
Adds a search field at the bottom of every sources tree. The text is matched against the data source name, its full URI, and the contents of the data in the source. 

# Screenshots

**No search text**
![image](https://user-images.githubusercontent.com/6320992/44357698-b426a200-a480-11e8-99e8-f4693632efdf.png)

**Searching for "mecanum"**
![image](https://user-images.githubusercontent.com/6320992/44357702-b8eb5600-a480-11e8-8d8b-f609af323439.png)
