### PR TITLE
Make builds for single platforms

### DIFF
--- a/api/api.gradle.kts
+++ b/api/api.gradle.kts
@@ -13,5 +13,5 @@ dependencies {
     api(group = "org.controlsfx", name = "controlsfx", version = "8.40.14")
     api(group = "de.codecentric.centerdevice", name = "javafxsvg", version = "1.2.1")
     api(group = "eu.hansolo", name = "Medusa", version = "7.9") // Note the capital 'M' -- lowercase is a much older version!
-    api(group = "com.cedarsoft.commons", name = "version", version = "8.3.1")
+    api(group = "com.github.zafarkhaja", name = "java-semver", version = "0.9.0")
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/plugin/Plugin.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/plugin/Plugin.java
@@ -13,7 +13,8 @@ import edu.wpi.first.shuffleboard.api.theme.Theme;
 import edu.wpi.first.shuffleboard.api.util.Storage;
 import edu.wpi.first.shuffleboard.api.widget.ComponentType;
 
-import com.cedarsoft.version.Version;
+import com.github.zafarkhaja.semver.ParseException;
+import com.github.zafarkhaja.semver.Version;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -71,7 +72,7 @@ public class Plugin {
 
     this.groupId = description.group();
     this.name = description.name();
-    this.version = Version.parse(description.version());
+    this.version = Version.valueOf(description.version());
     this.summary = description.summary();
   }
 
@@ -98,9 +99,10 @@ public class Plugin {
     }
     String version = description.version();
     try {
-      Version.parse(version);
-    } catch (IllegalArgumentException e) {
-      throw new InvalidPluginDefinitionException("The version string does not follow semantic versioning", e);
+      Version.valueOf(version);
+    } catch (IllegalArgumentException | ParseException e) {
+      throw new InvalidPluginDefinitionException(
+          "The version string '" + version + "' does not follow semantic versioning", e);
     }
   }
 

--- a/app/app.gradle.kts
+++ b/app/app.gradle.kts
@@ -27,7 +27,6 @@ dependencies {
     compile(project(path = ":plugins:powerup"))
     compile(group = "de.huxhorn.lilith", name = "de.huxhorn.lilith.3rdparty.junique", version = "1.0.4")
     compile(group = "com.github.samcarlberg", name = "update-checker", version = "+")
-    compile(group = "com.github.zafarkhaja", name = "java-semver", version = "0.9.0")
     compile(group = "org.apache.commons", name = "commons-csv", version = "1.5")
     testCompile(project("test_plugins"))
 }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoaderHelper.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoaderHelper.java
@@ -1,0 +1,94 @@
+package edu.wpi.first.shuffleboard.app.plugin;
+
+import edu.wpi.first.shuffleboard.api.plugin.Description;
+import edu.wpi.first.shuffleboard.api.plugin.InvalidPluginDefinitionException;
+import edu.wpi.first.shuffleboard.api.plugin.Plugin;
+import edu.wpi.first.shuffleboard.api.plugin.Requirements;
+import edu.wpi.first.shuffleboard.api.plugin.Requires;
+
+import com.github.zafarkhaja.semver.Version;
+import com.google.common.annotations.VisibleForTesting;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Helper class for {@link PluginLoader}.
+ */
+final class PluginLoaderHelper {
+
+  private static final Logger log = Logger.getLogger(PluginLoaderHelper.class.getName());
+
+  private PluginLoaderHelper() {
+    throw new UnsupportedOperationException("This is a utility class");
+  }
+
+  static Stream<Class<?>> tryLoadClass(String name, ClassLoader classLoader) {
+    try {
+      return Stream.of(Class.forName(name, false, classLoader));
+    } catch (ClassNotFoundException e) {
+      log.log(Level.WARNING, "Could not load class for name '" + name + "' with classloader " + classLoader, e);
+      return Stream.empty();
+    }
+  }
+
+  /**
+   * Gets the description of a plugin.
+   *
+   * @param pluginClass the class to get the description of
+   *
+   * @return the description of a plugin
+   *
+   * @throws InvalidPluginDefinitionException if the plugin class does not have a {@code @Description} annotation
+   */
+  static Description getDescription(Class<? extends Plugin> pluginClass)
+      throws InvalidPluginDefinitionException {
+    if (pluginClass.isAnnotationPresent(Description.class)) {
+      return pluginClass.getAnnotation(Description.class);
+    } else {
+      // Shouldn't happen; the plugin should have been validated earlier
+      throw new InvalidPluginDefinitionException("A plugin MUST have a @Description annotation");
+    }
+  }
+
+  /**
+   * Gets all the <i>direct requirements</i> of a plugin by extracting that data from any present
+   * {@link Requirements @Requirements} and {@link Requires @Requires} annotations on the class.
+   *
+   * @param pluginClass the plugin class to get the dependencies of
+   *
+   * @return a list of the direct plugin requirements of a plugin class
+   */
+  static List<Requires> getRequirements(Class<? extends Plugin> pluginClass) {
+    Requirements requirements = pluginClass.getAnnotation(Requirements.class);
+    Requires[] requires = pluginClass.getAnnotationsByType(Requires.class);
+    return Stream.concat(
+        Stream.of(requirements)
+            .filter(Objects::nonNull)
+            .map(Requirements::value)
+            .flatMap(Stream::of),
+        Stream.of(requires)
+    ).collect(Collectors.toList());
+  }
+
+  /**
+   * Checks if version <tt>A</tt> is a backwards-compatible with version <tt>B</tt>; that is, something that depends on
+   * version <tt>B</tt> will still function when version <tt>A</tt> is present. This assumes that the versioning scheme
+   * strictly follows semantic versioning guidelines and increments the major number whenever the API has a change that
+   * breaks backwards compatibility.
+   *
+   * @param versionA the newer version
+   * @param versionB the older version
+   *
+   * @return true if version <tt>A</tt> is backwards compatible with version <tt>B</tt>
+   */
+  @VisibleForTesting
+  static boolean isCompatible(Version versionA, Version versionB) {
+    return versionA.equals(versionB)
+        || (versionA.getMajorVersion() == versionB.getMajorVersion() && versionA.compareTo(versionB) >= 0);
+  }
+}

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/json/WidgetSaverTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/json/WidgetSaverTest.java
@@ -16,7 +16,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -167,7 +166,7 @@ public class WidgetSaverTest extends ApplicationTest {
 
     // Test loading
     Widget read = gson.fromJson(jsonObject, Widget.class);
-    Assertions.assertThat(read).isExactlyInstanceOf(WidgetWithSavedProperties.class);
+    assertEquals(WidgetWithSavedProperties.class, read.getClass());
 
     WidgetWithSavedProperties actualRead = (WidgetWithSavedProperties) read;
 
@@ -199,7 +198,7 @@ public class WidgetSaverTest extends ApplicationTest {
 
     // Test loading
     Widget read = gson.fromJson(jsonObject, Widget.class);
-    Assertions.assertThat(read).isExactlyInstanceOf(WidgetSavingPropertiesFromFields.class);
+    assertEquals(WidgetSavingPropertiesFromFields.class, read.getClass());
 
     WidgetSavingPropertiesFromFields actualRead = (WidgetSavingPropertiesFromFields) read;
 

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoaderTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoaderTest.java
@@ -18,7 +18,7 @@ import edu.wpi.first.shuffleboard.app.tab.TabInfoRegistry;
 import edu.wpi.first.shuffleboard.testplugins.BasicPlugin;
 import edu.wpi.first.shuffleboard.testplugins.DependentOnUnknownPlugin;
 
-import com.cedarsoft.version.Version;
+import com.github.zafarkhaja.semver.Version;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
@@ -239,44 +239,44 @@ public class PluginLoaderTest {
 
   @Test
   public void testVersionCompatibilitySameMajor() {
-    Version lower = new Version(1, 0, 0);
-    Version higher = new Version(1, 1, 0);
+    Version lower = Version.forIntegers(1, 0, 0);
+    Version higher = Version.forIntegers(1, 1, 0);
     assertAll(() ->
         assertTrue(
-            PluginLoader.isCompatible(higher, lower),
+            PluginLoaderHelper.isCompatible(higher, lower),
             "Version " + higher + " should be backward compatible with version " + lower
         ), () ->
         assertFalse(
-            PluginLoader.isCompatible(lower, higher),
+            PluginLoaderHelper.isCompatible(lower, higher),
             "Version " + lower + " should not be backward compatible with version " + higher
         ));
   }
 
   @Test
   public void testVersionCompatibilityDifferentMajor() {
-    Version lower = new Version(1, 1, 0);
-    Version higher = new Version(lower.getMajor() + 1, 1, 0);
+    Version lower = Version.forIntegers(1, 1, 0);
+    Version higher = Version.forIntegers(lower.getMajorVersion() + 1, 1, 0);
     assertAll(() ->
         assertFalse(
-            PluginLoader.isCompatible(higher, lower),
+            PluginLoaderHelper.isCompatible(higher, lower),
             "Version " + higher + " should not be backward compatible with version " + lower
         ), () ->
         assertFalse(
-            PluginLoader.isCompatible(lower, higher),
+            PluginLoaderHelper.isCompatible(lower, higher),
             "Version " + lower + " should not be backward compatible with version " + higher
         ));
   }
 
   @Test
   public void testVersionCompatibilitySameVersion() {
-    Version version = new Version(1, 0, 0);
-    Version same = new Version(version.getMajor(), version.getMinor(), version.getBuild());
+    Version version = Version.forIntegers(1, 0, 0);
+    Version same = Version.forIntegers(version.getMajorVersion(), version.getMinorVersion(), version.getPatchVersion());
     assertTrue(
-        PluginLoader.isCompatible(version, same),
+        PluginLoaderHelper.isCompatible(version, same),
         "Identical versions should always be compatible"
     );
     assertTrue(
-        PluginLoader.isCompatible(same, version),
+        PluginLoaderHelper.isCompatible(same, version),
         "Identical versions should always be compatible"
     );
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,28 +100,6 @@ allprojects {
     }
 }
 
-val currentPlatform: String
-    get() {
-        val os: String = when {
-            System.getProperty("os.name").contains("windows", true) -> "win"
-            System.getProperty("os.name").contains("mac", true) -> "mac"
-            System.getProperty("os.name").contains("linux", true) -> "linux"
-            else -> throw UnsupportedOperationException("Unknown OS: ${System.getProperty("os.name")}")
-        }
-        val osarch = System.getProperty("os.arch")
-        var arch: String =
-                if (osarch.contains("x86_64") || osarch.contains("amd64")) {
-                    "64"
-                } else if (osarch.contains("x86")) {
-                    "32"
-                } else {
-                    throw UnsupportedOperationException(osarch)
-                }
-        return os + arch
-    }
-
-println("Current OS: $currentPlatform")
-
 allprojects {
     apply {
         plugin("java")

--- a/buildSrc/README.md
+++ b/buildSrc/README.md
@@ -1,0 +1,4 @@
+# buildsrc
+
+This directory contains shared code for all subproject buildscripts to reduce code duplication. All subproject build
+scripts load the Kotlin files in `src/main/kotlin` automatically.

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    `kotlin-dsl`
+}

--- a/buildSrc/src/main/kotlin/PlatformMapper.kt
+++ b/buildSrc/src/main/kotlin/PlatformMapper.kt
@@ -1,0 +1,62 @@
+/**
+ * The platform performing the build. This is in the format `"<os.name><os.arch>"`, e.g. `win32`, `mac64`, `linux64`.
+ */
+val currentPlatform: String by lazy {
+    val osName = System.getProperty("os.name")
+    val os: String = when {
+        osName.contains("windows", true) -> "win"
+        osName.contains("mac", true) -> "mac"
+        osName.contains("linux", true) -> "linux"
+        else -> throw UnsupportedOperationException("Unknown OS: $osName")
+    }
+    val osArch = System.getProperty("os.arch")
+    val arch: String =
+            if (osArch.contains("x86_64") || osArch.contains("amd64")) {
+                "64"
+            } else if (osArch.contains("x86")) {
+                "32"
+            } else {
+                throw UnsupportedOperationException(osArch)
+            }
+    os + arch
+}
+
+/**
+ * Generates a classifier string for a platform-specific WPILib native library.
+ *
+ * @param platform the platform string to get the WPILib classifier for. Platform strings should be one of:
+ * - win32
+ * - win64
+ * - mac64
+ * - linux32
+ * - linux64
+ * Note that WPILib typically only has builds for win32, win64, mac64, and linux64
+ */
+fun wpilibClassifier(platform: String) = when (platform) {
+    "win32" -> "windowsx86"
+    "win64" -> "windowsx86-64"
+    "mac64" -> "osxx86-64"
+    // No 32-bit Linux support
+    "linux64" -> "linuxx86-64"
+    else -> throw UnsupportedOperationException("WPILib does not support the '$platform' platform")
+}
+
+
+/**
+ * Generates a classifier string for a platform-specific WPILib native library.
+ *
+ * @param platform the platform string to get the WPILib classifier for. Platform strings should be one of:
+ * - win32
+ * - win64
+ * - mac64
+ * - linux32
+ * - linux64
+ */
+fun javaCppClassifier(platform: String): String = when (platform) {
+    "win32" -> "windows-x86"
+    "win64" -> "windows-x86_64"
+    "mac64" -> "macosx-x86_64"
+    "linux32" -> "linux-x86"
+    "linux64" -> "linux-x86_64"
+    else -> throw UnsupportedOperationException("JavaCPP does not support the '$platform' platform")
+}

--- a/plugins/cameraserver/cameraserver.gradle.kts
+++ b/plugins/cameraserver/cameraserver.gradle.kts
@@ -2,7 +2,7 @@ description = """
 The bundled CameraServer plugin. This plugin provides data sources and widgets for viewing MJPEG streams from the WPILib CameraServer.
 """.trimIndent().trim()
 
-val platform = ext["platform"] as String
+val platform: String by extra
 val javaCppClassifier = javaCppClassifier(platform)
 val javaCppVersion = "1.4.1"
 val wpilibClassifier = wpilibClassifier(platform)
@@ -20,26 +20,4 @@ dependencies {
     compile(group = "org.bytedeco.javacpp-presets", name = "ffmpeg", version = "3.4.2-$javaCppVersion", classifier = javaCppClassifier)
     compile(group = "org.bytedeco.javacpp-presets", name = "opencv", version = "3.4.1-$javaCppVersion", classifier = javaCppClassifier)
     testRuntime(group = "org.bytedeco.javacpp-presets", name = "ffmpeg", version = "3.4.2-$javaCppVersion", classifier = javaCppClassifier)
-}
-
-fun javaCppClassifier(platform: String): String {
-    return when (platform) {
-        "win32" -> "windows-x86"
-        "win64" -> "windows-x86_64"
-        "mac64" -> "macosx-x86_64"
-        "linux32" -> "linux-x86"
-        "linux64" -> "linux-x86_64"
-        else -> throw UnsupportedOperationException("JavaCPP does not support the '$platform' platform")
-    }
-}
-
-fun wpilibClassifier(platform: String): String {
-    return when (platform) {
-        "win32" -> "windowsx86"
-        "win64" -> "windowsx86-64"
-        "mac64" -> "osxx86-64"
-        // No 32-bit Linux support
-        "linux64" -> "linuxx86-64"
-        else -> throw UnsupportedOperationException("WPILib does not support the '$platform' platform")
-    }
 }

--- a/plugins/cameraserver/cameraserver.gradle.kts
+++ b/plugins/cameraserver/cameraserver.gradle.kts
@@ -2,24 +2,44 @@ description = """
 The bundled CameraServer plugin. This plugin provides data sources and widgets for viewing MJPEG streams from the WPILib CameraServer.
 """.trimIndent().trim()
 
-plugins {
-    id("com.google.osdetector") version "1.4.0"
-}
-
-val os = osdetector.classifier.replace("osx", "macosx").replace("x86_32", "x86")
+val platform = ext["platform"] as String
+val javaCppClassifier = javaCppClassifier(platform)
+val javaCppVersion = "1.4.1"
+val wpilibClassifier = wpilibClassifier(platform)
 
 dependencies {
+    // ntcore, cscore dependencies
     compile(project(":plugins:networktables"))
     compile(group = "edu.wpi.first.cscore", name = "cscore-java", version = "+")
+    runtime(group = "edu.wpi.first.cscore", name = "cscore-jni", version = "+", classifier = wpilibClassifier)
     compile(group = "org.opencv", name = "opencv-java", version = "3.2.0")
-    compile(group = "edu.wpi.first.cscore", name = "cscore-jni", version = "+", classifier = "all")
-    compile(group = "org.opencv", name = "opencv-jni", version = "+", classifier = "all")
-    compile(group = "org.bytedeco", name = "javacv", version = "1.4.1")
+    runtime(group = "org.opencv", name = "opencv-jni", version = "+", classifier = wpilibClassifier)
 
     // FFMPEG binaries
-    runtime(group = "org.bytedeco.javacpp-presets", name = "ffmpeg", version = "3.4.2-1.4.1", classifier = "linux-x86_64")
-    runtime(group = "org.bytedeco.javacpp-presets", name = "ffmpeg", version = "3.4.2-1.4.1", classifier = "windows-x86_64")
-    runtime(group = "org.bytedeco.javacpp-presets", name = "ffmpeg", version = "3.4.2-1.4.1", classifier = "windows-x86")
-    runtime(group = "org.bytedeco.javacpp-presets", name = "ffmpeg", version = "3.4.2-1.4.1", classifier = "macosx-x86_64")
-    testRuntime(group = "org.bytedeco.javacpp-presets", name = "ffmpeg", version = "3.4.2-1.4.1", classifier = os)
+    compile(group = "org.bytedeco", name = "javacv", version = javaCppVersion)
+    compile(group = "org.bytedeco.javacpp-presets", name = "ffmpeg", version = "3.4.2-$javaCppVersion", classifier = javaCppClassifier)
+    compile(group = "org.bytedeco.javacpp-presets", name = "opencv", version = "3.4.1-$javaCppVersion", classifier = javaCppClassifier)
+    testRuntime(group = "org.bytedeco.javacpp-presets", name = "ffmpeg", version = "3.4.2-$javaCppVersion", classifier = javaCppClassifier)
+}
+
+fun javaCppClassifier(platform: String): String {
+    return when (platform) {
+        "win32" -> "windows-x86"
+        "win64" -> "windows-x86_64"
+        "mac64" -> "macosx-x86_64"
+        "linux32" -> "linux-x86"
+        "linux64" -> "linux-x86_64"
+        else -> throw UnsupportedOperationException("JavaCPP does not support the '$platform' platform")
+    }
+}
+
+fun wpilibClassifier(platform: String): String {
+    return when (platform) {
+        "win32" -> "windowsx86"
+        "win64" -> "windowsx86-64"
+        "mac64" -> "osxx86-64"
+        // No 32-bit Linux support
+        "linux64" -> "linuxx86-64"
+        else -> throw UnsupportedOperationException("WPILib does not support the '$platform' platform")
+    }
 }

--- a/plugins/networktables/networktables.gradle.kts
+++ b/plugins/networktables/networktables.gradle.kts
@@ -3,11 +3,25 @@ The bundled NetworkTable plugin. This plugin provides sources for network tables
 subtables) and a widget for displaying MapData as a tree table.
 """.trim()
 
+val platform = ext["platform"] as String
+val wpilibClassifier = wpilibClassifier(platform)
+
 dependencies {
     val ntcoreVersion = "2018.4.+"
     val wpiUtilVersion = "2018.4.+"
 
     compile(group = "edu.wpi.first.ntcore", name = "ntcore-java", version = ntcoreVersion)
-    runtime(group = "edu.wpi.first.ntcore", name = "ntcore-jni", version = ntcoreVersion, classifier = "all")
+    runtime(group = "edu.wpi.first.ntcore", name = "ntcore-jni", version = ntcoreVersion, classifier = wpilibClassifier)
     runtime(group = "edu.wpi.first.wpiutil", name = "wpiutil-java", version = wpiUtilVersion)
+}
+
+fun wpilibClassifier(platform: String): String {
+    return when (platform) {
+        "win32" -> "windowsx86"
+        "win64" -> "windowsx86-64"
+        "mac64" -> "osxx86-64"
+        // No 32-bit Linux support
+        "linux64" -> "linuxx86-64"
+        else -> throw UnsupportedOperationException("WPILib does not support the '$platform' platform")
+    }
 }

--- a/plugins/networktables/networktables.gradle.kts
+++ b/plugins/networktables/networktables.gradle.kts
@@ -3,7 +3,7 @@ The bundled NetworkTable plugin. This plugin provides sources for network tables
 subtables) and a widget for displaying MapData as a tree table.
 """.trim()
 
-val platform = ext["platform"] as String
+val platform: String by extra
 val wpilibClassifier = wpilibClassifier(platform)
 
 dependencies {
@@ -13,15 +13,4 @@ dependencies {
     compile(group = "edu.wpi.first.ntcore", name = "ntcore-java", version = ntcoreVersion)
     runtime(group = "edu.wpi.first.ntcore", name = "ntcore-jni", version = ntcoreVersion, classifier = wpilibClassifier)
     runtime(group = "edu.wpi.first.wpiutil", name = "wpiutil-java", version = wpiUtilVersion)
-}
-
-fun wpilibClassifier(platform: String): String {
-    return when (platform) {
-        "win32" -> "windowsx86"
-        "win64" -> "windowsx86-64"
-        "mac64" -> "osxx86-64"
-        // No 32-bit Linux support
-        "linux64" -> "linuxx86-64"
-        else -> throw UnsupportedOperationException("WPILib does not support the '$platform' platform")
-    }
 }


### PR DESCRIPTION
Reduces JAR size from 105MB to about 50MB (per platform)  
Remove cedarsoft semver library, since it was pulling in the kotlin runtime (and some other libraries).  
Refactor PluginLoader a bit to avoid a new God Class classification

By default, the build will use native artifacts for the running operating system. This can be changed with the `platform` gradle property:

| Target OS | Flag |
|---|---|
| Windows 32-bit | `-Pplatform=win32` |
| Windows 64-bit | `-Pplatform=win64` |
| Mac OS (10.7+)  | `-Pplatform=mac64` |
| Liinux 64-bit | `-Pplatform=linux64` |
 
Platform builds for the app fat jar use the platform names above for the artifact classifier.