### PR TITLE
Update to Java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ Shuffleboard is installed by the WPILib Eclipse Plugins. It can be launched from
 It can also be run manually `java -jar C:\Users\<username\>wpilib\tools\Shuffleboard.jar`
 
 ### Requirements
-- [JRE 10](http://www.oracle.com/technetwork/java/javase/downloads/jre10-downloads-4417026.html). Java 10 is required.
-No other version of Java is supported.
+- [JRE 11](http://jdk.java.net/11/). Java 11 is required.
+No other version of Java is supported. Java 11 is installed on Windows by the
+[FRC vscode extension](https://github.com/wpilibsuite/vscode-wpilib). Users on Mac or Linux will have to install Java 11
+manually.
 
 ## Building
 
@@ -34,5 +36,5 @@ following:
 - `linux64` for 64-bit Linux
 
 ### Requirements
-- [JDK 10](http://www.oracle.com/technetwork/java/javase/downloads/jdk10-downloads-4416644.html). JDK 10 is required.
+- [JDK 11](http://jdk.java.net/11/). JDK 11 is required.
 No other version of Java is supported.

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/EditableLabel.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/EditableLabel.java
@@ -36,7 +36,7 @@ public class EditableLabel extends StackPane {
       }
     });
 
-    editField.setOnAction(__ae -> editing.set(false));
+    editField.setOnAction(__ -> editing.set(false));
 
     editField.focusedProperty().addListener((__, wasFocused, isFocused) -> {
       if (!isFocused) {

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/json/PropertySaver.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/json/PropertySaver.java
@@ -214,7 +214,7 @@ public final class PropertySaver {
     // Convert the first character to uppercase, so property name "foo" becomes "getFoo" or "isFoo"
     String base = Character.toUpperCase(propertyName.charAt(0)) + propertyName.substring(1);
     String getterName = "get" + base;
-    String isName = "is" + base;
+    String isName = "is" + base; // NOPMD linguistics antipattern - this is the name of a boolean "isX" method
     List<Method> possibleGetters = Arrays.stream(clazz.getMethods())
         .filter(m -> m.getName().equals(getterName) || isBooleanGetterWithName(m, isName))
         .filter(m -> m.getParameterCount() == 0)

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Components.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Components.java
@@ -172,7 +172,7 @@ public class Components extends Registry<ComponentType> {
    */
   public Optional<? extends Component> createComponent(String name) {
     // Widgets need to be created using the createWidget function due to state
-    Optional<Widget> widget = typeFor(name).filter(WidgetType.class::isInstance).flatMap(_w -> createWidget(name));
+    Optional<Widget> widget = typeFor(name).filter(WidgetType.class::isInstance).flatMap(__ -> createWidget(name));
     widget.ifPresent(this::setId);
     if (widget.isPresent()) {
       return widget;

--- a/app/app.gradle.kts
+++ b/app/app.gradle.kts
@@ -1,4 +1,3 @@
-
 import org.gradle.jvm.tasks.Jar
 
 plugins {
@@ -20,6 +19,16 @@ repositories {
 }
 
 dependencies {
+    // JavaFX dependencies
+    compile(javafx("base"))
+    compile(javafx("controls"))
+    compile(javafx("fxml"))
+    compile(javafx("graphics"))
+    // Note: we don't use these modules, but third-party plugins might
+    runtime(javafx("media"))
+    runtime(javafx("swing"))
+    runtime(javafx("web"))
+
     compile(project(":api"))
     compile(project(path = ":plugins:base"))
     compile(project(path = ":plugins:cameraserver"))
@@ -31,22 +40,19 @@ dependencies {
     testCompile(project("test_plugins"))
 }
 
-val theMainClassName = "edu.wpi.first.shuffleboard.app.Shuffleboard"
+val theMainClassName = "edu.wpi.first.shuffleboard.app.Main"
 
 application {
     mainClassName = theMainClassName
     applicationDefaultJvmArgs = listOf(
             "-Xverify:none",
-            "-Dprism.order=d3d,es2,sw",
-            "--add-exports", "javafx.controls/com.sun.javafx.scene.control.inputmap=ALL-UNNAMED"
+            "-Dprism.order=d3d,es2,sw"
     )
 }
 
 tasks.withType<Jar> {
     manifest {
         attributes["Main-Class"] = theMainClassName
-        attributes["JavaFX-Main-Class"] = theMainClassName
-        attributes["JavaFX-Preloader-Class"] = "edu.wpi.first.shuffleboard.app.ShuffleboardPreloader"
     }
 }
 

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Main.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Main.java
@@ -1,0 +1,19 @@
+package edu.wpi.first.shuffleboard.app;
+
+import com.sun.javafx.application.LauncherImpl;
+
+/**
+ * The true main class.  This bypasses module boot layer introspection by the Java launcher that attempts to
+ * reflectively access the JavaFX application launcher classes - this will fail because there is no module path;
+ * everything is in the same, unnamed module.  This is also how we are able to call {@link LauncherImpl} directly,
+ * which is not in a package exported by the {@code javafx.graphics} module.
+ */
+@SuppressWarnings("PMD.UseUtilityClass") // Nope.
+public final class Main {
+  public static void main(String[] args) {
+    // JavaFX 11+ uses GTK3 by default, and has problems on some display servers
+    // This flag forces JavaFX to use GTK2
+    System.setProperty("jdk.gtk.version", "2");
+    LauncherImpl.launchApplication(Shuffleboard.class, ShuffleboardPreloader.class, args);
+  }
+}

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -49,10 +49,6 @@ public class Shuffleboard extends Application {
   private final Stopwatch startupTimer = Stopwatch.createStarted();
   private MainWindowController mainWindowController;
 
-  public static void main(String[] args) {
-    launch(Shuffleboard.class, args);
-  }
-
   @Override
   public void init() throws AlreadyLockedException, IOException, InterruptedException {
     try {

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/ShuffleboardUpdateChecker.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/ShuffleboardUpdateChecker.java
@@ -13,6 +13,8 @@ import com.github.samcarlberg.updatechecker.UpdateChecker;
 import com.github.samcarlberg.updatechecker.UpdateStatus;
 import com.github.zafarkhaja.semver.Version;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -274,6 +276,7 @@ public final class ShuffleboardUpdateChecker {
    *
    * @throws InterruptedException if the calling thread is interrupted while the script is running
    */
+  @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE") // Complains about Files.copy(in, scriptFile) ...
   private static void runCopyScript(File temp, Path target) throws InterruptedException {
     try {
       final String scriptFileExtension;

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneDragHandler.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneDragHandler.java
@@ -193,8 +193,8 @@ final class WidgetPaneDragHandler implements EventHandler<DragEvent> {
     int newCol = layout.origin.getCol() + dx;
     int newRow = layout.origin.getRow() + dy;
     WidgetPane.Highlight highlight = highlights.computeIfAbsent(tile, t -> pane.addHighlight());
-    highlight.setLocation(new GridPoint(newCol, newRow));
-    highlight.setSize(layout.size);
+    highlight.withLocation(new GridPoint(newCol, newRow));
+    highlight.withSize(layout.size);
     highlights.put(tile, highlight);
     return highlight;
   }
@@ -337,7 +337,7 @@ final class WidgetPaneDragHandler implements EventHandler<DragEvent> {
   private void dropGalleryWidget(String componentType, GridPoint point) {
     Components.getDefault().createComponent(componentType).ifPresent(c -> {
       TileSize size = pane.sizeOfWidget(c);
-      if (pane.isOpen(point, size, _t -> false)) {
+      if (pane.isOpen(point, size, __ -> false)) {
         Tile<?> tile = pane.addComponentToTile(c);
         moveTile(tile, point);
       }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/AdderTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/AdderTab.java
@@ -23,7 +23,7 @@ public class AdderTab extends Tab implements HandledTab {
     TabHandle handle = new TabHandle(this);
     this.setGraphic(handle);
 
-    this.setOnSelectionChanged(__event -> {
+    this.setOnSelectionChanged(__ -> {
       TabPane tabPane = getTabPane();
       if (tabPane == null) {
         return;

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
@@ -292,6 +292,7 @@ public class DashboardTab extends Tab implements HandledTab, Populatable {
   }
 
   @Override
+  @SuppressWarnings("PMD.LinguisticNaming") // Predicates prefixed with "is" makes PMD mad
   public boolean hasComponentFor(String sourceId) {
     List<Component> topLevelComponents = getWidgetPane().getTiles().stream()
         .map(t -> (Tile<?>) t)

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/TabHandle.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/TabHandle.java
@@ -73,6 +73,6 @@ public class TabHandle extends StackPane {
         () -> FxUtils.runOnFxThread(tab::onDragOver),
         DRAG_FOCUS_DELAY, TimeUnit.MILLISECONDS);
 
-    setOnDragExited(__de -> task.cancel(false));
+    setOnDragExited(__ -> task.cancel(false));
   }
 }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/WidgetPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/WidgetPane.java
@@ -505,7 +505,7 @@ public class WidgetPane extends TilePane implements ComponentContainer {
 
   /**
    * Creates a new highlight object and adds it to this pane at (0, 0) with size (1, 1). The location and size of the
-   * highlight can be configured with {@link Highlight#setLocation} and {@link Highlight#setSize}, respectively.
+   * highlight can be configured with {@link Highlight#withLocation} and {@link Highlight#withSize}, respectively.
    *
    * @return a new highlight object
    */
@@ -535,12 +535,12 @@ public class WidgetPane extends TilePane implements ComponentContainer {
       getStyleClass().add("grid-highlight");
     }
 
-    public Highlight setSize(TileSize size) {
+    public Highlight withSize(TileSize size) {
       this.size.setValue(size);
       return this;
     }
 
-    public Highlight setLocation(GridPoint location) {
+    public Highlight withLocation(GridPoint location) {
       this.location.setValue(location);
       return this;
     }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/dnd/DragUtils.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/dnd/DragUtils.java
@@ -16,6 +16,7 @@ public final class DragUtils {
   /**
    * A predicate for testing if a node is a widget tile being dragged.
    */
+  @SuppressWarnings("PMD.LinguisticNaming") // Predicates prefixed with "is" makes PMD mad
   public static final Predicate<Node> isDraggedWidget = DragUtils::isDraggedWidget;
 
   private DragUtils() {

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/dnd/ResizeUtils.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/dnd/ResizeUtils.java
@@ -12,6 +12,7 @@ import javafx.scene.Node;
  */
 public final class ResizeUtils {
 
+  @SuppressWarnings("PMD.LinguisticNaming") // Predicates prefixed with "is" makes PMD mad
   public static final Predicate<Node> isResizedTile = n -> n instanceof Tile && isResizedTile((Tile) n);
 
   private static final AtomicReference<Tile<?>> currentTile = new AtomicReference<>(null);

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ plugins {
     id("com.github.johnrengelman.shadow") version "2.0.1"
     id("com.diffplug.gradle.spotless") version "3.13.0"
     id("org.ajoberstar.grgit") version "1.7.2"
-    id("com.github.spotbugs") version "1.6.2"
+    id("com.github.spotbugs") version "1.6.4"
     id("com.google.osdetector") version "1.4.0"
 }
 
@@ -133,6 +133,16 @@ allprojects {
         "testCompile"(testFx(name = "testfx-core"))
         "testCompile"(testFx(name = "testfx-junit5"))
         "testRuntime"(testFx(name = "openjfx-monocle", version = "jdk-9+181"))
+
+        "compileOnly"(javafx("base"))
+        "compileOnly"(javafx("controls"))
+        "compileOnly"(javafx("fxml"))
+        "compileOnly"(javafx("graphics"))
+
+        "testCompile"(javafx("base"))
+        "testCompile"(javafx("controls"))
+        "testCompile"(javafx("fxml"))
+        "testCompile"(javafx("graphics"))
     }
 
     checkstyle {
@@ -141,7 +151,7 @@ allprojects {
     }
 
     pmd {
-        toolVersion = "6.5.0"
+        toolVersion = "6.7.0"
         isConsoleOutput = true
         sourceSets = setOf(java.sourceSets["main"])
         reportsDir = file("${project.buildDir}/reports/pmd")
@@ -150,7 +160,7 @@ allprojects {
     }
 
     spotbugs {
-        toolVersion = "3.1.6"
+        toolVersion = "3.1.7"
         sourceSets = setOf(java.sourceSets["main"], java.sourceSets["test"])
         excludeFilter = file("$rootDir/findBugsSuppressions.xml")
         effort = "max"
@@ -179,6 +189,10 @@ allprojects {
                         ?.also { logger.warn(it) }
             }
         })
+    }
+
+    jacoco {
+        toolVersion = "0.8.2"
     }
 
     tasks.withType<JacocoReport> {

--- a/buildSrc/src/main/kotlin/JavaFXExtensions.kt
+++ b/buildSrc/src/main/kotlin/JavaFXExtensions.kt
@@ -1,0 +1,16 @@
+import org.gradle.api.artifacts.dsl.DependencyHandler
+
+/**
+ * The JavaFX artifact classifier for the [currentPlatform]. One of: `win32`, `win`, `linux`, or `mac`.
+ */
+val javaFxClassifier: String = javaFxClassifier(currentPlatform)
+
+/**
+ * Generates a dependency on a JavaFX artifact. The artifact name is preprended with `"javafx-"`, so `name` should be
+ * something like `"base"` instead of `"javafx-base"` or `"graphics"` vs `"javafx-graphics"`.  This generates a
+ * platform-specific dependency, so this should only be used as a `compileOnly` dependency _except_ in the app project,
+ * which wants the dependencies as `compile` or `runtime` dependencies so they can be included in the fatjar
+ * distribution.
+ */
+fun DependencyHandler.javafx(name: String, version: String = "11") =
+        "org.openjfx:javafx-$name:$version:$javaFxClassifier"

--- a/buildSrc/src/main/kotlin/PlatformMapper.kt
+++ b/buildSrc/src/main/kotlin/PlatformMapper.kt
@@ -43,7 +43,7 @@ fun wpilibClassifier(platform: String) = when (platform) {
 
 
 /**
- * Generates a classifier string for a platform-specific WPILib native library.
+ * Generates a classifier string for a platform-specific JavaCPP native library.
  *
  * @param platform the platform string to get the WPILib classifier for. Platform strings should be one of:
  * - win32
@@ -59,4 +59,22 @@ fun javaCppClassifier(platform: String): String = when (platform) {
     "linux32" -> "linux-x86"
     "linux64" -> "linux-x86_64"
     else -> throw UnsupportedOperationException("JavaCPP does not support the '$platform' platform")
+}
+
+
+/**
+ * Generates a classifier string for a platform-specific JavaFX artifact.
+ *
+ * @param platform the platform string to get the WPILib classifier for. Platform strings should be one of:
+ * - win32 (pending WPILib builds and releases)
+ * - win64
+ * - mac64
+ * - linux64
+ */
+fun javaFxClassifier(platform: String): String = when (platform) {
+    // "win32" -> "win32" // TODO: WPILib builds and releases
+    "win64" -> "win"
+    "mac64" -> "mac"
+    "linux64" -> "linux"
+    else -> throw UnsupportedOperationException("JavaFX does not support the '$platform' platform")
 }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/GridLayout.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/GridLayout.java
@@ -41,6 +41,7 @@ public final class GridLayout extends LayoutBase {
   @FXML
   private GridPane grid;
 
+  @SuppressWarnings("PMD.LinguisticNaming") // Predicates prefixed with "is" makes PMD mad
   private static final Predicate<Node> isPlaceholder = n -> n instanceof Placeholder;
 
   private final IntegerProperty numColumns = new SimpleIntegerProperty(this, "columns", 3);

--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -32,6 +32,12 @@
         <exclude name="UselessParentheses"/>
         <exclude name="AvoidFinalLocalVariable"/>
         <exclude name="CommentDefaultAccessModifier"/>
+        <exclude name="FieldNamingConventions"/>
+    </rule>
+    <rule ref="category/java/codestyle.xml/FormalParameterNamingConventions">
+        <properties>
+            <property name="lambdaParameterPattern" value="__|[a-z][a-zA-Z0-9]*"/>
+        </properties>
     </rule>
     <rule ref="category/java/codestyle.xml/ShortMethodName">
         <properties>


### PR DESCRIPTION
# Overview
- Use JavaFX maven artifacts
- Remove module exports for controlsfx since we're not using the module path
- Add a trivial main class to call the JavaFX launcher to avoid issues with the Java launcher inspecting the module boot layer for the javafx.graphics module, which breaks because we don't use the module path
- Update PMD to 6.7.0, fix issues introduced by new rules
- Update spotbugs to 3.1.7
- Update jacoco to 0.8.2
- Force GTK2 on Linux. JavaFX 11 uses GTK3 by default and has issues on some display servers (nominally just Wayland, but I've run into issues on X)

Closes #515 by breaking the JavaFX module system and placing everything in the unnamed module
