### PR TITLE
Resolve JavaFX artifacts for the target platform, not the build platform

### DIFF
--- a/app/app.gradle.kts
+++ b/app/app.gradle.kts
@@ -18,16 +18,18 @@ repositories {
     }
 }
 
+val platform: String by extra
+
 dependencies {
     // JavaFX dependencies
-    compile(javafx("base"))
-    compile(javafx("controls"))
-    compile(javafx("fxml"))
-    compile(javafx("graphics"))
+    compile(javafx("base", platform))
+    compile(javafx("controls", platform))
+    compile(javafx("fxml", platform))
+    compile(javafx("graphics", platform))
     // Note: we don't use these modules, but third-party plugins might
-    runtime(javafx("media"))
-    runtime(javafx("swing"))
-    runtime(javafx("web"))
+    runtime(javafx("media", platform))
+    runtime(javafx("swing", platform))
+    runtime(javafx("web", platform))
 
     compile(project(":api"))
     compile(project(path = ":plugins:base"))

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,6 +119,7 @@ allprojects {
     project.ext {
         this["platform"] = properties["platform"] ?: currentPlatform
     }
+    val platform: String by extra
 
     dependencies {
         fun junitJupiter(name: String, version: String = "5.2.0") =
@@ -134,15 +135,15 @@ allprojects {
         "testCompile"(testFx(name = "testfx-junit5"))
         "testRuntime"(testFx(name = "openjfx-monocle", version = "jdk-9+181"))
 
-        "compileOnly"(javafx("base"))
-        "compileOnly"(javafx("controls"))
-        "compileOnly"(javafx("fxml"))
-        "compileOnly"(javafx("graphics"))
+        "compileOnly"(javafx("base", platform))
+        "compileOnly"(javafx("controls", platform))
+        "compileOnly"(javafx("fxml", platform))
+        "compileOnly"(javafx("graphics", platform))
 
-        "testCompile"(javafx("base"))
-        "testCompile"(javafx("controls"))
-        "testCompile"(javafx("fxml"))
-        "testCompile"(javafx("graphics"))
+        "testCompile"(javafx("base", platform))
+        "testCompile"(javafx("controls", platform))
+        "testCompile"(javafx("fxml", platform))
+        "testCompile"(javafx("graphics", platform))
     }
 
     checkstyle {

--- a/buildSrc/src/main/kotlin/JavaFXExtensions.kt
+++ b/buildSrc/src/main/kotlin/JavaFXExtensions.kt
@@ -1,16 +1,11 @@
 import org.gradle.api.artifacts.dsl.DependencyHandler
 
 /**
- * The JavaFX artifact classifier for the [currentPlatform]. One of: `win32`, `win`, `linux`, or `mac`.
- */
-val javaFxClassifier: String = javaFxClassifier(currentPlatform)
-
-/**
  * Generates a dependency on a JavaFX artifact. The artifact name is preprended with `"javafx-"`, so `name` should be
  * something like `"base"` instead of `"javafx-base"` or `"graphics"` vs `"javafx-graphics"`.  This generates a
  * platform-specific dependency, so this should only be used as a `compileOnly` dependency _except_ in the app project,
  * which wants the dependencies as `compile` or `runtime` dependencies so they can be included in the fatjar
  * distribution.
  */
-fun DependencyHandler.javafx(name: String, version: String = "11") =
-        "org.openjfx:javafx-$name:$version:$javaFxClassifier"
+fun DependencyHandler.javafx(name: String, platform: String, version: String = "11") =
+        "org.openjfx:javafx-$name:$version:${javaFxClassifier(platform)}"


### PR DESCRIPTION
Previously, the JavaFX dependencies were only for the system that ran the build, even if a different platform was begin targeted (eg building on Linux but targeting win64 would use the linux JavaFX artifacts, and win64 for all the other native libraries).