### PR TITLE
Make widget title bars optional

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/AbstractWidget.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/AbstractWidget.java
@@ -9,6 +9,8 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 import javafx.beans.InvalidationListener;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
 import javafx.beans.value.ChangeListener;
@@ -24,6 +26,7 @@ public abstract class AbstractWidget implements Widget {
   protected final ObservableList<DataSource> sources = FXCollections.observableArrayList();
 
   private final StringProperty title = new SimpleStringProperty(this, "title", "");
+  private final BooleanProperty titleVisible = new SimpleBooleanProperty(this, "titleVisible", true);
 
   private final ChangeListener<Boolean> connectionListener = (__, was, is) -> {
     if (is) {
@@ -78,6 +81,11 @@ public abstract class AbstractWidget implements Widget {
   @Override
   public StringProperty titleProperty() {
     return title;
+  }
+
+  @Override
+  public BooleanProperty titleVisibleProperty() {
+    return titleVisible;
   }
 
   @Override

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Component.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Component.java
@@ -7,7 +7,6 @@ import java.util.stream.Stream;
 
 import javafx.beans.property.Property;
 import javafx.scene.layout.Pane;
-import org.apache.xpath.operations.Bool;
 
 /**
  * A Component is base interface for any part of the dashboard that can be instantiated by the user. For example, a

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Component.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Component.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 
 import javafx.beans.property.Property;
 import javafx.scene.layout.Pane;
+import org.apache.xpath.operations.Bool;
 
 /**
  * A Component is base interface for any part of the dashboard that can be instantiated by the user. For example, a
@@ -35,6 +36,19 @@ public interface Component {
 
   default void setTitle(String title) {
     titleProperty().setValue(title);
+  }
+
+  /**
+   * Gets the title bar visibility for this component.
+   */
+  Property<Boolean> titleVisibleProperty();
+
+  default Boolean getTitleVisible() {
+    return titleVisibleProperty().getValue();
+  }
+
+  default void setTitleVisible(Boolean visible) {
+    titleVisibleProperty().setValue(visible);
   }
 
   /**

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/LayoutBase.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/LayoutBase.java
@@ -10,10 +10,7 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import javafx.beans.property.Property;
-import javafx.beans.property.SimpleObjectProperty;
-import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
+import javafx.beans.property.*;
 import javafx.scene.Node;
 import javafx.scene.SnapshotParameters;
 import javafx.scene.control.Label;
@@ -31,6 +28,7 @@ public abstract class LayoutBase implements Layout {
 
   private final List<Component> children = new ArrayList<>();
   private final StringProperty title = new SimpleStringProperty(this, "title", getName());
+  private final BooleanProperty titleVisible = new SimpleBooleanProperty(this, "titleVisible", getTitleVisible());
   private final Property<LabelPosition> labelPosition =
       new SimpleObjectProperty<>(this, "labelPosition", LabelPosition.BOTTOM);
 
@@ -76,6 +74,11 @@ public abstract class LayoutBase implements Layout {
   @Override
   public Property<String> titleProperty() {
     return title;
+  }
+
+  @Override
+  public Property<Boolean> titleVisibleProperty() {
+    return titleVisible;
   }
 
   /**

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/LayoutBase.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/LayoutBase.java
@@ -10,7 +10,12 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 
-import javafx.beans.property.*;
+import javafx.beans.property.Property;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.StringProperty;
 import javafx.scene.Node;
 import javafx.scene.SnapshotParameters;
 import javafx.scene.control.Label;

--- a/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
+++ b/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
@@ -195,6 +195,10 @@
     -fx-font-size: 11pt;
 }
 
+.not-visible {
+    -fx-padding: -50px;
+}
+
 .tile .scroll-pane, .tile .viewport,
 .tile .property-sheet .property-pane, .tile .property-sheet .tool-bar {
     -fx-background-color: transparent;

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
@@ -639,6 +639,11 @@ public class WidgetPaneController {
             "Title",
             "The title of this " + component.getName().toLowerCase(Locale.US),
             component.titleProperty()
+        ),
+        Setting.of(
+            "Title visible",
+            "The title bar's visibility of this " + component.getName().toLowerCase(Locale.US),
+            component.titleVisibleProperty()
         )
     );
   }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
@@ -614,7 +614,7 @@ public class WidgetPaneController {
    */
   private Category createSettingsCategoriesForComponent(Component component) {
     List<Group> groups = new ArrayList<>(component.getSettings());
-    groups.add(titleGroup(component));
+    groups.add(0, titleGroup(component));
     String categoryName = component.getTitle().isEmpty() ? "Unnamed " + component.getName() : component.getTitle();
     if (component instanceof ComponentContainer) {
       List<Category> subCategories = ((ComponentContainer) component).components()
@@ -634,7 +634,7 @@ public class WidgetPaneController {
    * @return a new settings group
    */
   private Group titleGroup(Component component) {
-    return Group.of("Miscellaneous",
+    return Group.of("Title",
         Setting.of(
             "Title",
             "The title of this " + component.getName().toLowerCase(Locale.US),

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/Tile.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/Tile.java
@@ -8,6 +8,7 @@ import edu.wpi.first.shuffleboard.api.widget.Layout;
 import edu.wpi.first.shuffleboard.api.widget.TileSize;
 import edu.wpi.first.shuffleboard.api.widget.Widget;
 
+import javafx.scene.layout.StackPane;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.monadic.MonadicBinding;
 import org.fxmisc.easybind.monadic.PropertyBinding;
@@ -38,6 +39,9 @@ public class Tile<T extends Component> extends BorderPane {
   private final PropertyBinding<String> contentTitle = // NOPMD local variable
       EasyBind.monadic(content)
           .selectProperty(Component::titleProperty);
+  private final PropertyBinding<Boolean> contentTitleVisible = // NOPMD local variable
+      EasyBind.monadic(content)
+          .selectProperty(Component::titleVisibleProperty);
 
   /**
    * Creates an empty tile. The content and size must be set with {@link #setContent(T)} and
@@ -54,6 +58,8 @@ public class Tile<T extends Component> extends BorderPane {
 
     getStyleClass().addAll("tile", "card");
     PropertyUtils.bindWithConverter(idProperty(), contentProperty(), w -> "tile[" + w + "]");
+    StackPane titlePane = (StackPane) lookup("#titlePane");
+    titlePane.visibleProperty().bindBidirectional(contentTitleVisible);
     EditableLabel editableLabel = (EditableLabel) lookup("#titleLabel");
     editableLabel.textProperty().bindBidirectional(contentTitle);
     ((Label) lookup("#titleLabel").lookup(".label")).setTextOverrun(OverrunStyle.LEADING_ELLIPSIS);
@@ -69,6 +75,13 @@ public class Tile<T extends Component> extends BorderPane {
           });
     });
     contentTitle.addListener((__, prev, cur) -> editableLabel.setText(cur));
+    contentTitleVisible.addListener((__, prev, cur) -> {
+      if (cur) {
+        titlePane.getStyleClass().remove("not-visible");
+      } else {
+        titlePane.getStyleClass().add("not-visible");
+      }
+    });
   }
 
   private Optional<Pane> getContentPane() {

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/Tile.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/Tile.java
@@ -8,7 +8,6 @@ import edu.wpi.first.shuffleboard.api.widget.Layout;
 import edu.wpi.first.shuffleboard.api.widget.TileSize;
 import edu.wpi.first.shuffleboard.api.widget.Widget;
 
-import javafx.scene.layout.StackPane;
 import org.fxmisc.easybind.EasyBind;
 import org.fxmisc.easybind.monadic.MonadicBinding;
 import org.fxmisc.easybind.monadic.PropertyBinding;
@@ -24,6 +23,7 @@ import javafx.scene.control.Label;
 import javafx.scene.control.OverrunStyle;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.StackPane;
 
 /**
  * Contains any component directly embedded in a WidgetPane. Has a size, content, and title.

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/components/Tile.fxml
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/components/Tile.fxml
@@ -10,7 +10,7 @@
          type="Tile"
          fx:id="tile">
     <top>
-        <StackPane styleClass="tile-title-bar">
+        <StackPane fx:id="titlePane" styleClass="tile-title-bar">
             <EditableLabel fx:id="titleLabel" styleClass="tile-title-label"/>
         </StackPane>
     </top>

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/MockLayout.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/MockLayout.java
@@ -9,7 +9,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.Property;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
@@ -44,6 +46,11 @@ public final class MockLayout implements Layout {
   @Override
   public Property<String> titleProperty() {
     return new SimpleStringProperty();
+  }
+
+  @Override
+  public Property<Boolean> titleVisibleProperty() {
+    return new SimpleBooleanProperty(true);
   }
 
   @Override

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/MockWidget.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/MockWidget.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 import javafx.beans.property.Property;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -30,6 +31,11 @@ public final class MockWidget implements Widget {
   @Override
   public Property<String> titleProperty() {
     return new SimpleObjectProperty<>();
+  }
+
+  @Override
+  public Property<Boolean> titleVisibleProperty() {
+    return new SimpleBooleanProperty(true);
   }
 
   @Override

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/json/DashboardTabPaneSaverTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/json/DashboardTabPaneSaverTest.java
@@ -13,7 +13,6 @@ import edu.wpi.first.shuffleboard.app.components.DashboardTab;
 import edu.wpi.first.shuffleboard.app.components.DashboardTabPane;
 import edu.wpi.first.shuffleboard.app.components.Tile;
 
-import javafx.beans.property.SimpleBooleanProperty;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -27,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 
 import javafx.beans.property.Property;
+import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/json/DashboardTabPaneSaverTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/json/DashboardTabPaneSaverTest.java
@@ -13,6 +13,7 @@ import edu.wpi.first.shuffleboard.app.components.DashboardTab;
 import edu.wpi.first.shuffleboard.app.components.DashboardTabPane;
 import edu.wpi.first.shuffleboard.app.components.Tile;
 
+import javafx.beans.property.SimpleBooleanProperty;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Tag;
@@ -114,6 +115,11 @@ public class DashboardTabPaneSaverTest extends ApplicationTest {
     @Override
     public Property<String> titleProperty() {
       return new SimpleStringProperty();
+    }
+
+    @Override
+    public Property<Boolean> titleVisibleProperty() {
+      return new SimpleBooleanProperty(true);
     }
 
     @Override


### PR DESCRIPTION
Closes https://github.com/wpilibsuite/shuffleboard/issues/400

<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
This PR adds a widget property allowing the title bar to be hidden. This is useful for widgets which don't need a title or are fairly self-explanatory, and to save room on the screen.

# Screenshots
With widget title bar:
![with_title](https://user-images.githubusercontent.com/10191084/46264564-391ac780-c4d3-11e8-9f47-e052d97bcb53.PNG)

Without widget title bar:
![without_title](https://user-images.githubusercontent.com/10191084/46264565-3c15b800-c4d3-11e8-8b08-5101b4b6796f.PNG)
