### PR TITLE
WIP: Add programmatic tab switching

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/tab/model/TabStructure.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/tab/model/TabStructure.java
@@ -1,5 +1,7 @@
 package edu.wpi.first.shuffleboard.api.tab.model;
 
+import com.google.common.collect.Iterables;
+
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -13,7 +15,7 @@ public final class TabStructure {
   private final Map<String, TabModel> tabs = new LinkedHashMap<>();
   private final List<StructureChangeListener> structureChangeListeners = new ArrayList<>();
 
-  private int selectedIndex;
+  private int selectedIndex = -1;
 
   /**
    * Gets the tab with the given title, creating it if it does not already exist.
@@ -44,7 +46,10 @@ public final class TabStructure {
    * @param tabIndex the index of the tab to select
    */
   public void setSelectedTab(int tabIndex) {
-    selectedIndex = tabIndex;
+    if (selectedIndex != tabIndex) {
+      selectedIndex = tabIndex;
+      dirty();
+    }
   }
 
   /**
@@ -54,7 +59,7 @@ public final class TabStructure {
    */
   public void setSelectedTab(String title) {
     if (tabs.containsKey(title)) {
-      selectedIndex = new ArrayList<>(tabs.keySet()).indexOf(title);
+      setSelectedTab(Iterables.indexOf(tabs.keySet(), title::equals));
     }
   }
 

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/tab/model/TabStructure.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/tab/model/TabStructure.java
@@ -13,6 +13,8 @@ public final class TabStructure {
   private final Map<String, TabModel> tabs = new LinkedHashMap<>();
   private final List<StructureChangeListener> structureChangeListeners = new ArrayList<>();
 
+  private int selectedIndex;
+
   /**
    * Gets the tab with the given title, creating it if it does not already exist.
    *
@@ -34,6 +36,35 @@ public final class TabStructure {
    */
   public Map<String, TabModel> getTabs() {
     return tabs;
+  }
+
+  /**
+   * Sets the currently selected tab.
+   *
+   * @param tabIndex the index of the tab to select
+   */
+  public void setSelectedTab(int tabIndex) {
+    selectedIndex = tabIndex;
+  }
+
+  /**
+   * Sets the currently selected tab.
+   *
+   * @param title the title of the tab to select
+   */
+  public void setSelectedTab(String title) {
+    if (tabs.containsKey(title)) {
+      selectedIndex = new ArrayList<>(tabs.keySet()).indexOf(title);
+    }
+  }
+
+  /**
+   * Gets the currently selected tab.
+   *
+   * @return the index of the currently selected tab
+   */
+  public int getSelectedTab() {
+    return selectedIndex;
   }
 
   /**

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
@@ -48,6 +48,8 @@ public class DashboardTabPane extends TabPane {
         }
         tab.populate();
       }
+
+      selectTab(tabs.getSelectedTab());
     });
   };
 

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
@@ -35,7 +35,7 @@ import javafx.beans.value.ChangeListener;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "NetworkTables",
-    version = "2.0.0",
+    version = "2.1.0",
     summary = "Provides sources and widgets for NetworkTables"
 )
 public class NetworkTablesPlugin extends Plugin {

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGenerator.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGenerator.java
@@ -29,6 +29,7 @@ import java.util.stream.Collectors;
 /**
  * Helper class for generating tabs in the UI from data in NetworkTables.
  */
+@SuppressWarnings("PMD.GodClass")
 final class TabGenerator {
 
   public static final String ROOT_TABLE_NAME = "/Shuffleboard";

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGenerator.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGenerator.java
@@ -17,6 +17,7 @@ import edu.wpi.first.networktables.EntryNotification;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.NetworkTableValue;
+import edu.wpi.first.networktables.NetworkTableType;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -38,6 +39,7 @@ final class TabGenerator {
   public static final String TABS_ENTRY_PATH = METADATA_TABLE_NAME + "/" + TABS_ENTRY_KEY;
   public static final String POSITION_ENTRY_NAME = "Position";
   public static final String SIZE_ENTRY_NAME = "Size";
+  public static final String SELECTED_ENTRY_NAME = "Selected";
 
   public static final String TAB_TYPE = "ShuffleboardTab";
   public static final String LAYOUT_TYPE = "ShuffleboardLayout";
@@ -122,6 +124,16 @@ final class TabGenerator {
       double[] size = inst.getEntry(name).getDoubleArray(new double[0]);
       if (size.length == 2) {
         tab.getChild(real).setPreferredSize(new TileSize((int) size[0], (int) size[1]));
+      }
+    }
+
+    // Selected tab
+    if (name.endsWith("/" + SELECTED_ENTRY_NAME)) {
+      // If the value is a double, assume it's the tab index. If it's a string, assume tab title.
+      if (event.getEntry().getType() == NetworkTableType.kDouble) {
+        tabs.setSelectedTab((int) event.getEntry().getValue().getDouble());
+      } else if (event.getEntry().getType() == NetworkTableType.kString) {
+        tabs.setSelectedTab(event.getEntry().getValue().getString());
       }
     }
 


### PR DESCRIPTION
Closes https://github.com/wpilibsuite/shuffleboard/issues/511

This is currently untested. Will give it a shot on Tuesday when I have access to the robot and make changes as necessary. Just opening now to get some initial feedback.

# Overview
This PR adds an API to programmatically switch tabs from plugins. It also adds a NetworkTables listener on the Shuffleboard `/Selected` metadata, which automatically switches the tab to one with a specific index or title.
