### PR TITLE
Add sendable chooser widget with segmented toggle buttons

### DIFF
--- a/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
+++ b/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
@@ -518,10 +518,41 @@
  * Sendable Chooser                                                            *
  *                                                                             *
  ******************************************************************************/
-.combobox-chooser .confirmation-label {
+.combobox-chooser .confirmation-label,
+.split-button-chooser .confirmation-label {
     -fx-text-fill: -confirmation-color-confirmed !important;
 }
 
-.combobox-chooser .confirmation-label:error {
+.combobox-chooser .confirmation-label:error,
+.split-button-chooser .confirmation-label:error {
     -fx-text-fill: -confirmation-color-error !important;
+}
+
+/*******************************************************************************
+ *                                                                             *
+ * Segmented Button                                                            *
+ *                                                                             *
+ ******************************************************************************/
+.segmented-button {
+    -fx-effect: dropshadow(gaussian, rgba(0.0, 0.0, 0.0, 0.30), 6.0, 0.3, 0, 2);
+}
+
+.segmented-button .toggle-button {
+    -fx-effect: none;
+}
+
+.segmented-button .toggle-button:selected {
+    -fx-background-color: -swatch-500;
+}
+
+.segmented-button .toggle-button.left-pill {
+    -fx-background-radius: 4 0 0 4;
+}
+
+.segmented-button .toggle-button.right-pill {
+    -fx-background-radius: 0 4 4 0;
+}
+
+.segmented-button .toggle-button.only-button {
+    -fx-background-radius: 4 4 4 4;
 }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -52,6 +52,7 @@ import edu.wpi.first.shuffleboard.plugin.base.widget.RelayWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.RobotPreferencesWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.SimpleDialWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.SpeedControllerWidget;
+import edu.wpi.first.shuffleboard.plugin.base.widget.SplitButtonChooserWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.TextViewWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.ThreeAxisAccelerometerWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.ToggleButtonWidget;
@@ -69,7 +70,7 @@ import java.util.Set;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "Base",
-    version = "1.0.2",
+    version = "1.1.0",
     summary = "Defines all the WPILib data types and stock widgets"
 )
 @SuppressWarnings("PMD.CouplingBetweenObjects")
@@ -114,6 +115,7 @@ public class BasePlugin extends Plugin {
         WidgetType.forAnnotatedWidget(VoltageViewWidget.class),
         WidgetType.forAnnotatedWidget(PowerDistributionPanelWidget.class),
         WidgetType.forAnnotatedWidget(ComboBoxChooserWidget.class),
+        WidgetType.forAnnotatedWidget(SplitButtonChooserWidget.class),
         WidgetType.forAnnotatedWidget(EncoderWidget.class),
         WidgetType.forAnnotatedWidget(RobotPreferencesWidget.class),
         WidgetType.forAnnotatedWidget(SpeedControllerWidget.class),

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/SplitButtonChooserWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/SplitButtonChooserWidget.java
@@ -1,0 +1,110 @@
+package edu.wpi.first.shuffleboard.plugin.base.widget;
+
+import edu.wpi.first.shuffleboard.api.widget.Description;
+import edu.wpi.first.shuffleboard.api.widget.ParametrizedController;
+import edu.wpi.first.shuffleboard.api.widget.SimpleAnnotatedWidget;
+import edu.wpi.first.shuffleboard.plugin.base.data.SendableChooserData;
+import edu.wpi.first.shuffleboard.plugin.base.data.types.SendableChooserType;
+
+import javafx.css.PseudoClass;
+import javafx.scene.control.Label;
+import javafx.scene.control.Tooltip;
+import org.controlsfx.control.SegmentedButton;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.ToggleButton;
+import javafx.scene.layout.Pane;
+import org.controlsfx.glyphfont.FontAwesome;
+import org.controlsfx.glyphfont.GlyphFont;
+import org.controlsfx.glyphfont.GlyphFontRegistry;
+
+@Description(name = "Split Button Chooser", dataTypes = SendableChooserType.class)
+@ParametrizedController("SplitButtonChooserWidget.fxml")
+public final class SplitButtonChooserWidget extends SimpleAnnotatedWidget<SendableChooserData> {
+
+  private static final GlyphFont fontAwesome = GlyphFontRegistry.font("FontAwesome");
+  private static final PseudoClass error = PseudoClass.getPseudoClass("error");
+
+  @FXML
+  private Pane root;
+  @FXML
+  private SegmentedButton buttons;
+  @FXML
+  private Pane selectionLabelContainer;
+
+  private final Tooltip activeTooltip = new Tooltip();
+
+  @FXML
+  private void initialize() {
+    buttons.setFocusTraversable(false);
+    dataOrDefault.addListener((__, old, data) -> {
+      Map<String, Object> changes = data.changesFrom(old);
+
+      if (changes.containsKey(SendableChooserData.OPTIONS_KEY)) {
+        String selectedOption = data.getSelectedOption();
+        buttons.getButtons().setAll(Stream.of(data.getOptions())
+            .map(this::createToggleButton)
+            .collect(Collectors.toList()));
+        selectToggleButton(selectedOption);
+      }
+
+      if (changes.containsKey(SendableChooserData.DEFAULT_OPTION_KEY)
+          && buttons.getToggleGroup().getSelectedToggle() == null) {
+        selectToggleButton(data.getDefaultOption());
+      }
+
+      if (changes.containsKey(SendableChooserData.SELECTED_OPTION_KEY)) {
+        selectToggleButton(data.getSelectedOption());
+      }
+      confirmationLabel(data.getActiveOption().equals(data.getSelectedOption()));
+    });
+
+    activeTooltip.textProperty().bind(
+        dataOrDefault
+            .map(SendableChooserData::getActiveOption)
+            .map(option -> "Active option: '" + option + "'"));
+  }
+
+  private ToggleButton createToggleButton(String option) {
+    ToggleButton button = new ToggleButton(option);
+    button.setFocusTraversable(false);
+    button.setOnAction(e -> setData(dataOrDefault.get().withSelectedOption(option)));
+    button.selectedProperty().addListener((__, was, is) -> {
+      if (buttons.getButtons().stream().noneMatch(ToggleButton::isSelected)) {
+        button.setSelected(true);
+      }
+    });
+    return button;
+  }
+
+  private void confirmationLabel(boolean confirmation) {
+    Label activeSelectionLabel;
+    if (confirmation) {
+      activeSelectionLabel = fontAwesome.create(FontAwesome.Glyph.CHECK);
+    } else {
+      activeSelectionLabel = fontAwesome.create(FontAwesome.Glyph.EXCLAMATION);
+    }
+    activeSelectionLabel.getStyleClass().add("confirmation-label");
+    activeSelectionLabel.pseudoClassStateChanged(error, !confirmation);
+    activeSelectionLabel.setTooltip(activeTooltip);
+    selectionLabelContainer.getChildren().setAll(activeSelectionLabel);
+  }
+
+  @Override
+  public Pane getView() {
+    return root;
+  }
+
+  private void selectToggleButton(String option) {
+    buttons.getButtons()
+        .stream()
+        .filter(b -> b.getText().equals(option))
+        .findFirst()
+        .ifPresent(b -> b.setSelected(true));
+  }
+
+}

--- a/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/SplitButtonChooserWidget.fxml
+++ b/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/SplitButtonChooserWidget.fxml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import org.controlsfx.control.SegmentedButton?>
+<?import javafx.scene.layout.StackPane?>
+<?import javafx.scene.layout.HBox?>
+<HBox xmlns="http://javafx.com/javafx"
+      xmlns:fx="http://javafx.com/fxml"
+      fx:controller="edu.wpi.first.shuffleboard.plugin.base.widget.SplitButtonChooserWidget"
+      fx:id="root"
+      minWidth="64" minHeight="64"
+      styleClass="split-button-chooser"
+      alignment="CENTER"
+      spacing="4">
+    <StackPane>
+        <SegmentedButton fx:id="buttons"/>
+    </StackPane>
+    <StackPane fx:id="selectionLabelContainer" minWidth="16"/>
+</HBox>


### PR DESCRIPTION
# Overview
Currently, the only widget capable of manipulating sendable choosers is a combobox, which only shows all available options when clicked on. An implementation with a split button can show all available options at once.

# Screenshots
![image](https://user-images.githubusercontent.com/6320992/46559685-161b5980-c8bf-11e8-9f08-aa9473d4abc5.png)
