### PR TITLE
Use waitForEntryListenerQueue instead of hard sleeps

### DIFF
--- a/plugins/cameraserver/src/test/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/StreamDiscovererTest.java
+++ b/plugins/cameraserver/src/test/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/StreamDiscovererTest.java
@@ -5,10 +5,8 @@ import edu.wpi.first.networktables.NetworkTableInstance;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.TimeUnit;
-
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.testfx.util.WaitForAsyncUtils.sleep;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class StreamDiscovererTest {
 
@@ -70,8 +68,10 @@ public class StreamDiscovererTest {
     assertArrayEquals(new String[0], discoverer.getUrls());
   }
 
-  private static void waitForNtEvents() {
-    sleep(100, TimeUnit.MILLISECONDS);
+  private void waitForNtEvents() {
+    if (!ntInstance.waitForEntryListenerQueue(0.5)) {
+      fail("Timed out while waiting for entry listeners to fire");
+    }
   }
 
 }

--- a/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/RecorderControllerTest.java
+++ b/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/RecorderControllerTest.java
@@ -10,14 +10,12 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.testfx.util.WaitForAsyncUtils.sleep;
 
 public class RecorderControllerTest {
 
@@ -52,7 +50,7 @@ public class RecorderControllerTest {
     ntInstance.getEntry(RecorderController.DEFAULT_START_STOP_KEY).setBoolean(true);
     ntInstance.getEntry(RecorderController.DEFAULT_FILE_NAME_FORMAT_KEY).setString(format);
     controller.start();
-    sleep(100, TimeUnit.MILLISECONDS); // wait for nt events
+    ntInstance.waitForEntryListenerQueue(-1);
     assertAll(
         () -> assertTrue(recorder.isRunning(), "Recorder should be running"),
         () -> assertEquals(format, recorder.getFileNameFormat(), "File name format should have been set")
@@ -63,7 +61,7 @@ public class RecorderControllerTest {
   public void testStartWhenEntryUpdates() {
     controller.start();
     ntInstance.getEntry(RecorderController.DEFAULT_START_STOP_KEY).setBoolean(true);
-    sleep(100, TimeUnit.MILLISECONDS);
+    ntInstance.waitForEntryListenerQueue(-1);
     assertTrue(recorder.isRunning(), "Recorder should have been started");
   }
 
@@ -71,7 +69,7 @@ public class RecorderControllerTest {
   public void testNoUpdatesWhenNotRunning() {
     controller.start();
     controller.stop();
-    sleep(100, TimeUnit.MILLISECONDS);
+    ntInstance.waitForEntryListenerQueue(-1);
     ntInstance.getEntry(RecorderController.DEFAULT_START_STOP_KEY).setBoolean(true);
     assertFalse(recorder.isRunning(), "Recording should not be running");
   }
@@ -80,10 +78,10 @@ public class RecorderControllerTest {
   public void testStopsRecorder() {
     controller.start();
     ntInstance.getEntry(RecorderController.DEFAULT_START_STOP_KEY).setBoolean(true);
-    sleep(100, TimeUnit.MILLISECONDS);
+    ntInstance.waitForEntryListenerQueue(-1);
     assertTrue(recorder.isRunning());
     ntInstance.getEntry(RecorderController.DEFAULT_START_STOP_KEY).setBoolean(false);
-    sleep(100, TimeUnit.MILLISECONDS);
+    ntInstance.waitForEntryListenerQueue(-1);
     assertFalse(recorder.isRunning(), "Recorder should have been stopped");
   }
 
@@ -92,7 +90,7 @@ public class RecorderControllerTest {
     controller.start();
     DashboardMode.setCurrentMode(DashboardMode.PLAYBACK);
     ntInstance.getEntry(RecorderController.DEFAULT_START_STOP_KEY).setBoolean(true);
-    sleep(100, TimeUnit.MILLISECONDS);
+    ntInstance.waitForEntryListenerQueue(-1);
     assertFalse(recorder.isRunning(), "Recorder should not have been started");
   }
 }

--- a/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGeneratorTest.java
+++ b/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGeneratorTest.java
@@ -15,19 +15,19 @@ import edu.wpi.first.networktables.NetworkTableInstance;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.testfx.util.WaitForAsyncUtils;
 
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class TabGeneratorTest {
 
+  private NetworkTableInstance ntInstance;
   private NetworkTable rootTable;
   private NetworkTable rootMetaTable;
   private TabGenerator generator;
@@ -35,7 +35,7 @@ public class TabGeneratorTest {
 
   @BeforeEach
   public void setup() {
-    NetworkTableInstance ntInstance = NetworkTableInstance.create();
+    ntInstance = NetworkTableInstance.create();
     ntInstance.setUpdateRate(0.01);
     rootTable = ntInstance.getTable("/Shuffleboard");
     rootMetaTable = rootTable.getSubTable(".metadata");
@@ -50,8 +50,10 @@ public class TabGeneratorTest {
     Components.setDefault(new Components());
   }
 
-  private static void waitForNtUpdate() {
-    WaitForAsyncUtils.sleep(100, TimeUnit.MILLISECONDS);
+  private void waitForNtUpdate() {
+    if (!ntInstance.waitForEntryListenerQueue(0.5)) {
+      fail("Timed out while waiting for entry listeners to fire");
+    }
   }
 
   @Test


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->
Updates tests for classes that use NetworkTables to wait for entry listeners to fire rather than hardcoded sleeps