### PR TITLE
Fixes the capitalization of the shuffleboard app artifact

### DIFF
--- a/app/app.gradle.kts
+++ b/app/app.gradle.kts
@@ -102,7 +102,7 @@ publishing {
     publications {
         create<MavenPublication>("app") {
             groupId = "edu.wpi.first.shuffleboard"
-            artifactId = "shuffleboard"
+            artifactId = "Shuffleboard"
             version = project.version as String
             nativeShadowTasks.forEach {
                 artifact(it) {


### PR DESCRIPTION
In the past, we had published a `Shuffleboard` artifact, and with case insensitive OS's having potential issues by going to lowercase, we should go back to the capital location

http://first.wpi.edu/FRC/roborio/maven/development/edu/wpi/first/shuffleboard/

Both `Shuffleboard` and `shuffleboard` exist here, which is bad. Release doesn't have a `shuffleboard` posted yet, and development only has 1, so the dev one is safe to delete.

