### PR TITLE
Fix editing component properties if no title is set

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneController.java
@@ -615,13 +615,14 @@ public class WidgetPaneController {
   private Category createSettingsCategoriesForComponent(Component component) {
     List<Group> groups = new ArrayList<>(component.getSettings());
     groups.add(titleGroup(component));
+    String categoryName = component.getTitle().isEmpty() ? "Unnamed " + component.getName() : component.getTitle();
     if (component instanceof ComponentContainer) {
       List<Category> subCategories = ((ComponentContainer) component).components()
           .map(this::createSettingsCategoriesForComponent)
           .collect(Collectors.toList());
-      return Category.of(component.getTitle(), subCategories, groups);
+      return Category.of(categoryName, subCategories, groups);
     } else {
-      return Category.of(component.getTitle(), groups);
+      return Category.of(categoryName, groups);
     }
   }
 

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneDragHandler.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/WidgetPaneDragHandler.java
@@ -338,6 +338,7 @@ final class WidgetPaneDragHandler implements EventHandler<DragEvent> {
     Components.getDefault().createComponent(componentType).ifPresent(c -> {
       TileSize size = pane.sizeOfWidget(c);
       if (pane.isOpen(point, size, __ -> false)) {
+        c.setTitle(componentType);
         Tile<?> tile = pane.addComponentToTile(c);
         moveTile(tile, point);
       }


### PR DESCRIPTION
The settings dialog would not appear if a selected component had an empty title. Newly created widgets now have default titles set to the widget name (e.g. creating an accelerometer widget will have its title set to "Accelerometer"). If a component has an empty title, it will appear as "Unnamed (component type)" in the categories list