### PR TITLE
Replace setting width and height with maximized

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -34,7 +34,6 @@ import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.control.ButtonType;
 import javafx.scene.layout.Pane;
-import javafx.stage.Screen;
 import javafx.stage.Stage;
 
 @SuppressWarnings("PMD.MoreThanOneLogger") // there's only one logger used, the others are for setting up file logging
@@ -129,8 +128,7 @@ public class Shuffleboard extends Application {
     primaryStage.setTitle("Shuffleboard");
     primaryStage.setMinWidth(640);
     primaryStage.setMinHeight(480);
-    primaryStage.setWidth(Screen.getPrimary().getVisualBounds().getWidth());
-    primaryStage.setHeight(Screen.getPrimary().getVisualBounds().getHeight());
+    primaryStage.setMaximized(true);
     primaryStage.setOnCloseRequest(closeEvent -> {
       if (!AppPreferences.getInstance().isConfirmExit()) {
         // Don't show the confirmation dialog, just exit

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/ShuffleboardTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/ShuffleboardTest.java
@@ -20,6 +20,7 @@ public class ShuffleboardTest extends ApplicationTest {
     Pane mainPane = FXMLLoader.load(MainWindowController.class.getResource("MainWindow.fxml"));
     Scene scene = new Scene(mainPane);
     stage.setScene(scene);
+    stage.setMaximized(true);
     stage.show();
   }
 


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
This replaces the two calls to set the width and height of Shuffleboard's primaryStage with one call to maximize the window.

# Screenshots
![image](https://user-images.githubusercontent.com/28938587/46925064-ca636100-cfde-11e8-8f2e-687b4d9d28db.png)
