### PR TITLE
Add markers to data recordings

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/properties/AtomicPropertyListenerDelegate.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/properties/AtomicPropertyListenerDelegate.java
@@ -1,7 +1,7 @@
 package edu.wpi.first.shuffleboard.api.properties;
 
+import edu.wpi.first.shuffleboard.api.util.AsyncUtils;
 import edu.wpi.first.shuffleboard.api.util.EqualityUtils;
-import edu.wpi.first.shuffleboard.api.util.FxUtils;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
@@ -73,10 +73,10 @@ public final class AtomicPropertyListenerDelegate<T> {
    * application thread.
    */
   public void invalidated(T oldValue, T newValue) {
-    invalidationListeners.forEach(l -> FxUtils.runOnFxThread(() -> l.invalidated(atomicProperty)));
+    invalidationListeners.forEach(l -> AsyncUtils.runAsync(() -> l.invalidated(atomicProperty)));
     if (EqualityUtils.isDifferent(oldValue, newValue)) {
       immediateListeners.forEach(l -> l.changed(atomicProperty, oldValue, newValue));
-      changeListeners.forEach(l -> FxUtils.runOnFxThread(() -> l.changed(atomicProperty, oldValue, newValue)));
+      changeListeners.forEach(l -> AsyncUtils.runAsync(() -> l.changed(atomicProperty, oldValue, newValue)));
     }
   }
 

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Marker.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Marker.java
@@ -1,0 +1,94 @@
+package edu.wpi.first.shuffleboard.api.sources.recording;
+
+import java.util.Objects;
+
+/**
+ * Marks an event in a recording.
+ */
+public final class Marker {
+
+  private final String name;
+  private final String description;
+  private final MarkerImportance importance;
+  private final long timestamp;
+
+  /**
+   * Creates a new event marker.
+   *
+   * @param name        the name of the marked event
+   * @param description a description of the marked event
+   * @param importance  the importance of the event
+   * @param timestamp   the time the event occurred, measured in milliseconds since the start of the recording
+   */
+  public Marker(String name, String description, MarkerImportance importance, long timestamp) {
+    this.name = Objects.requireNonNull(name, "name");
+    this.description = Objects.requireNonNull(description, "description");
+    this.importance = Objects.requireNonNull(importance, "importance");
+    this.timestamp = timestamp;
+  }
+
+  /**
+   * Creates a new event marker with no description.
+   *
+   * @param name       the name of the marked event
+   * @param importance the importance of the event
+   * @param timestamp  the time the event occurred, measured in milliseconds since the start of the recording
+   */
+  public Marker(String name, MarkerImportance importance, long timestamp) {
+    this(name, "", importance, timestamp);
+  }
+
+  /**
+   * Gets the name of the marked event.
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Gets the description of the marked event.
+   */
+  public String getDescription() {
+    return description;
+  }
+
+  /**
+   * Gets the importance of the marked event.
+   */
+  public MarkerImportance getImportance() {
+    return importance;
+  }
+
+  /**
+   * Gets the timestamp of the marked event.
+   */
+  public long getTimestamp() {
+    return timestamp;
+  }
+
+  @Override
+  public String toString() {
+    return String.format("Marker(name=\"%s\", description=\"%s\", importance=%s, timestamp=%d)",
+        name, description, importance, timestamp);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    Marker that = (Marker) obj;
+    return this.name.equals(that.name)
+        && this.description.equals(that.description)
+        && this.importance.equals(that.importance)
+        && this.timestamp == that.timestamp;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, description, importance, timestamp);
+  }
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/MarkerImportance.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/MarkerImportance.java
@@ -4,11 +4,16 @@ package edu.wpi.first.shuffleboard.api.sources.recording;
  * The levels of importance of a marker.
  */
 public enum MarkerImportance {
+
+
+  // Maintainer note: this enum is mirrored in WPILib. Adding or removing entries, or changing the name of any entry,
+  // requires a corresponding change to WPILib.
+
   /**
    * The lowest importance level. This can be used for marking the most minor events that are nice to know if something
    * goes wrong, but otherwise has no use.
    */
-  NONE,
+  TRIVIAL,
   /**
    * Marks an event with low importance.
    */
@@ -22,7 +27,7 @@ public enum MarkerImportance {
    */
   HIGH,
   /**
-   * Marks a critical event such as a component failure or robot reboot.
+   * Marks a critically important event such as a component failure, power loss, software deadlock, or timeout.
    */
   CRITICAL;
 
@@ -36,7 +41,7 @@ public enum MarkerImportance {
   public static MarkerImportance valueOf(int ordinal) {
     switch (ordinal) {
       case 0:
-        return NONE;
+        return TRIVIAL;
       case 1:
         return LOW;
       case 2:

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/MarkerImportance.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/MarkerImportance.java
@@ -4,11 +4,27 @@ package edu.wpi.first.shuffleboard.api.sources.recording;
  * The levels of importance of a marker.
  */
 public enum MarkerImportance {
-  LOWEST,
+  /**
+   * The lowest importance level. This can be used for marking the most minor events that are nice to know if something
+   * goes wrong, but otherwise has no use.
+   */
+  NONE,
+  /**
+   * Marks an event with low importance.
+   */
   LOW,
+  /**
+   * Marks an event with no special connotations, such as the start of a match or match period, or scoring a game piece.
+   */
   NORMAL,
+  /**
+   * Marks an important event.
+   */
   HIGH,
-  HIGHEST;
+  /**
+   * Marks a critical event such as a component failure or robot reboot.
+   */
+  CRITICAL;
 
   /**
    * Identical to {@code values()[ordinal]}, but without the array copy.
@@ -20,7 +36,7 @@ public enum MarkerImportance {
   public static MarkerImportance valueOf(int ordinal) {
     switch (ordinal) {
       case 0:
-        return LOWEST;
+        return NONE;
       case 1:
         return LOW;
       case 2:
@@ -28,7 +44,7 @@ public enum MarkerImportance {
       case 3:
         return HIGH;
       case 4:
-        return HIGHEST;
+        return CRITICAL;
       default:
         throw new IllegalArgumentException("Ordinal out of range: " + ordinal);
     }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/MarkerImportance.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/MarkerImportance.java
@@ -13,33 +13,39 @@ public enum MarkerImportance {
    * The lowest importance level. This can be used for marking the most minor events that are nice to know if something
    * goes wrong, but otherwise has no use.
    */
-  TRIVIAL,
+  TRIVIAL(0),
   /**
    * Marks an event with low importance.
    */
-  LOW,
+  LOW(1),
   /**
    * Marks an event with no special connotations, such as the start of a match or match period, or scoring a game piece.
    */
-  NORMAL,
+  NORMAL(2),
   /**
    * Marks an important event.
    */
-  HIGH,
+  HIGH(3),
   /**
    * Marks a critically important event such as a component failure, power loss, software deadlock, or timeout.
    */
-  CRITICAL;
+  CRITICAL(4);
+
+  private final int id;
+
+  MarkerImportance(int id) {
+    this.id = id;
+  }
 
   /**
-   * Identical to {@code values()[ordinal]}, but without the array copy.
+   * Gets the importance level with the given ID number.
    *
-   * @param ordinal the ordinal of the enum constant to get
+   * @param id the ID number of the enum constant to get
    *
-   * @return the enum constant with the given ordinal
+   * @return the enum constant with the given ID
    */
-  public static MarkerImportance valueOf(int ordinal) {
-    switch (ordinal) {
+  public static MarkerImportance forId(int id) {
+    switch (id) {
       case 0:
         return TRIVIAL;
       case 1:
@@ -51,8 +57,11 @@ public enum MarkerImportance {
       case 4:
         return CRITICAL;
       default:
-        throw new IllegalArgumentException("Ordinal out of range: " + ordinal);
+        throw new IllegalArgumentException("Unknown ID: " + id);
     }
   }
 
+  public int getId() {
+    return id;
+  }
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/MarkerImportance.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/MarkerImportance.java
@@ -1,0 +1,37 @@
+package edu.wpi.first.shuffleboard.api.sources.recording;
+
+/**
+ * The levels of importance of a marker.
+ */
+public enum MarkerImportance {
+  LOWEST,
+  LOW,
+  NORMAL,
+  HIGH,
+  HIGHEST;
+
+  /**
+   * Identical to {@code values()[ordinal]}, but without the array copy.
+   *
+   * @param ordinal the ordinal of the enum constant to get
+   *
+   * @return the enum constant with the given ordinal
+   */
+  public static MarkerImportance valueOf(int ordinal) {
+    switch (ordinal) {
+      case 0:
+        return LOWEST;
+      case 1:
+        return LOW;
+      case 2:
+        return NORMAL;
+      case 3:
+        return HIGH;
+      case 4:
+        return HIGHEST;
+      default:
+        throw new IllegalArgumentException("Ordinal out of range: " + ordinal);
+    }
+  }
+
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recorder.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recorder.java
@@ -190,6 +190,20 @@ public final class Recorder {
     recording.append(new TimestampedData(id.intern(), dataType, value, timestamp()));
   }
 
+  /**
+   * Adds a marker to the recording at the current time.
+   *
+   * @param name        the name of the marker
+   * @param description a description of the marked event
+   * @param importance  the importance of the marker
+   */
+  public void addMarker(String name, String description, MarkerImportance importance) {
+    if (!isRunning()) {
+      return;
+    }
+    recording.addMarker(new Marker(name, description, importance, timestamp()));
+  }
+
   private long timestamp() {
     return Instant.now().toEpochMilli() - startTime.toEpochMilli();
   }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recorder.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recorder.java
@@ -13,6 +13,8 @@ import edu.wpi.first.shuffleboard.api.util.ShutdownHooks;
 import edu.wpi.first.shuffleboard.api.util.Storage;
 import edu.wpi.first.shuffleboard.api.util.ThreadUtils;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -234,5 +236,16 @@ public final class Recorder {
 
   public void setFileNameFormat(String fileNameFormat) {
     this.fileNameFormat.set(fileNameFormat);
+  }
+
+  /**
+   * Gets the recording being recorded to. This method should only be used for tests to make sure the recording is
+   * being used properly.
+   */
+  @VisibleForTesting
+  public Recording getRecording() {
+    synchronized (startStopLock) {
+      return recording;
+    }
   }
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recording.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recording.java
@@ -1,13 +1,17 @@
 package edu.wpi.first.shuffleboard.api.sources.recording;
 
+import edu.wpi.first.shuffleboard.api.util.ThreadUtils;
+
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 public class Recording {
 
-  private final Object modificationLock = new Object();
   private TimestampedData first;
   private TimestampedData last;
   private final List<TimestampedData> data = Collections.synchronizedList(new ArrayList<>());
@@ -17,13 +21,16 @@ public class Recording {
   private final List<Marker> markersReadOnly = Collections.unmodifiableList(markers);
   private final List<String> sourceIdsReadOnly = Collections.unmodifiableList(sourceIds);
 
+  private final ReadWriteLock lock = new ReentrantReadWriteLock();
+
   /**
    * Appends the given data to the end of the data list.
    *
    * @param data the data to append
    */
   public void append(TimestampedData data) {
-    synchronized (modificationLock) {
+    try {
+      lock.writeLock().lock();
       this.data.add(data);
       if (!sourceIds.contains(data.getSourceId())) {
         sourceIds.add(data.getSourceId());
@@ -34,6 +41,8 @@ public class Recording {
       if (last == null || data.getTimestamp() > last.getTimestamp()) {
         last = data;
       }
+    } finally {
+      lock.writeLock().unlock();
     }
   }
 
@@ -43,76 +52,99 @@ public class Recording {
    * @param marker the marker to add
    */
   public void addMarker(Marker marker) {
-    synchronized (modificationLock) {
-      markers.add(marker);
-    }
+    ThreadUtils.withLock(lock.writeLock(), () -> markers.add(marker));
   }
 
   /**
-   * Gets the markers in this recording.
+   * Gets the markers in this recording. Note: if you need to get the data objects and markers at the same time,
+   * use {@link #copyData copyData()} to avoid locking issues (the individual methods each lock, but the lists may
+   * change between method calls).
+   *
+   * <p>In live recordings, this list will not be exhaustive. Markers are removed after saving to disk to reduce
+   * memory and CPU usage. Recordings loaded in playback mode will have all the markers present.
+   *
+   * @return the markers in this recording
    */
   public List<Marker> getMarkers() {
-    synchronized (modificationLock) {
-      return markersReadOnly;
-    }
+    return ThreadUtils.withLock(lock.readLock(), () -> markersReadOnly);
   }
 
-  @SuppressWarnings("JavadocMethod")
+  /**
+   * Gets the data in this recording. Note: if you need to get the data objects and markers at the same time,
+   * use {@link #copyData copyData()} to avoid locking issues (the individual methods each lock, but the lists may
+   * change between method calls).
+   *
+   * <p>In live recordings, this list will not be exhaustive. Data is removed after saving to disk to reduce
+   * memory and CPU usage. Recordings loaded in playback mode will have all the data present.
+   *
+   * @return the data in this recording
+   */
   public List<TimestampedData> getData() {
-    synchronized (modificationLock) {
-      return dataReadOnly;
-    }
+    return ThreadUtils.withLock(lock.readLock(), () -> dataReadOnly);
+  }
+
+  /**
+   * Safely copies all data from this recording. The target collections will be cleared and overwritten with the data
+   * currently in this recording.
+   *
+   * @param data    the target collection into which to copy the data objects
+   * @param markers the target collection into which to copy the event markers
+   */
+  public void copyData(Collection<TimestampedData> data, Collection<Marker> markers) {
+    ThreadUtils.withLock(lock.readLock(), () -> {
+      data.clear();
+      data.addAll(this.data);
+
+      markers.clear();
+      markers.addAll(this.markers);
+    });
   }
 
   /**
    * Clears the data and markers to free memory. This should <strong>ONLY</strong> be called by the recording mechanism
    * after the current data is saved to disk.
    */
-  @SuppressWarnings("PMD.DefaultPackage") // This should only be used by the Serialization class in the same package
+  @SuppressWarnings("PMD.DefaultPackage")
+  // This should only be used by the Serialization class in the same package
   void clear() {
-    synchronized (modificationLock) {
+    ThreadUtils.withLock(lock.writeLock(), () -> {
       data.clear();
       markers.clear();
-    }
+    });
   }
 
   @SuppressWarnings("JavadocMethod")
   public List<String> getSourceIds() {
-    synchronized (modificationLock) {
-      return sourceIdsReadOnly;
-    }
+    return ThreadUtils.withLock(lock.readLock(), () -> sourceIdsReadOnly);
   }
 
   @SuppressWarnings("JavadocMethod")
   public TimestampedData getFirst() {
-    synchronized (modificationLock) {
-      return first;
-    }
+    return ThreadUtils.withLock(lock.readLock(), () -> first);
   }
 
   @SuppressWarnings("JavadocMethod")
   public TimestampedData getLast() {
-    synchronized (modificationLock) {
-      return last;
-    }
+    return ThreadUtils.withLock(lock.readLock(), () -> last);
   }
 
   /**
    * Gets the length of this recording in milliseconds. Recordings wth 0 or 1 data points have a length of 0.
    */
   public long getLength() {
-    synchronized (modificationLock) {
+    return ThreadUtils.withLock(lock.readLock(), () -> {
       if (first == null || last == null) {
-        return 0;
+        return 0L;
       } else {
         return last.getTimestamp() - first.getTimestamp();
       }
-    }
+    });
   }
 
   @Override
   public boolean equals(Object obj) {
-    synchronized (modificationLock) {
+    try {
+      lock.readLock().lock();
       if (this == obj) {
         return true;
       }
@@ -121,24 +153,26 @@ public class Recording {
       }
 
       Recording that = (Recording) obj;
-
-      return this.data.equals(that.data)
-          && this.markers.equals(that.markers);
+      try {
+        that.lock.readLock().lock();
+        return this.data.equals(that.data)
+            && this.markers.equals(that.markers);
+      } finally {
+        that.lock.readLock().unlock();
+      }
+    } finally {
+      lock.readLock().unlock();
     }
   }
 
   @Override
   public int hashCode() {
-    synchronized (modificationLock) {
-      return Objects.hash(data, markers);
-    }
+    return ThreadUtils.withLock(lock.readLock(), () -> Objects.hash(data, markers));
   }
 
   @Override
   public String toString() {
-    synchronized (modificationLock) {
-      return "Recording(data=" + data + ", markers=" + markers + ")";
-    }
+    return ThreadUtils.withLock(lock.readLock(), () -> "Recording(data=" + data + ", markers=" + markers + ")");
   }
 
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recording.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recording.java
@@ -13,6 +13,9 @@ public class Recording {
   private final List<TimestampedData> data = Collections.synchronizedList(new ArrayList<>());
   private final List<Marker> markers = Collections.synchronizedList(new ArrayList<>());
   private final List<String> sourceIds = new ArrayList<>();
+  private final List<TimestampedData> dataReadOnly = Collections.unmodifiableList(data);
+  private final List<Marker> markersReadOnly = Collections.unmodifiableList(markers);
+  private final List<String> sourceIdsReadOnly = Collections.unmodifiableList(sourceIds);
 
   /**
    * Appends the given data to the end of the data list.
@@ -50,21 +53,33 @@ public class Recording {
    */
   public List<Marker> getMarkers() {
     synchronized (modificationLock) {
-      return markers;
+      return markersReadOnly;
     }
   }
 
   @SuppressWarnings("JavadocMethod")
   public List<TimestampedData> getData() {
     synchronized (modificationLock) {
-      return data;
+      return dataReadOnly;
+    }
+  }
+
+  /**
+   * Clears the data and markers to free memory. This should <strong>ONLY</strong> be called by the recording mechanism
+   * after the current data is saved to disk.
+   */
+  @SuppressWarnings("PMD.DefaultPackage") // This should only be used by the Serialization class in the same package
+  void clear() {
+    synchronized (modificationLock) {
+      data.clear();
+      markers.clear();
     }
   }
 
   @SuppressWarnings("JavadocMethod")
   public List<String> getSourceIds() {
     synchronized (modificationLock) {
-      return sourceIds;
+      return sourceIdsReadOnly;
     }
   }
 

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recording.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Recording.java
@@ -11,10 +11,11 @@ public class Recording {
   private TimestampedData first;
   private TimestampedData last;
   private final List<TimestampedData> data = Collections.synchronizedList(new ArrayList<>());
+  private final List<Marker> markers = Collections.synchronizedList(new ArrayList<>());
   private final List<String> sourceIds = new ArrayList<>();
 
   /**
-   * Appends the given data to the end of the data list. Note that this does not
+   * Appends the given data to the end of the data list.
    *
    * @param data the data to append
    */
@@ -30,6 +31,26 @@ public class Recording {
       if (last == null || data.getTimestamp() > last.getTimestamp()) {
         last = data;
       }
+    }
+  }
+
+  /**
+   * Adds a marker to this recording.
+   *
+   * @param marker the marker to add
+   */
+  public void addMarker(Marker marker) {
+    synchronized (modificationLock) {
+      markers.add(marker);
+    }
+  }
+
+  /**
+   * Gets the markers in this recording.
+   */
+  public List<Marker> getMarkers() {
+    synchronized (modificationLock) {
+      return markers;
     }
   }
 
@@ -86,21 +107,22 @@ public class Recording {
 
       Recording that = (Recording) obj;
 
-      return this.data.equals(that.data);
+      return this.data.equals(that.data)
+          && this.markers.equals(that.markers);
     }
   }
 
   @Override
   public int hashCode() {
     synchronized (modificationLock) {
-      return Objects.hash(data);
+      return Objects.hash(data, markers);
     }
   }
 
   @Override
   public String toString() {
     synchronized (modificationLock) {
-      return "Recording(data=" + data + ")";
+      return "Recording(data=" + data + ", markers=" + markers + ")";
     }
   }
 

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -49,7 +49,7 @@ public final class Serialization {
    *     - Timestamp (8 bytes)
    *     - Name string as UTF-8 byte array
    *     - Description string as UTF-8 byte array (may be zero-length)
-   *     - Importance level [0..4]
+   *     - Importance level ID (byte)
    * - Data points (variable size) (Complex array)
    */
 

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -7,6 +7,7 @@ import edu.wpi.first.shuffleboard.api.data.types.StringType;
 import edu.wpi.first.shuffleboard.api.sources.recording.serialization.Serializers;
 import edu.wpi.first.shuffleboard.api.sources.recording.serialization.TypeAdapter;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Bytes;
 
 import java.io.File;
@@ -143,9 +144,11 @@ public final class Serialization {
     Serializers.getAdapters().forEach(a -> a.setCurrentFile(file.toFile()));
     // Work on a copy, since the recording can have new data added to it while we're in the middle of saving
     var snapshot = recording.takeSnapshotAndClear();
-    final var dataCopy = new ArrayList<>(snapshot.getData());
+    final var dataCopy = snapshot.getData()
+        .stream()
+        .sorted()
+        .collect(ImmutableList.toImmutableList());
     final var markers = snapshot.getMarkers();
-    dataCopy.sort(TimestampedData::compareTo); // make sure the data is sorted properly
     final byte[] header = header(dataCopy);
     put(header, toByteArray(0), Offsets.DATA_POSITION_OFFSET);
     final List<String> constantPool = generateConstantPool(dataCopy);

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -46,8 +46,8 @@ public final class Serialization {
    * - Event markers (variable size) (Complex array)
    *   - Number of markers (4 bytes)
    *     - Timestamp (8 bytes)
-   *     - Name as UTF-8 byte array
-   *     - Description as UTF-8 byte array (may be zero-length)
+   *     - Name string as UTF-8 byte array
+   *     - Description string as UTF-8 byte array (may be zero-length)
    *     - Importance level [0..4]
    * - Data points (variable size) (Complex array)
    */

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -198,6 +198,7 @@ public final class Serialization {
    *
    * @throws IOException if the save file could not be updated
    */
+  @SuppressWarnings("PMD.ExcessiveMethodLength")
   public static void updateRecordingSave(Recording recording, Path file) throws IOException {
     if (Files.notExists(file) || Files.size(file) == 0) {
       saveRecording(recording, file);

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -142,8 +142,9 @@ public final class Serialization {
   public static void saveRecording(Recording recording, Path file) throws IOException {
     Serializers.getAdapters().forEach(a -> a.setCurrentFile(file.toFile()));
     // Work on a copy, since the recording can have new data added to it while we're in the middle of saving
-    final List<TimestampedData> dataCopy = new ArrayList<>(recording.getData());
-    final List<Marker> markers = new ArrayList<>(recording.getMarkers());
+    final List<TimestampedData> dataCopy = new ArrayList<>();
+    final List<Marker> markers = new ArrayList<>();
+    recording.copyData(dataCopy, markers);
     recording.clear();
     dataCopy.sort(TimestampedData::compareTo); // make sure the data is sorted properly
     final byte[] header = header(dataCopy);
@@ -204,9 +205,10 @@ public final class Serialization {
       saveRecording(recording, file);
       return;
     }
-    // Use a copy to avoid synchronization locking
-    List<TimestampedData> dataCopy = new ArrayList<>(recording.getData());
-    List<Marker> markers = new ArrayList<>(recording.getMarkers());
+    // Use a copy to avoid synchronization issues
+    List<TimestampedData> dataCopy = new ArrayList<>();
+    List<Marker> markers = new ArrayList<>();
+    recording.copyData(dataCopy, markers);
     recording.clear();
     if (dataCopy.isEmpty() && markers.isEmpty()) {
       // No new data

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -142,10 +142,9 @@ public final class Serialization {
   public static void saveRecording(Recording recording, Path file) throws IOException {
     Serializers.getAdapters().forEach(a -> a.setCurrentFile(file.toFile()));
     // Work on a copy, since the recording can have new data added to it while we're in the middle of saving
-    final List<TimestampedData> dataCopy = new ArrayList<>();
-    final List<Marker> markers = new ArrayList<>();
-    recording.copyData(dataCopy, markers);
-    recording.clear();
+    var snapshot = recording.takeSnapshotAndClear();
+    final var dataCopy = new ArrayList<>(snapshot.getData());
+    final var markers = snapshot.getMarkers();
     dataCopy.sort(TimestampedData::compareTo); // make sure the data is sorted properly
     final byte[] header = header(dataCopy);
     put(header, toByteArray(0), Offsets.DATA_POSITION_OFFSET);
@@ -206,10 +205,9 @@ public final class Serialization {
       return;
     }
     // Use a copy to avoid synchronization issues
-    List<TimestampedData> dataCopy = new ArrayList<>();
-    List<Marker> markers = new ArrayList<>();
-    recording.copyData(dataCopy, markers);
-    recording.clear();
+    var snapshot = recording.takeSnapshotAndClear();
+    final var dataCopy = snapshot.getData();
+    final var markers = snapshot.getMarkers();
     if (dataCopy.isEmpty() && markers.isEmpty()) {
       // No new data
       return;

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Serialization.java
@@ -162,7 +162,7 @@ public final class Serialization {
       segments.add(toByteArray(marker.getTimestamp()));
       segments.add(toByteArray(marker.getName()));
       segments.add(toByteArray(marker.getDescription()));
-      segments.add(new byte[]{(byte) marker.getImportance().getId()});
+      segments.add(toByteArray((byte) marker.getImportance().getId()));
     }
 
     // Data
@@ -531,6 +531,13 @@ public final class Serialization {
    */
   public static byte[] toByteArray(boolean val) {
     return new byte[]{(byte) (val ? 1 : 0)};
+  }
+
+  /**
+   * Creates a 1-element array containing the given byte.
+   */
+  public static byte[] toByteArray(byte val) {
+    return new byte[]{val};
   }
 
   /**

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/ThreadUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/ThreadUtils.java
@@ -2,8 +2,6 @@ package edu.wpi.first.shuffleboard.api.util;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.locks.Lock;
-import java.util.function.Supplier;
 
 /**
  * Utilities dealing with threading.
@@ -29,36 +27,4 @@ public final class ThreadUtils {
     return thread;
   }
 
-  /**
-   * Runs a function with a synchronization lock.
-   *
-   * @param lock     the synchronization lock to use
-   * @param function the function to run
-   */
-  public static void withLock(Lock lock, Runnable function) {
-    try {
-      lock.lock();
-      function.run();
-    } finally {
-      lock.unlock();
-    }
-  }
-
-  /**
-   * Runs a function with a synchronization lock and returns its result.
-   *
-   * @param lock     the synchronization lock to use
-   * @param function the function to run
-   * @param <T>      the type of the value returned by the function
-   *
-   * @return the output of {@code function}
-   */
-  public static <T> T withLock(Lock lock, Supplier<? extends T> function) {
-    try {
-      lock.lock();
-      return function.get();
-    } finally {
-      lock.unlock();
-    }
-  }
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/ThreadUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/ThreadUtils.java
@@ -2,6 +2,8 @@ package edu.wpi.first.shuffleboard.api.util;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.locks.Lock;
+import java.util.function.Supplier;
 
 /**
  * Utilities dealing with threading.
@@ -27,4 +29,36 @@ public final class ThreadUtils {
     return thread;
   }
 
+  /**
+   * Runs a function with a synchronization lock.
+   *
+   * @param lock     the synchronization lock to use
+   * @param function the function to run
+   */
+  public static void withLock(Lock lock, Runnable function) {
+    try {
+      lock.lock();
+      function.run();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Runs a function with a synchronization lock and returns its result.
+   *
+   * @param lock     the synchronization lock to use
+   * @param function the function to run
+   * @param <T>      the type of the value returned by the function
+   *
+   * @return the output of {@code function}
+   */
+  public static <T> T withLock(Lock lock, Supplier<? extends T> function) {
+    try {
+      lock.lock();
+      return function.get();
+    } finally {
+      lock.unlock();
+    }
+  }
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/concurrent/DelegatedFunctionalReadWriteLock.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/concurrent/DelegatedFunctionalReadWriteLock.java
@@ -1,0 +1,22 @@
+package edu.wpi.first.shuffleboard.api.util.concurrent;
+
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+
+final class DelegatedFunctionalReadWriteLock implements FunctionalReadWriteLock {
+  private final ReadWriteLock delegate;
+
+  DelegatedFunctionalReadWriteLock(ReadWriteLock delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public Lock readLock() {
+    return delegate.readLock();
+  }
+
+  @Override
+  public Lock writeLock() {
+    return delegate.writeLock();
+  }
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/concurrent/FunctionalReadWriteLock.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/concurrent/FunctionalReadWriteLock.java
@@ -1,0 +1,95 @@
+package edu.wpi.first.shuffleboard.api.util.concurrent;
+
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Supplier;
+
+/**
+ * An extension to {@code ReadWriteLock} that adds methods for using the read and write locks in a functional style.
+ */
+public interface FunctionalReadWriteLock extends ReadWriteLock {
+
+  /**
+   * Creates a new functional read/write lock that uses the read and write locks from the provided delegate.
+   *
+   * @param delegate the lock to delegate to
+   *
+   * @return a new functional read/write lock
+   */
+  static FunctionalReadWriteLock create(ReadWriteLock delegate) {
+    return new DelegatedFunctionalReadWriteLock(delegate);
+  }
+
+  /**
+   * Creates a new functional read/write lock uses reentrant locks.
+   *
+   * @return a new functional read/write lock
+   *
+   * @see ReentrantReadWriteLock
+   */
+  static FunctionalReadWriteLock createReentrant() {
+    return new DelegatedFunctionalReadWriteLock(new ReentrantReadWriteLock());
+  }
+
+  /**
+   * Performs a read operation.
+   *
+   * @param operation the read operation to run
+   */
+  default void reading(Runnable operation) {
+    try {
+      readLock().lock();
+      operation.run();
+    } finally {
+      readLock().unlock();
+    }
+  }
+
+  /**
+   * Performs a read operation.
+   *
+   * @param operation the read operation to run
+   * @param <T>       the type of the provided value
+   *
+   * @return the result of the operation
+   */
+  default <T> T reading(Supplier<? extends T> operation) {
+    try {
+      readLock().lock();
+      return operation.get();
+    } finally {
+      readLock().unlock();
+    }
+  }
+
+  /**
+   * Performs a write operation.
+   *
+   * @param operation the write operation to run
+   */
+  default void writing(Runnable operation) {
+    try {
+      writeLock().lock();
+      operation.run();
+    } finally {
+      writeLock().unlock();
+    }
+  }
+
+  /**
+   * Performs a write operation.
+   *
+   * @param operation the write operation to run
+   * @param <T>       the type of the provided value
+   *
+   * @return the result of the operation
+   */
+  default <T> T writing(Supplier<? extends T> operation) {
+    try {
+      writeLock().lock();
+      return operation.get();
+    } finally {
+      writeLock().unlock();
+    }
+  }
+}

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/SerializationTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/SerializationTest.java
@@ -136,11 +136,10 @@ public class SerializationTest {
   public void testEncodeRecodeWithMarkers() throws IOException {
     final Path file = Files.createTempFile("testEncodeRecodeWithMarkers", ".sbr");
     Recording recording = new Recording();
-    recording.addMarker(new Marker("First", "", MarkerImportance.LOWEST, 0));
-    recording.addMarker(new Marker("Second", "The second marker", MarkerImportance.HIGHEST, 1));
+    recording.addMarker(new Marker("First", "", MarkerImportance.NONE, 0));
+    recording.addMarker(new Marker("Second", "The second marker", MarkerImportance.CRITICAL, 1));
     Serialization.saveRecording(recording, file);
     Recording loaded = Serialization.loadRecording(file);
-    System.out.println(loaded.getMarkers());
     assertAll(
         () -> assertEquals(recording.getData(), loaded.getData(), "Data was wrong"),
         () -> assertEquals(recording.getMarkers(), loaded.getMarkers(), "Markers were wrong")

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/SerializationTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/SerializationTest.java
@@ -136,7 +136,7 @@ public class SerializationTest {
   public void testEncodeRecodeWithMarkers() throws IOException {
     final Path file = Files.createTempFile("testEncodeRecodeWithMarkers", ".sbr");
     Recording recording = new Recording();
-    recording.addMarker(new Marker("First", "", MarkerImportance.NONE, 0));
+    recording.addMarker(new Marker("First", "", MarkerImportance.TRIVIAL, 0));
     recording.addMarker(new Marker("Second", "The second marker", MarkerImportance.CRITICAL, 1));
     Serialization.saveRecording(recording, file);
     Recording loaded = Serialization.loadRecording(file);

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/SerializationTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/sources/recording/SerializationTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -129,6 +130,21 @@ public class SerializationTest {
     Serialization.updateRecordingSave(recording, file);
     final Recording last = Serialization.loadRecording(file);
     assertEquals(data, last.getData(), "Second update was wrong");
+  }
+
+  @Test
+  public void testEncodeRecodeWithMarkers() throws IOException {
+    final Path file = Files.createTempFile("testEncodeRecodeWithMarkers", ".sbr");
+    Recording recording = new Recording();
+    recording.addMarker(new Marker("First", "", MarkerImportance.LOWEST, 0));
+    recording.addMarker(new Marker("Second", "The second marker", MarkerImportance.HIGHEST, 1));
+    Serialization.saveRecording(recording, file);
+    Recording loaded = Serialization.loadRecording(file);
+    System.out.println(loaded.getMarkers());
+    assertAll(
+        () -> assertEquals(recording.getData(), loaded.getData(), "Data was wrong"),
+        () -> assertEquals(recording.getMarkers(), loaded.getMarkers(), "Markers were wrong")
+    );
   }
 
   @Test

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/ConvertRecordingPaneController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/ConvertRecordingPaneController.java
@@ -202,7 +202,7 @@ public final class ConvertRecordingPaneController {
           Path dst = Paths.get(outputDir.getValue().getAbsolutePath(), dstFileName);
           log.info("Exporting " + file + " to " + dst);
           converter.export(recording, dst, settings);
-        } catch (IOException e) {
+        } catch (IOException | RuntimeException e) {
           log.log(Level.WARNING,
               "Could not export recording file " + file + " with converter " + converter.formatName(), e);
         }

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/MainWindow.fxml
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/MainWindow.fxml
@@ -8,6 +8,7 @@
 <?import javafx.scene.control.SeparatorMenuItem?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.layout.BorderPane?>
 <VBox fx:id="root" maxHeight="Infinity" maxWidth="Infinity"
       xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="edu.wpi.first.shuffleboard.app.MainWindowController">
@@ -48,4 +49,15 @@
             </StackPane.margin>
         </fx:include>
     </StackPane>
+    <BorderPane styleClass="footer">
+        <padding>
+            <Insets topRightBottomLeft="4"/>
+        </padding>
+        <center>
+            <fx:include source="PlaybackControls.fxml"/>
+        </center>
+        <right>
+            <fx:include source="ConnectionIndicators.fxml"/>
+        </right>
+    </BorderPane>
 </VBox>

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -134,6 +134,7 @@ allprojects {
         "testCompile"(junitJupiter(name = "junit-jupiter-api"))
         "testCompile"(junitJupiter(name = "junit-jupiter-engine"))
         "testCompile"(junitJupiter(name = "junit-jupiter-params"))
+        "testCompile"(create(group = "org.junit-pioneer", name = "junit-pioneer", version = "0.3.0"))
         "testRuntime"(create(group = "org.junit.platform", name = "junit-platform-launcher", version = "1.0.0"))
         fun testFx(name: String, version: String = "4.0.13-alpha") =
                 create(group = "org.testfx", name = name, version = version)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -134,8 +134,8 @@ allprojects {
         "testCompile"(junitJupiter(name = "junit-jupiter-api"))
         "testCompile"(junitJupiter(name = "junit-jupiter-engine"))
         "testCompile"(junitJupiter(name = "junit-jupiter-params"))
-        "testCompile"(create(group = "org.junit-pioneer", name = "junit-pioneer", version = "0.3.0"))
-        "testRuntime"(create(group = "org.junit.platform", name = "junit-platform-launcher", version = "1.0.0"))
+        "testCompile"(group = "org.junit-pioneer", name = "junit-pioneer", version = "0.3.0")
+        "testRuntime"(group = "org.junit.platform", name = "junit-platform-launcher", version = "1.0.0")
         fun testFx(name: String, version: String = "4.0.13-alpha") =
                 create(group = "org.testfx", name = name, version = version)
         "testCompile"(testFx(name = "testfx-core"))

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/MarkerGenerator.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/MarkerGenerator.java
@@ -1,0 +1,63 @@
+package edu.wpi.first.shuffleboard.plugin.networktables;
+
+import edu.wpi.first.shuffleboard.api.sources.recording.MarkerImportance;
+import edu.wpi.first.shuffleboard.api.sources.recording.Recorder;
+
+import edu.wpi.first.networktables.EntryListenerFlags;
+import edu.wpi.first.networktables.EntryNotification;
+import edu.wpi.first.networktables.NetworkTableInstance;
+
+/**
+ * Generates event markers from NetworkTables. If the specified marker importance is invalid,
+ * {@link MarkerImportance#NORMAL} will be used.
+ */
+final class MarkerGenerator {
+
+  public static final String MARKER_ENTRY_KEY = "/Shuffleboard/.recording/EventMarker";
+
+  private final NetworkTableInstance inst;
+  private final Recorder recorder;
+
+  private static final int LISTENER_FLAGS = EntryListenerFlags.kImmediate
+      | EntryListenerFlags.kLocal
+      | EntryListenerFlags.kNew
+      | EntryListenerFlags.kUpdate;
+
+  private int listenerHandle = 0;
+
+  MarkerGenerator(NetworkTableInstance inst, Recorder recorder) {
+    this.inst = inst;
+    this.recorder = recorder;
+  }
+
+  public void start() {
+    listenerHandle = inst.addEntryListener(MARKER_ENTRY_KEY, this::handleMarkerEvent, LISTENER_FLAGS);
+  }
+
+  public void stop() {
+    inst.removeEntryListener(listenerHandle);
+  }
+
+  private void handleMarkerEvent(EntryNotification event) {
+    String[] eventInfo = event.value.getStringArray();
+    if (eventInfo.length < 3) {
+      // Not enough info; bail
+      return;
+    }
+    String name = eventInfo[0];
+    if (name == null || name.isEmpty() || name.chars().allMatch(Character::isWhitespace)) {
+      // Invalid name; bail
+      return;
+    }
+    String description = eventInfo[1] == null ? "" : eventInfo[1];
+    String importanceName = eventInfo[2];
+    MarkerImportance importance = MarkerImportance.NORMAL;
+    for (MarkerImportance value : MarkerImportance.values()) {
+      if (value.name().equalsIgnoreCase(importanceName)) {
+        importance = value;
+        break;
+      }
+    }
+    recorder.addMarker(name, description, importance);
+  }
+}

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/MarkerGenerator.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/MarkerGenerator.java
@@ -31,7 +31,6 @@ final class MarkerGenerator {
 
   private static final Logger log = Logger.getLogger(MarkerGenerator.class.getName());
 
-  public static final String MARKER_ENTRY_KEY = "/Shuffleboard/.recording/EventMarker";
   public static final String EVENT_TABLE_NAME = "/Shuffleboard/.recording/events/";
   public static final String EVENT_INFO_KEY = "/Info";
   private static final String[] EMPTY = new String[0];

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/MarkerGenerator.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/MarkerGenerator.java
@@ -7,6 +7,8 @@ import edu.wpi.first.networktables.EntryListenerFlags;
 import edu.wpi.first.networktables.EntryNotification;
 import edu.wpi.first.networktables.NetworkTableInstance;
 
+import java.util.Locale;
+
 /**
  * Generates event markers from NetworkTables. If the specified marker importance is invalid,
  * {@link MarkerImportance#NORMAL} will be used.
@@ -51,13 +53,7 @@ final class MarkerGenerator {
     }
     String description = eventInfo[1] == null ? "" : eventInfo[1];
     String importanceName = eventInfo[2];
-    MarkerImportance importance = MarkerImportance.NORMAL;
-    for (MarkerImportance value : MarkerImportance.values()) {
-      if (value.name().equalsIgnoreCase(importanceName)) {
-        importance = value;
-        break;
-      }
-    }
+    MarkerImportance importance = MarkerImportance.valueOf(importanceName.toUpperCase(Locale.US));
     recorder.addMarker(name, description, importance);
   }
 }

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
@@ -35,7 +35,7 @@ import javafx.beans.value.ChangeListener;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "NetworkTables",
-    version = "2.1.0",
+    version = "2.2.0",
     summary = "Provides sources and widgets for NetworkTables"
 )
 public class NetworkTablesPlugin extends Plugin {

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
@@ -109,7 +109,9 @@ public class NetworkTablesPlugin extends Plugin {
     }, 0xFF);
 
     DashboardMode.currentModeProperty().addListener(dashboardModeChangeListener);
-    recorderController.start();
+    if (Recorder.getInstance().isRunning()) {
+      recorderController.start();
+    }
     tabGenerator.start();
 
     serverChangeListener.changed(null, null, serverId.get());

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/RecorderController.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/RecorderController.java
@@ -22,6 +22,7 @@ public final class RecorderController {
   private final NetworkTableEntry startStopControlEntry;
   private final NetworkTableEntry fileNameFormatEntry;
   private final Recorder recorder;
+  private final MarkerGenerator markerGenerator;
 
   private static final int updateFlags =
       EntryListenerFlags.kImmediate
@@ -62,6 +63,7 @@ public final class RecorderController {
     startStopControlEntry = ntInstance.getEntry(startStopKey);
     fileNameFormatEntry = ntInstance.getEntry(fileNameFormatKey);
     this.recorder = recorder;
+    this.markerGenerator = new MarkerGenerator(ntInstance, recorder);
   }
 
   /**
@@ -70,6 +72,7 @@ public final class RecorderController {
    */
   public void start() {
     listenerHandle = startStopControlEntry.addListener(this::updateControl, updateFlags);
+    markerGenerator.start();
   }
 
   /**
@@ -77,6 +80,7 @@ public final class RecorderController {
    */
   public void stop() {
     startStopControlEntry.removeListener(listenerHandle);
+    markerGenerator.stop();
   }
 
   /**

--- a/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/MarkerGeneratorTest.java
+++ b/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/MarkerGeneratorTest.java
@@ -14,11 +14,9 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.TimeUnit;
-
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.testfx.util.WaitForAsyncUtils.sleep;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class MarkerGeneratorTest {
 
@@ -71,7 +69,9 @@ public class MarkerGeneratorTest {
   private void waitForEntry() {
     recorder.start();
     generator.start();
-    sleep(50, TimeUnit.MILLISECONDS);
+    if (!ntInstance.waitForEntryListenerQueue(10)) {
+      fail("Entry notification timed out");
+    }
   }
 
   @Test

--- a/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/MarkerGeneratorTest.java
+++ b/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/MarkerGeneratorTest.java
@@ -1,0 +1,121 @@
+package edu.wpi.first.shuffleboard.plugin.networktables;
+
+import edu.wpi.first.shuffleboard.api.sources.recording.Marker;
+import edu.wpi.first.shuffleboard.api.sources.recording.MarkerImportance;
+import edu.wpi.first.shuffleboard.api.sources.recording.Recorder;
+import edu.wpi.first.shuffleboard.api.util.AsyncUtils;
+import edu.wpi.first.shuffleboard.api.util.FxUtils;
+import edu.wpi.first.shuffleboard.plugin.networktables.util.NetworkTableUtils;
+
+import edu.wpi.first.networktables.NetworkTableEntry;
+import edu.wpi.first.networktables.NetworkTableInstance;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.testfx.util.WaitForAsyncUtils.sleep;
+
+public class MarkerGeneratorTest {
+
+  private NetworkTableInstance ntInstance;
+  private Recorder recorder;
+  private MarkerGenerator generator;
+  private NetworkTableEntry entry;
+
+  @BeforeEach
+  public void setup() {
+    AsyncUtils.setAsyncRunner(Runnable::run);
+    ntInstance = NetworkTableInstance.create();
+    ntInstance.setUpdateRate(0.01);
+    entry = ntInstance.getEntry(MarkerGenerator.MARKER_ENTRY_KEY);
+    recorder = Recorder.createDummyInstance();
+    generator = new MarkerGenerator(ntInstance, recorder);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    NetworkTableUtils.shutdown(ntInstance);
+    AsyncUtils.setAsyncRunner(FxUtils::runOnFxThread);
+  }
+
+  @Test
+  public void testInvalidEntryType() {
+    entry.setBoolean(false);
+    assertNoMarkersAdded();
+  }
+
+  @Test
+  public void testEmptyStringArray() {
+    entry.setStringArray(new String[0]);
+    assertNoMarkersAdded();
+  }
+
+  @Test
+  public void testStringArrayTooLarge() {
+    entry.setStringArray(new String[4]);
+    assertNoMarkersAdded();
+  }
+
+  @Test
+  public void testEmptyMarkerName() {
+    entry.setStringArray(new String[]{"", "description", "severity"});
+    assertNoMarkersAdded();
+  }
+
+  @Test
+  public void testWhitespaceMarkerName() {
+    entry.setStringArray(new String[]{"\t\r\n\n ", "description", "severity"});
+    assertNoMarkersAdded();
+  }
+
+  private void assertNoMarkersAdded() {
+    waitForEntry();
+    assertEquals(0, recorder.getRecording().getMarkers().size(), "No markers should have been added");
+  }
+
+  private void waitForEntry() {
+    recorder.start();
+    generator.start();
+    sleep(50, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  public void testMarkerAdded() {
+    String name = "name";
+    String description = "description";
+    String importance = "none";
+    entry.setStringArray(new String[]{name, description, importance});
+    Marker expected = new Marker(name, description, MarkerImportance.NONE, 0);
+    waitForEntry();
+    assertAll(
+        () -> assertEquals(1, recorder.getRecording().getMarkers().size(), "One marker should have been added"),
+        () -> assertEqualsIgnoreTimestamp(expected, recorder.getRecording().getMarkers().get(0))
+    );
+  }
+
+  @Test
+  public void testNoDescription() {
+    String name = "name";
+    String importance = "critical";
+    entry.setStringArray(new String[]{name, "", importance});
+    Marker expected = new Marker(name, "", MarkerImportance.CRITICAL, 0);
+    waitForEntry();
+    assertAll(
+        () -> assertEquals(1, recorder.getRecording().getMarkers().size(), "One marker should have been added"),
+        () -> assertEqualsIgnoreTimestamp(expected, recorder.getRecording().getMarkers().get(0))
+    );
+  }
+
+  private void assertEqualsIgnoreTimestamp(Marker expected, Marker actual) {
+    assertAll("Marker did not match",
+        () -> assertEquals(expected.getName(), actual.getName(), "Names did not match"),
+        () -> assertEquals(expected.getDescription(), actual.getDescription(), "Descriptions did not match"),
+        () -> assertEquals(expected.getImportance(), actual.getImportance(), "Importance did not match")
+    );
+  }
+}

--- a/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/MarkerGeneratorTest.java
+++ b/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/MarkerGeneratorTest.java
@@ -88,9 +88,9 @@ public class MarkerGeneratorTest {
   public void testMarkerAdded() {
     String name = "name";
     String description = "description";
-    String importance = "none";
+    String importance = "trivial";
     entry.setStringArray(new String[]{name, description, importance});
-    Marker expected = new Marker(name, description, MarkerImportance.NONE, 0);
+    Marker expected = new Marker(name, description, MarkerImportance.TRIVIAL, 0);
     waitForEntry();
     assertAll(
         () -> assertEquals(1, recorder.getRecording().getMarkers().size(), "One marker should have been added"),

--- a/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/MarkerGeneratorTest.java
+++ b/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/MarkerGeneratorTest.java
@@ -22,6 +22,8 @@ import static org.testfx.util.WaitForAsyncUtils.sleep;
 
 public class MarkerGeneratorTest {
 
+  private static final String MARKER_NAME = "MyEvent";
+
   private NetworkTableInstance ntInstance;
   private Recorder recorder;
   private MarkerGenerator generator;
@@ -32,7 +34,7 @@ public class MarkerGeneratorTest {
     AsyncUtils.setAsyncRunner(Runnable::run);
     ntInstance = NetworkTableInstance.create();
     ntInstance.setUpdateRate(0.01);
-    entry = ntInstance.getEntry(MarkerGenerator.MARKER_ENTRY_KEY);
+    entry = ntInstance.getEntry(MarkerGenerator.EVENT_TABLE_NAME + MARKER_NAME + MarkerGenerator.EVENT_INFO_KEY);
     recorder = Recorder.createDummyInstance();
     generator = new MarkerGenerator(ntInstance, recorder);
   }
@@ -57,19 +59,7 @@ public class MarkerGeneratorTest {
 
   @Test
   public void testStringArrayTooLarge() {
-    entry.setStringArray(new String[4]);
-    assertNoMarkersAdded();
-  }
-
-  @Test
-  public void testEmptyMarkerName() {
-    entry.setStringArray(new String[]{"", "description", "severity"});
-    assertNoMarkersAdded();
-  }
-
-  @Test
-  public void testWhitespaceMarkerName() {
-    entry.setStringArray(new String[]{"\t\r\n\n ", "description", "severity"});
+    entry.setStringArray(new String[3]);
     assertNoMarkersAdded();
   }
 
@@ -86,11 +76,10 @@ public class MarkerGeneratorTest {
 
   @Test
   public void testMarkerAdded() {
-    String name = "name";
     String description = "description";
     String importance = "trivial";
-    entry.setStringArray(new String[]{name, description, importance});
-    Marker expected = new Marker(name, description, MarkerImportance.TRIVIAL, 0);
+    entry.setStringArray(new String[]{description, importance});
+    Marker expected = new Marker(MARKER_NAME, description, MarkerImportance.TRIVIAL, 0);
     waitForEntry();
     assertAll(
         () -> assertEquals(1, recorder.getRecording().getMarkers().size(), "One marker should have been added"),
@@ -100,10 +89,9 @@ public class MarkerGeneratorTest {
 
   @Test
   public void testNoDescription() {
-    String name = "name";
     String importance = "critical";
-    entry.setStringArray(new String[]{name, "", importance});
-    Marker expected = new Marker(name, "", MarkerImportance.CRITICAL, 0);
+    entry.setStringArray(new String[]{"", importance});
+    Marker expected = new Marker(MARKER_NAME, "", MarkerImportance.CRITICAL, 0);
     waitForEntry();
     assertAll(
         () -> assertEquals(1, recorder.getRecording().getMarkers().size(), "One marker should have been added"),


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->
This adds a mechanism for adding event markers to data recordings. Markers can be added to a recording from plugins with `Recorder.addMarker(name, description, importance)`.

## Creating markers via NetworkTables

Markers can also be added by NetworkTables clients (eg robot programs) by creating or updating an entry with the format
`/Shuffleboard/.recording/events/<marker name>/Info=["description", "importance"]`
The description is optional and may be an empty string.  
The importance must be one of `"TRIVIAL"`, `"LOW"`, `"NORMAL"`, `"HIGH"`, or `"CRITICAL"` (capitalization is ignored).

Recording converters and UI elements will be added in followup pull requests.