### PR TITLE
Only attempt to save a frame from a camera stream if recording

### DIFF
--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/CameraServerSource.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/CameraServerSource.java
@@ -251,7 +251,9 @@ public final class CameraServerSource extends AbstractDataSource<CameraServerDat
       } else {
         setData(getData().withImage(image));
       }
-      Recorder.getInstance().record(getId(), getDataType(), getData().withImage(image.clone()));
+      if (Recorder.getInstance().isRunning()) {
+        Recorder.getInstance().record(getId(), getDataType(), getData().withImage(image.clone()));
+      }
     }
     return true;
   }


### PR DESCRIPTION
Fixes a rather large potential memory leak caused by keeping camera frames in memory waiting to be saved to disk but never are. 

Fixes #544