### PR TITLE
Allow widgets added via NetworkTables to use arbitrary data sources

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/function/MappableSupplier.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/function/MappableSupplier.java
@@ -1,0 +1,26 @@
+package edu.wpi.first.shuffleboard.api.util.function;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * A type of supplier that can have its output mapped to a different type.
+ *
+ * @param <T> the type of results supplied by this supplier
+ */
+@FunctionalInterface
+public interface MappableSupplier<T> extends Supplier<T> {
+
+  /**
+   * Creates a new mappable supplier whose output corresponds, roughly, to {@code mappingFunction.apply(get())}.
+   *
+   * @param mappingFunction the function to use to map the output of this supplier to a different value
+   * @param <U> the type of the mapped value
+   *
+   * @return a new mappable supplier
+   */
+  default <U> MappableSupplier<U> map(Function<? super T, ? extends U> mappingFunction) {
+    return () -> mappingFunction.apply(get());
+  }
+
+}

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
@@ -13,6 +13,7 @@ import edu.wpi.first.shuffleboard.api.sources.recording.Recorder;
 import edu.wpi.first.shuffleboard.api.tab.model.TabStructure;
 import edu.wpi.first.shuffleboard.api.util.PreferencesUtils;
 import edu.wpi.first.shuffleboard.api.widget.ComponentType;
+import edu.wpi.first.shuffleboard.api.widget.Components;
 import edu.wpi.first.shuffleboard.api.widget.WidgetType;
 import edu.wpi.first.shuffleboard.plugin.networktables.sources.NetworkTableSourceType;
 import edu.wpi.first.shuffleboard.plugin.networktables.util.NetworkTableUtils;
@@ -35,7 +36,7 @@ import javafx.beans.value.ChangeListener;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "NetworkTables",
-    version = "2.2.1",
+    version = "2.2.2",
     summary = "Provides sources and widgets for NetworkTables"
 )
 public class NetworkTablesPlugin extends Plugin {
@@ -47,7 +48,7 @@ public class NetworkTablesPlugin extends Plugin {
   private final StringProperty serverId = new SimpleStringProperty(this, "server", "localhost");
   private final InvalidationListener serverSaver = __ -> PreferencesUtils.save(serverId, preferences);
 
-  private final TabGenerator tabGenerator = new TabGenerator(inst);
+  private final TabGenerator tabGenerator = new TabGenerator(inst, Components.getDefault());
   private final RecorderController recorderController = RecorderController.createWithDefaultEntries(inst);
 
   private final ChangeListener<DashboardMode> dashboardModeChangeListener = (__, old, mode) -> {

--- a/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGeneratorTest.java
+++ b/plugins/networktables/src/test/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGeneratorTest.java
@@ -1,12 +1,16 @@
 package edu.wpi.first.shuffleboard.plugin.networktables;
 
+import edu.wpi.first.shuffleboard.api.data.DataType;
+import edu.wpi.first.shuffleboard.api.data.DataTypes;
 import edu.wpi.first.shuffleboard.api.tab.model.ComponentModel;
 import edu.wpi.first.shuffleboard.api.tab.model.TabModel;
 import edu.wpi.first.shuffleboard.api.tab.model.TabStructure;
 import edu.wpi.first.shuffleboard.api.util.GridPoint;
+import edu.wpi.first.shuffleboard.api.widget.AbstractWidget;
 import edu.wpi.first.shuffleboard.api.widget.ComponentType;
 import edu.wpi.first.shuffleboard.api.widget.Components;
 import edu.wpi.first.shuffleboard.api.widget.TileSize;
+import edu.wpi.first.shuffleboard.api.widget.WidgetType;
 import edu.wpi.first.shuffleboard.plugin.networktables.sources.NetworkTableSourceType;
 
 import com.google.common.collect.Iterables;
@@ -19,6 +23,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Map;
+import java.util.Set;
+
+import javafx.scene.layout.Pane;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -41,10 +48,11 @@ public class TabGeneratorTest {
     ntInstance.setUpdateRate(0.01);
     rootTable = ntInstance.getTable("/Shuffleboard");
     rootMetaTable = rootTable.getSubTable(".metadata");
-    generator = new TabGenerator(ntInstance);
     components = new Components();
+    generator = new TabGenerator(ntInstance, components);
     Components.setDefault(components);
     NetworkTableSourceType.setInstance(new NetworkTableSourceType(new NetworkTablesPlugin()));
+    DataTypes.getDefault().getItems().forEach(t -> components.setDefaultComponent(t, new MockWidgetType()));
   }
 
   @AfterAll
@@ -361,6 +369,42 @@ public class TabGeneratorTest {
     @Override
     public Object get() {
       return null;
+    }
+  }
+
+  private static final class MockWidget extends AbstractWidget {
+
+    @Override
+    public Pane getView() {
+      return null;
+    }
+
+    @Override
+    public String getName() {
+      return "Mock Widget";
+    }
+  }
+
+  private static final class MockWidgetType implements WidgetType<MockWidget> {
+
+    @Override
+    public Class<MockWidget> getType() {
+      return MockWidget.class;
+    }
+
+    @Override
+    public String getName() {
+      return "Mock Widget";
+    }
+
+    @Override
+    public Set<DataType> getDataTypes() {
+      return Set.of();
+    }
+
+    @Override
+    public MockWidget get() {
+      return new MockWidget();
     }
   }
 }


### PR DESCRIPTION
Add a ".ShuffleboardURI" entry to the table to provide a fully-qualified URI (including protocol) to the data source the widget should use, e.g. "camera_server://MyCamera".

This opens up WPILib for making VideoSources sendable to Shuffleboard via the WPILib Shuffleboard API.

Adds a `MappableSupplier` functional interface for cleaner data mapping in a `Supplier`