### PR TITLE
Allow complex widget property types to be specified remotely

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/PropertyParser.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/PropertyParser.java
@@ -1,0 +1,80 @@
+package edu.wpi.first.shuffleboard.api;
+
+/**
+ * Parses arbitrary input and returns the result. This is used to set the values of
+ * {@link edu.wpi.first.shuffleboard.api.widget.Component Component} settings provided by a remote definition (such as
+ * a FRC robot program).
+ *
+ * @param <T> the type of values this parser provides
+ */
+public interface PropertyParser<T> {
+
+  /**
+   * Creates a new property parser for an enum type. Valid inputs are {@code E}, {@code String} (matching the enum
+   * constant name), and {@code Integer} (enum ordinal).
+   *
+   * @param type the enum type to create a parser for
+   * @param <E>  the type of the enum class
+   *
+   * @return a parser that outputs constants from the given enum type
+   */
+  static <E extends Enum<E>> PropertyParser<E> forEnum(Class<E> type) {
+    if (!type.isEnum()) {
+      throw new IllegalArgumentException("Not an enum type: " + type);
+    }
+    return new PropertyParser<>() {
+      @Override
+      public Class<E> outputType() {
+        return type;
+      }
+
+      @Override
+      public boolean canParse(Object input) {
+        return type.isInstance(input)
+            || input instanceof String
+            || input instanceof Integer;
+      }
+
+      @Override
+      public E parse(Object input) {
+        if (type.isInstance(input)) {
+          return (E) input;
+        }
+        E[] values = type.getEnumConstants();
+        if (input instanceof String) {
+          for (E value : values) {
+            if (value.name().equals(input)) {
+              return value;
+            }
+          }
+        } else if (input instanceof Integer) {
+          return values[(Integer) input];
+        }
+        throw new IllegalArgumentException("Unsupported input: " + input);
+      }
+    };
+  }
+
+  /**
+   * Gets the type of the output of the parser.
+   */
+  Class<T> outputType();
+
+  /**
+   * Checks if the given input is supported by this parser.
+   *
+   * @param input the input to check
+   *
+   * @return true if the input can be {@link #parse(Object) parsed}, false if not
+   */
+  boolean canParse(Object input);
+
+  /**
+   * Parses the given input and returns the result.
+   *
+   * @param input the value to parse
+   *
+   * @return the parsed value
+   */
+  T parse(Object input);
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/PropertyParsers.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/PropertyParsers.java
@@ -56,15 +56,15 @@ public final class PropertyParsers extends Registry<PropertyParser<?>> {
   /**
    * Parses the given input as a value of the given output type.
    *
-   * @param outputType the type of the value to parse as
    * @param input      the value to parse
+   * @param outputType the type of the value to parse as
    * @param <T>        the type of the parsed result
    *
    * @return the parse result
    *
    * @throws IllegalStateException if there are multiple registered parsers for type {@code T}
    */
-  public <T> Optional<T> parse(Class<T> outputType, Object input) {
+  public <T> Optional<T> parse(Object input, Class<T> outputType) {
     Set<T> possibilities = getItems()
         .stream()
         .filter(p -> outputType.isAssignableFrom(p.outputType()))

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/PropertyParsers.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/PropertyParsers.java
@@ -67,7 +67,7 @@ public final class PropertyParsers extends Registry<PropertyParser<?>> {
   public <T> Optional<T> parse(Class<T> outputType, Object input) {
     Set<T> possibilities = getItems()
         .stream()
-        .filter(p -> p.outputType().isAssignableFrom(outputType))
+        .filter(p -> outputType.isAssignableFrom(p.outputType()))
         .filter(p -> p.canParse(input))
         .map(p -> (PropertyParser<T>) p)
         .map(p -> p.parse(input))

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/PropertyParsers.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/PropertyParsers.java
@@ -1,0 +1,168 @@
+package edu.wpi.first.shuffleboard.api;
+
+import edu.wpi.first.shuffleboard.api.util.Registry;
+import edu.wpi.first.shuffleboard.api.widget.LayoutBase;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javafx.geometry.Orientation;
+import javafx.scene.paint.Color;
+
+/**
+ * Registry for {@link PropertyParser PropertyParsers}.
+ */
+public final class PropertyParsers extends Registry<PropertyParser<?>> {
+
+  private static final PropertyParser<Orientation> ORIENTATION =
+      PropertyParser.forEnum(Orientation.class);
+
+  private static final PropertyParser<LayoutBase.LabelPosition> LABEL_POSITION =
+      PropertyParser.forEnum(LayoutBase.LabelPosition.class);
+
+  private static final PropertyParser<String> STRING = new StringPropertyParser();
+  private static final PropertyParser<Number> NUMBER = new NumberPropertyParser();
+  private static final PropertyParser<Boolean> BOOLEAN = new BooleanPropertyParser();
+  private static final PropertyParser<Color> COLOR = new ColorPropertyParser();
+
+  private static final PropertyParsers defaultInstance = new PropertyParsers();
+
+  public PropertyParsers() {
+    registerAll(BOOLEAN, COLOR, NUMBER, STRING, ORIENTATION, LABEL_POSITION);
+  }
+
+  public static PropertyParsers getDefault() {
+    return defaultInstance;
+  }
+
+  @Override
+  public void register(PropertyParser<?> item) {
+    if (getItems().stream().anyMatch(item::equals)) {
+      throw new IllegalArgumentException("Parser " + item + " is already registered");
+    }
+    if (getItems().stream().map(PropertyParser::outputType).anyMatch(item.outputType()::equals)) {
+      throw new IllegalArgumentException(
+          "A parser is already registered with the same output type: " + item.outputType());
+    }
+    addItem(item);
+  }
+
+  @Override
+  public void unregister(PropertyParser<?> item) {
+    removeItem(item);
+  }
+
+  /**
+   * Parses the given input as a value of the given output type.
+   *
+   * @param outputType the type of the value to parse as
+   * @param input      the value to parse
+   * @param <T>        the type of the parsed result
+   *
+   * @return the parse result
+   *
+   * @throws IllegalStateException if there are multiple registered parsers for type {@code T}
+   */
+  public <T> Optional<T> parse(Class<T> outputType, Object input) {
+    Set<T> possibilities = getItems()
+        .stream()
+        .filter(p -> p.outputType().isAssignableFrom(outputType))
+        .filter(p -> p.canParse(input))
+        .map(p -> (PropertyParser<T>) p)
+        .map(p -> p.parse(input))
+        .collect(Collectors.toSet());
+    if (possibilities.isEmpty()) {
+      return Optional.empty();
+    }
+    if (possibilities.size() > 1) {
+      throw new IllegalStateException(
+          "Multiple parsers for " + input + " supporting output type " + outputType.getSimpleName());
+    }
+    return Optional.of(possibilities.iterator().next());
+  }
+
+  private static final class StringPropertyParser implements PropertyParser<String> {
+    @Override
+    public Class<String> outputType() {
+      return String.class;
+    }
+
+    @Override
+    public boolean canParse(Object input) {
+      return input != null;
+    }
+
+    @Override
+    public String parse(Object input) {
+      return input.toString();
+    }
+  }
+
+  private static final class NumberPropertyParser implements PropertyParser<Number> {
+    @Override
+    public Class<Number> outputType() {
+      return Number.class;
+    }
+
+    @Override
+    public boolean canParse(Object input) {
+      return input instanceof Number;
+    }
+
+    @Override
+    public Number parse(Object input) {
+      return (Number) input;
+    }
+  }
+
+  private static final class BooleanPropertyParser implements PropertyParser<Boolean> {
+    @Override
+    public Class<Boolean> outputType() {
+      return Boolean.class;
+    }
+
+    @Override
+    public boolean canParse(Object input) {
+      return input instanceof Boolean;
+    }
+
+    @Override
+    public Boolean parse(Object input) {
+      return (Boolean) input;
+    }
+  }
+
+  private static final class ColorPropertyParser implements PropertyParser<Color> {
+    @Override
+    public Class<Color> outputType() {
+      return Color.class;
+    }
+
+    @Override
+    public boolean canParse(Object input) {
+      return input instanceof Color
+          || input instanceof String
+          || input instanceof Number;
+    }
+
+    @Override
+    @SuppressWarnings("LocalVariableName") // r, g, b, a for color channels are OK names
+    public Color parse(Object input) {
+      if (input instanceof Color) {
+        return (Color) input;
+      } else if (input instanceof String) {
+        return Color.web((String) input);
+      } else if (input instanceof Number) {
+        int rgba = ((Number) input).intValue();
+        int r = (rgba >> 24) & 0xFF;
+        int g = (rgba >> 16) & 0xFF;
+        int b = (rgba >> 8) & 0xFF;
+        int a = rgba & 0xFF;
+        return Color.rgb(r, g, b, a / 255.0);
+      } else {
+        throw new IllegalArgumentException("Unsupported input: " + input);
+      }
+    }
+  }
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/ExtendedPropertySheet.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/ExtendedPropertySheet.java
@@ -323,7 +323,8 @@ public class ExtendedPropertySheet extends PropertySheet {
 
     @Override
     public Class<?> getType() {
-      return setting.getProperty().getValue().getClass();
+      Class<?> type = setting.getType();
+      return type == null ? setting.getProperty().getValue().getClass() : type;
     }
 
     @Override
@@ -349,7 +350,7 @@ public class ExtendedPropertySheet extends PropertySheet {
     @Override
     @SuppressWarnings("unchecked")
     public void setValue(Object value) {
-      ((Property) setting.getProperty()).setValue(value);
+      ((Setting) setting).setValue(value);
     }
 
     @Override

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/json/PropertySaver.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/json/PropertySaver.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javafx.beans.property.Property;
+import javafx.beans.value.ObservableValue;
 
 /**
  * Saves property fields annotated with {@link SaveThisProperty @SaveThisProperty} and properties of fields annotated
@@ -48,7 +49,7 @@ public final class PropertySaver {
     // Save settings
     for (Group group : object.getSettings()) {
       for (Setting<?> setting : group.getSettings()) {
-        Property property = setting.getProperty();
+        var property = setting.getProperty();
         if (!savedProperties.contains(property)) {
           PropertySaver.serializeProperty(context, jsonObject, property, group.getName() + "/" + setting.getName());
         }
@@ -124,8 +125,8 @@ public final class PropertySaver {
 
     // Load settings
     for (Group group : object.getSettings()) {
-      for (Setting<?> setting : group.getSettings()) {
-        Property property = setting.getProperty();
+      for (Setting setting : group.getSettings()) {
+        var property = setting.getProperty();
         if (savedProperties.contains(property)) {
           continue;
         }
@@ -133,7 +134,7 @@ public final class PropertySaver {
             jsonObject.get(group.getName() + "/" + setting.getName()),
             property.getValue().getClass());
         if (deserialized != null) {
-          property.setValue(deserialized);
+          setting.setValue(deserialized);
         }
       }
     }
@@ -288,7 +289,10 @@ public final class PropertySaver {
     }
   }
 
-  public static void serializeProperty(JsonSerializationContext context, JsonObject object, Property p, String name) {
+  public static void serializeProperty(JsonSerializationContext context,
+                                       JsonObject object,
+                                       ObservableValue<?> p,
+                                       String name) {
     object.add(name, context.serialize(p.getValue()));
   }
 

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/plugin/Plugin.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/plugin/Plugin.java
@@ -1,5 +1,6 @@
 package edu.wpi.first.shuffleboard.api.plugin;
 
+import edu.wpi.first.shuffleboard.api.PropertyParser;
 import edu.wpi.first.shuffleboard.api.data.DataType;
 import edu.wpi.first.shuffleboard.api.json.ElementTypeAdapter;
 import edu.wpi.first.shuffleboard.api.prefs.Group;
@@ -22,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.Property;
@@ -184,6 +186,13 @@ public class Plugin {
    */
   public List<ComponentType> getComponents() {
     return ImmutableList.of();
+  }
+
+  /**
+   * Gets the custom property parsers used to convert custom widget properties to useful values.
+   */
+  public Set<PropertyParser<?>> getPropertyParsers() {
+    return Set.of();
   }
 
   /**

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/prefs/Setting.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/prefs/Setting.java
@@ -3,6 +3,7 @@ package edu.wpi.first.shuffleboard.api.prefs;
 import java.util.Objects;
 
 import javafx.beans.property.Property;
+import javafx.beans.property.ReadOnlyProperty;
 
 /**
  * A single user-configurable setting.
@@ -14,9 +15,11 @@ public final class Setting<T> {
   private final Property<T> property;
   private final String name;
   private final String description;
+  private final Class<? extends T> type;
 
   /**
-   * Creates a new setting.
+   * Creates a new setting. Note: custom widgets and components should use one of the typed factory methods to allow
+   * their properties to be set from a remote definition (such as the program of an FRC robot).
    *
    * @param name        the name of the setting. This cannot be null or empty
    * @param description a description of the setting. This may be null or empty
@@ -24,25 +27,59 @@ public final class Setting<T> {
    * @param <T>         the type of the value to configure
    *
    * @return a new setting
+   *
+   * @see #of(String, String, Property, Class)
    */
   public static <T> Setting<T> of(String name, String description, Property<T> property) {
-    return new Setting<>(name, description, property);
+    return of(name, description, property, null);
   }
 
   /**
-   * Creates a new setting with no description.
+   * Creates a new setting.
+   *
+   * @param name        the name of the setting. This cannot be null or empty
+   * @param description a description of the setting. This may be null or empty
+   * @param property    the property to configure
+   * @param type        the type of values accepted by this setting
+   * @param <T>         the type of the value to configure
+   *
+   * @return a new setting
+   */
+  public static <T> Setting<T> of(String name, String description, Property<T> property, Class<? extends T> type) {
+    return new Setting<>(name, description, property, type);
+  }
+
+  /**
+   * Creates a new setting with no description. Note: custom widgets and components should use one of the typed factory
+   * methods to allow their properties to be set from a remote definition (such as the program of an FRC robot).
    *
    * @param name     the name of the setting
    * @param property the property to configure
    * @param <T>      the type of the value to configure
    *
    * @return a new setting
+   *
+   * @see #of(String, Property, Class)
    */
   public static <T> Setting<T> of(String name, Property<T> property) {
-    return new Setting<>(name, null, property);
+    return of(name, null, property, null);
   }
 
-  private Setting(String name, String description, Property<T> property) {
+  /**
+   * Creates a new setting with no description.
+   *
+   * @param name     the name of the setting. This cannot be null or empty
+   * @param property the property to configure
+   * @param type     the type of values accepted by this setting
+   * @param <T>      the type of the value to configure
+   *
+   * @return a new setting
+   */
+  public static <T> Setting<T> of(String name, Property<T> property, Class<? extends T> type) {
+    return of(name, null, property, type);
+  }
+
+  private Setting(String name, String description, Property<T> property, Class<? extends T> type) {
     Objects.requireNonNull(name, "A setting name cannot be null");
     if (name.chars().allMatch(Character::isWhitespace)) {
       throw new IllegalArgumentException("A setting name cannot be empty");
@@ -51,9 +88,25 @@ public final class Setting<T> {
     this.name = name;
     this.description = description;
     this.property = property;
+    this.type = type;
   }
 
-  public Property<T> getProperty() {
+  /**
+   * Sets the value of this setting.
+   *
+   * @param value the new value
+   *
+   * @throws IllegalArgumentException if the given value is incompatible with the {@link #getType() type} of this
+   *                                  setting
+   */
+  public void setValue(T value) {
+    if (type != null && !type.isInstance(value)) {
+      throw new IllegalArgumentException(Objects.toString(value));
+    }
+    property.setValue(value);
+  }
+
+  public ReadOnlyProperty<T> getProperty() {
     return property;
   }
 
@@ -63,5 +116,12 @@ public final class Setting<T> {
 
   public String getDescription() {
     return description;
+  }
+
+  /**
+   * Gets the type of allowable values. This may be null: if so, there is no restriction.
+   */
+  public Class<? extends T> getType() {
+    return type;
   }
 }

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/PropertyParsersTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/PropertyParsersTest.java
@@ -1,0 +1,50 @@
+package edu.wpi.first.shuffleboard.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import javafx.scene.paint.Color;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class PropertyParsersTest {
+
+  private PropertyParsers parsers;
+
+  @BeforeEach
+  public void setup() {
+    parsers = new PropertyParsers();
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1,1", "12.34,12.34", "abc,abc"})
+  public void testStringParse(Object input, String expectedOutput) {
+    Optional<String> result = parsers.parse(String.class, input);
+    assertTrue(result.isPresent(), "No result");
+    assertEquals(expectedOutput, result.get(), "Unexpected parse result");
+  }
+
+  @ParameterizedTest
+  @MethodSource("colorArgs")
+  public void testColor(Object input, Color expectedOutput) {
+    Optional<Color> result = parsers.parse(Color.class, input);
+    assertTrue(result.isPresent(), "No result");
+    assertEquals(expectedOutput, result.get(), "Unexpected parse result");
+  }
+
+  private static Stream<Arguments> colorArgs() {
+    return Stream.of(
+        Arguments.of(0xFFFFFFFF, Color.WHITE),  // numeric input
+        Arguments.of(Color.BLACK, Color.BLACK), // raw color input
+        Arguments.of("#FF0000", Color.RED),     // web color (basic)
+        Arguments.of("rgb(255, 255, 255)", Color.WHITE) // web color (advanced)
+    );
+  }
+}

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/PropertyParsersTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/PropertyParsersTest.java
@@ -26,7 +26,7 @@ public class PropertyParsersTest {
   @ParameterizedTest
   @CsvSource({"1,1", "12.34,12.34", "abc,abc"})
   public void testStringParse(Object input, String expectedOutput) {
-    Optional<String> result = parsers.parse(String.class, input);
+    Optional<String> result = parsers.parse(input, String.class);
     assertTrue(result.isPresent(), "No result");
     assertEquals(expectedOutput, result.get(), "Unexpected parse result");
   }
@@ -34,7 +34,7 @@ public class PropertyParsersTest {
   @ParameterizedTest
   @MethodSource("colorArgs")
   public void testColor(Object input, Color expectedOutput) {
-    Optional<Color> result = parsers.parse(Color.class, input);
+    Optional<Color> result = parsers.parse(input, Color.class);
     assertTrue(result.isPresent(), "No result");
     assertEquals(expectedOutput, result.get(), "Unexpected parse result");
   }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
@@ -1,5 +1,6 @@
 package edu.wpi.first.shuffleboard.app.components;
 
+import edu.wpi.first.shuffleboard.api.PropertyParsers;
 import edu.wpi.first.shuffleboard.api.plugin.Plugin;
 import edu.wpi.first.shuffleboard.api.sources.DataSource;
 import edu.wpi.first.shuffleboard.api.sources.SourceEntry;
@@ -42,7 +43,7 @@ public class DashboardTabPane extends TabPane {
     FxUtils.runOnFxThread(() -> {
       Map<TabModel, ProcedurallyDefinedTab> realTabs = pluginTabs.computeIfAbsent(tabs, __ -> new WeakHashMap<>());
       for (TabModel model : tabs.getTabs().values()) {
-        ProcedurallyDefinedTab tab = realTabs.computeIfAbsent(model, ProcedurallyDefinedTab::new);
+        var tab = realTabs.computeIfAbsent(model, m -> new ProcedurallyDefinedTab(m, PropertyParsers.getDefault()));
         if (!getTabs().contains(tab)) {
           getTabs().add(getTabs().size() - 1, tab);
         }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/ProcedurallyDefinedTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/ProcedurallyDefinedTab.java
@@ -152,7 +152,7 @@ public class ProcedurallyDefinedTab extends DashboardTab {
           .filter(s -> s.getType() != null)
           .forEach(s -> {
             if (s.getName().equalsIgnoreCase(name)) {
-              parsers.parse(s.getType(), value)
+              parsers.parse(value, s.getType())
                   .ifPresent(v -> ((Setting) s).setValue(v));
             }
           });

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/ProcedurallyDefinedTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/ProcedurallyDefinedTab.java
@@ -2,7 +2,6 @@ package edu.wpi.first.shuffleboard.app.components;
 
 import edu.wpi.first.shuffleboard.api.PropertyParsers;
 import edu.wpi.first.shuffleboard.api.prefs.Category;
-import edu.wpi.first.shuffleboard.api.prefs.Group;
 import edu.wpi.first.shuffleboard.api.prefs.Setting;
 import edu.wpi.first.shuffleboard.api.tab.model.ComponentModel;
 import edu.wpi.first.shuffleboard.api.tab.model.LayoutModel;
@@ -19,7 +18,6 @@ import edu.wpi.first.shuffleboard.api.widget.TileSize;
 import edu.wpi.first.shuffleboard.api.widget.Widget;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.logging.Logger;

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -71,7 +71,7 @@ import java.util.Set;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "Base",
-    version = "1.1.1",
+    version = "1.1.2",
     summary = "Defines all the WPILib data types and stock widgets"
 )
 @SuppressWarnings("PMD.CouplingBetweenObjects")

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -1,5 +1,6 @@
 package edu.wpi.first.shuffleboard.plugin.base;
 
+import edu.wpi.first.shuffleboard.api.PropertyParser;
 import edu.wpi.first.shuffleboard.api.data.DataType;
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
 import edu.wpi.first.shuffleboard.api.json.ElementTypeAdapter;
@@ -162,6 +163,13 @@ public class BasePlugin extends Plugin {
         .put(BasicSubsystemType.Instance, WidgetType.forAnnotatedWidget(BasicSubsystemWidget.class))
         .put(SubsystemType.Instance, createSubsystemLayoutType())
         .build();
+  }
+
+  @Override
+  public Set<PropertyParser<?>> getPropertyParsers() {
+    return Set.of(
+        PropertyParser.forEnum(ThreeAxisAccelerometerWidget.Range.class)
+    );
   }
 
   private static LayoutClass<SubsystemLayout> createSubsystemLayoutType() {

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/GridLayout.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/GridLayout.java
@@ -337,9 +337,9 @@ public final class GridLayout extends LayoutBase {
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Layout",
-            Setting.of("Number of columns", numColumns),
-            Setting.of("Number of rows", numRows),
-            Setting.of("Label position", labelPositionProperty())
+            Setting.of("Number of columns", numColumns, Integer.class),
+            Setting.of("Number of rows", numRows, Integer.class),
+            Setting.of("Label position", labelPositionProperty(), LabelPosition.class)
         )
     );
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/ListLayout.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/ListLayout.java
@@ -104,7 +104,7 @@ public class ListLayout extends LayoutBase {
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Layout",
-            Setting.of("Label position", labelPositionProperty())
+            Setting.of("Label position", labelPositionProperty(), LabelPosition.class)
         )
     );
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/AccelerometerWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/AccelerometerWidget.java
@@ -50,13 +50,13 @@ public class AccelerometerWidget extends SimpleAnnotatedWidget<AccelerometerData
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Visuals",
-            Setting.of("Show text", showText),
-            Setting.of("Precision", numDecimals),
-            Setting.of("Show tick marks", indicator.showTickMarksProperty())
+            Setting.of("Show text", showText, Boolean.class),
+            Setting.of("Precision", numDecimals, Integer.class),
+            Setting.of("Show tick marks", indicator.showTickMarksProperty(), Boolean.class)
         ),
         Group.of("Range",
-            Setting.of("Min", indicator.minProperty()),
-            Setting.of("Max", indicator.maxProperty())
+            Setting.of("Min", indicator.minProperty(), Number.class),
+            Setting.of("Max", indicator.maxProperty(), Number.class)
         )
     );
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/BooleanBoxWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/BooleanBoxWidget.java
@@ -45,8 +45,8 @@ public class BooleanBoxWidget extends SimpleAnnotatedWidget<Boolean> {
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Colors",
-            Setting.of("Color when true", "The color to use when the value is `true`", trueColor),
-            Setting.of("Color when false", "The color to use when the value is `false`", falseColor)
+            Setting.of("Color when true", "The color to use when the value is `true`", trueColor, Color.class),
+            Setting.of("Color when false", "The color to use when the value is `false`", falseColor, Color.class)
         )
     );
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/DifferentialDriveWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/DifferentialDriveWidget.java
@@ -121,11 +121,11 @@ public final class DifferentialDriveWidget extends AbstractDriveWidget<Different
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Wheels",
-            Setting.of("Number of wheels", numWheels),
-            Setting.of("Wheel diameter", wheelHeight)
+            Setting.of("Number of wheels", numWheels, Integer.class),
+            Setting.of("Wheel diameter", wheelHeight, Number.class)
         ),
         Group.of("Visuals",
-            Setting.of("Show velocity vectors", showVectors)
+            Setting.of("Show velocity vectors", showVectors, Boolean.class)
         )
     );
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/GraphWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/GraphWidget.java
@@ -386,13 +386,13 @@ public class GraphWidget extends AbstractWidget implements AnnotatedWidget {
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Graph",
-            Setting.of("Visible time", visibleTime)
+            Setting.of("Visible time", visibleTime, Number.class)
         ),
         Group.of("Visible data",
             visibleSeries.values()
                 .stream()
                 .sorted(Comparator.comparing(Property::getName, AlphanumComparator.INSTANCE))
-                .map(p -> Setting.of(p.getName(), p))
+                .map(p -> Setting.of(p.getName(), p, Boolean.class))
                 .collect(Collectors.toList())
         )
     );

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/GyroWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/GyroWidget.java
@@ -38,9 +38,9 @@ public class GyroWidget extends SimpleAnnotatedWidget<GyroData> {
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Visuals",
-            Setting.of("Major tick spacing", gauge.majorTickSpaceProperty()),
-            Setting.of("Starting angle", gauge.startAngleProperty()),
-            Setting.of("Show tick mark ring", gauge.tickMarkRingVisibleProperty())
+            Setting.of("Major tick spacing", gauge.majorTickSpaceProperty(), Number.class),
+            Setting.of("Starting angle", gauge.startAngleProperty(), Number.class),
+            Setting.of("Show tick mark ring", gauge.tickMarkRingVisibleProperty(), Boolean.class)
         )
     );
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/MecanumDriveWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/MecanumDriveWidget.java
@@ -139,7 +139,7 @@ public final class MecanumDriveWidget extends AbstractDriveWidget<MecanumDriveDa
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Visuals",
-            Setting.of("Show velocity vectors", showForceVectors)
+            Setting.of("Show velocity vectors", showForceVectors, Boolean.class)
         )
     );
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/NumberBarWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/NumberBarWidget.java
@@ -56,13 +56,13 @@ public class NumberBarWidget extends SimpleAnnotatedWidget<Number> {
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Range",
-            Setting.of("Min", indicator.minProperty()),
-            Setting.of("Max", indicator.maxProperty()),
-            Setting.of("Center", indicator.centerProperty())
+            Setting.of("Min", indicator.minProperty(), Number.class),
+            Setting.of("Max", indicator.maxProperty(), Number.class),
+            Setting.of("Center", indicator.centerProperty(), Number.class)
         ),
         Group.of("Visuals",
-            Setting.of("Num tick marks", numTicks),
-            Setting.of("Show text", showText)
+            Setting.of("Num tick marks", numTicks, Integer.class),
+            Setting.of("Show text", showText, Boolean.class)
         )
     );
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/NumberSliderWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/NumberSliderWidget.java
@@ -44,9 +44,9 @@ public class NumberSliderWidget extends SimpleAnnotatedWidget<Number> {
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Slider Settings",
-            Setting.of("Min", slider.minProperty()),
-            Setting.of("Max", slider.maxProperty()),
-            Setting.of("Block increment", slider.blockIncrementProperty())
+            Setting.of("Min", slider.minProperty(), Number.class),
+            Setting.of("Max", slider.maxProperty(), Number.class),
+            Setting.of("Block increment", slider.blockIncrementProperty(), Number.class)
         )
     );
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/PowerDistributionPanelWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/PowerDistributionPanelWidget.java
@@ -120,7 +120,7 @@ public class PowerDistributionPanelWidget extends SimpleAnnotatedWidget<PowerDis
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Visuals",
-            Setting.of("Show voltage and current values", showIndicatorText)
+            Setting.of("Show voltage and current values", showIndicatorText, Boolean.class)
         )
     );
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/RobotPreferencesWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/RobotPreferencesWidget.java
@@ -80,7 +80,7 @@ public class RobotPreferencesWidget extends SimpleAnnotatedWidget<RobotPreferenc
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Miscellaneous",
-            Setting.of("Show search box", propertySheet.searchBoxVisibleProperty())
+            Setting.of("Show search box", propertySheet.searchBoxVisibleProperty(), Boolean.class)
         )
     );
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/SimpleDialWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/SimpleDialWidget.java
@@ -33,11 +33,11 @@ public class SimpleDialWidget extends SimpleAnnotatedWidget<Number> {
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Range",
-            Setting.of("Min", dial.minValueProperty()),
-            Setting.of("Max", dial.maxValueProperty())
+            Setting.of("Min", dial.minValueProperty(), Number.class),
+            Setting.of("Max", dial.maxValueProperty(), Number.class)
         ),
         Group.of("Visuals",
-            Setting.of("Show value", dial.valueVisibleProperty())
+            Setting.of("Show value", dial.valueVisibleProperty(), Boolean.class)
         )
     );
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/SpeedControllerWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/SpeedControllerWidget.java
@@ -77,7 +77,7 @@ public class SpeedControllerWidget extends SimpleAnnotatedWidget<SpeedController
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Visuals",
-            Setting.of("Orientation", orientation)
+            Setting.of("Orientation", orientation, Orientation.class)
         )
     );
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/ThreeAxisAccelerometerWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/ThreeAxisAccelerometerWidget.java
@@ -28,7 +28,7 @@ import javafx.scene.layout.Pane;
 @ParametrizedController("ThreeAxisAccelerometerWidget.fxml")
 public class ThreeAxisAccelerometerWidget extends SimpleAnnotatedWidget<ThreeAxisAccelerometerData> {
 
-  private enum Range {
+  public enum Range {
     k2G(2),
     k4G(4),
     k8G(8),
@@ -92,12 +92,12 @@ public class ThreeAxisAccelerometerWidget extends SimpleAnnotatedWidget<ThreeAxi
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Accelerometer",
-            Setting.of("Range", range)
+            Setting.of("Range", range, Range.class)
         ),
         Group.of("Visuals",
-            Setting.of("Show value", showText),
-            Setting.of("Precision", numDecimals),
-            Setting.of("Show tick marks", x.showTickMarksProperty())
+            Setting.of("Show value", showText, Boolean.class),
+            Setting.of("Precision", numDecimals, Integer.class),
+            Setting.of("Show tick marks", x.showTickMarksProperty(), Boolean.class)
         )
     );
   }

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/VoltageViewWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/VoltageViewWidget.java
@@ -23,6 +23,7 @@ import java.util.logging.Logger;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.SimpleDoubleProperty;
 import javafx.fxml.FXML;
+import javafx.geometry.Orientation;
 import javafx.scene.layout.Pane;
 
 @Description(name = "Voltage View", dataTypes = {NumberType.class, AnalogInputType.class})
@@ -75,13 +76,13 @@ public class VoltageViewWidget extends SingleSourceWidget implements AnnotatedWi
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Range",
-            Setting.of("Min", indicator.minProperty()),
-            Setting.of("Max", indicator.maxProperty()),
-            Setting.of("Center", indicator.centerProperty())
+            Setting.of("Min", indicator.minProperty(), Number.class),
+            Setting.of("Max", indicator.maxProperty(), Number.class),
+            Setting.of("Center", indicator.centerProperty(), Number.class)
         ),
         Group.of("Visuals",
-            Setting.of("Orientation", indicator.orientationProperty()),
-            Setting.of("Number of tick marks", numTicks)
+            Setting.of("Orientation", indicator.orientationProperty(), Orientation.class),
+            Setting.of("Number of tick marks", numTicks, Integer.class)
         )
     );
   }

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/CameraServerPlugin.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/CameraServerPlugin.java
@@ -1,5 +1,6 @@
 package edu.wpi.first.shuffleboard.plugin.cameraserver;
 
+import edu.wpi.first.shuffleboard.api.PropertyParser;
 import edu.wpi.first.shuffleboard.api.data.DataType;
 import edu.wpi.first.shuffleboard.api.plugin.Description;
 import edu.wpi.first.shuffleboard.api.plugin.Plugin;
@@ -12,6 +13,7 @@ import edu.wpi.first.shuffleboard.plugin.cameraserver.data.type.CameraServerData
 import edu.wpi.first.shuffleboard.plugin.cameraserver.source.CameraServerSourceType;
 import edu.wpi.first.shuffleboard.plugin.cameraserver.source.CameraStreamAdapter;
 import edu.wpi.first.shuffleboard.plugin.cameraserver.widget.CameraServerWidget;
+import edu.wpi.first.shuffleboard.plugin.cameraserver.widget.CameraServerWidget.Rotation;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -22,12 +24,13 @@ import org.opencv.core.Core;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "CameraServer",
-    version = "2.0.0",
+    version = "2.0.1",
     summary = "Provides sources and widgets for viewing CameraServer MJPEG streams"
 )
 @Requires(group = "edu.wpi.first.shuffleboard", name = "NetworkTables", minVersion = "2.0.0")
@@ -35,6 +38,8 @@ public class CameraServerPlugin extends Plugin {
 
   private static final Logger log = Logger.getLogger(CameraServerPlugin.class.getName());
   private final CameraStreamAdapter streamRecorder = new CameraStreamAdapter();
+
+  private static final PropertyParser<Rotation> CAMERA_ROTATION = PropertyParser.forEnum(Rotation.class);
 
   @Override
   public void onLoad() {
@@ -49,6 +54,11 @@ public class CameraServerPlugin extends Plugin {
     return ImmutableList.of(
         WidgetType.forAnnotatedWidget(CameraServerWidget.class)
     );
+  }
+
+  @Override
+  public Set<PropertyParser<?>> getPropertyParsers() {
+    return Set.of(CAMERA_ROTATION);
   }
 
   @Override

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.java
@@ -141,12 +141,12 @@ public class CameraServerWidget extends SimpleAnnotatedWidget<CameraServerData> 
   public List<Group> getSettings() {
     return ImmutableList.of(
         Group.of("Crosshair",
-            Setting.of("Show crosshair", showCrosshair),
-            Setting.of("Crosshair color", crosshairColor)
+            Setting.of("Show crosshair", showCrosshair, Boolean.class),
+            Setting.of("Crosshair color", crosshairColor, Color.class)
         ),
         Group.of("Controls",
-            Setting.of("Show controls", showControls),
-            Setting.of("Rotation", rotation)
+            Setting.of("Show controls", showControls, Boolean.class),
+            Setting.of("Rotation", rotation, Rotation.class)
         )
     );
   }


### PR DESCRIPTION
# Overview

This allows custom widget properties to be properly parsed and set - e.g. setting custom colors on a boolean box widget from a robot program.

Parsers are available by default for numbers, strings, booleans, JavaFX colors, orientation, and layout label positions. The base and cameraserver plugins also have parsers for custom widget properties in those plugins.