### PR TITLE
Export event markers to csv

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Converter.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Converter.java
@@ -1,7 +1,16 @@
 package edu.wpi.first.shuffleboard.api.sources.recording;
 
+import edu.wpi.first.shuffleboard.api.sources.DataSourceUtils;
+
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Handles converting of recording files to a file. These are useful for making it easier to analyze recorded data with
@@ -31,5 +40,92 @@ public interface Converter {
    * @throws IOException if the file could not be written
    */
   void export(Recording recording, Path destination, ConversionSettings settings) throws IOException;
+
+  /**
+   * Flattens recording entries into a single map of timestamp-to-data. Note that each timestamp is expected to have
+   * no more than ONE event marker mapped to it.
+   *
+   * @param recording the recording to flatten
+   * @param settings  the conversion settings to use
+   * @param window    the time window within which temporally-close data should be considered to have the same
+   *                  timestamp. A value of zero will result in only entries for that timestamp being mapped to it;
+   *                  higher values loosens this restriction to accommodate potential variances in timestamps.
+   *
+   * @return a flattened view the timestamped entries in the recording
+   *
+   * @throws IllegalArgumentException if {@code window} is negative
+   */
+  @SuppressWarnings("LocalVariableName")
+  static Map<Long, List<RecordingEntry>> flatten(Recording recording, ConversionSettings settings, long window) {
+    if (window < 0) {
+      throw new IllegalArgumentException("Time window must be non-negative, given " + window);
+    }
+
+    if (recording.getData().isEmpty() && recording.getMarkers().isEmpty()) {
+      // No data or events
+      return Map.of();
+    }
+
+    // All the timestamped data and event markers, sorted by timestamp in ascending order (oldest data first)
+    final List<RecordingEntry> data = Stream.concat(
+        recording.getData().stream(),
+        recording.getMarkers().stream())
+        .sorted(Comparator.comparingLong(RecordingEntry::getTimestamp))
+        .collect(Collectors.toList());
+
+    final Map<Long, List<RecordingEntry>> map = new HashMap<>();
+    final boolean skipMetadata = !settings.isConvertMetadata();
+
+    for (int i = 0; i < data.size(); ) {
+      RecordingEntry point = data.get(i);
+      if (skipMetadata && isMetadata(point)) {
+        // Skip metadata
+        i++;
+        continue;
+      }
+
+      int j = i;
+      List<RecordingEntry> elements = new ArrayList<>();
+      // Collate data within a certain delta time to the same collection, since there may be some time jitter
+      // for multiple recorded data points that were updated at the same time, but network latencies
+      // or CPU usage caused the timestamps to be slightly different
+      for (; j < data.size() && data.get(j).getTimestamp() <= point.getTimestamp() + window; j++) {
+        var e = data.get(j);
+        if (skipMetadata && isMetadata(e)) {
+          continue;
+        }
+        elements.add(e);
+      }
+
+      // Place the marker (if present) at the beginning
+      // Note: assumes only one marker is present per slice, so the time window must
+      // be narrow enough to preserve this behavior
+      for (int k = elements.size() - 1; k >= 0; k--) {
+        if (elements.get(k) instanceof Marker) {
+          var element = elements.remove(k);
+          elements.add(0, element);
+          break;
+        }
+      }
+      map.put(point.getTimestamp(), elements);
+      i = j;
+    }
+    return map;
+  }
+
+  /**
+   * Checks if a recording entry is metadata.
+   *
+   * @param entry the entry to check
+   *
+   * @return true if the entry is metadata, false if not
+   */
+  private static boolean isMetadata(RecordingEntry entry) {
+    if (entry instanceof TimestampedData) {
+      var data = (TimestampedData) entry;
+      return DataSourceUtils.isMetadata(data.getSourceId());
+    }
+    return false;
+  }
 
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Marker.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/Marker.java
@@ -5,7 +5,7 @@ import java.util.Objects;
 /**
  * Marks an event in a recording.
  */
-public final class Marker {
+public final class Marker implements RecordingEntry {
 
   private final String name;
   private final String description;
@@ -62,6 +62,7 @@ public final class Marker {
   /**
    * Gets the timestamp of the marked event.
    */
+  @Override
   public long getTimestamp() {
     return timestamp;
   }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/RecordingEntry.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/RecordingEntry.java
@@ -1,0 +1,11 @@
+package edu.wpi.first.shuffleboard.api.sources.recording;
+
+/**
+ * Common interface for generic recording entries.
+ */
+public interface RecordingEntry {
+  /**
+   * The timestamp of this entry.
+   */
+  long getTimestamp();
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/TimestampedData.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/sources/recording/TimestampedData.java
@@ -8,7 +8,7 @@ import java.util.Objects;
 /**
  * Represents an immutable view of the value of a data source at a specific instant.
  */
-public final class TimestampedData implements Comparable<TimestampedData> {
+public final class TimestampedData implements RecordingEntry, Comparable<TimestampedData> {
 
   private final String sourceId;
   private final DataType dataType;
@@ -42,6 +42,7 @@ public final class TimestampedData implements Comparable<TimestampedData> {
     return data;
   }
 
+  @Override
   public long getTimestamp() {
     return timestamp;
   }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverter.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverter.java
@@ -3,7 +3,9 @@ package edu.wpi.first.shuffleboard.app.sources.recording;
 import edu.wpi.first.shuffleboard.api.sources.DataSourceUtils;
 import edu.wpi.first.shuffleboard.api.sources.recording.ConversionSettings;
 import edu.wpi.first.shuffleboard.api.sources.recording.Converter;
+import edu.wpi.first.shuffleboard.api.sources.recording.Marker;
 import edu.wpi.first.shuffleboard.api.sources.recording.Recording;
+import edu.wpi.first.shuffleboard.api.sources.recording.RecordingEntry;
 import edu.wpi.first.shuffleboard.api.sources.recording.TimestampedData;
 import edu.wpi.first.shuffleboard.api.util.AlphanumComparator;
 
@@ -15,10 +17,15 @@ import org.apache.commons.csv.CSVPrinter;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.io.Writer;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
 
 public final class CsvConverter implements Converter {
 
@@ -30,6 +37,10 @@ public final class CsvConverter implements Converter {
   // This value is set to be able to collate data that gets updated 100 times per second without
   // pulling data from two separate update events into a single row
   private static final int TIME_WINDOW = 7; // milliseconds
+
+  private static final Logger log = Logger.getLogger(CsvConverter.class.getName());
+  private static final String invariantViolatedMessageFormat =
+      "Invariant violated: multiple non-data points in data list (found: %s at index %d of %d), for timestamp %d";
 
   private CsvConverter() {
   }
@@ -45,43 +56,85 @@ public final class CsvConverter implements Converter {
   }
 
   @Override
-  @SuppressWarnings("LocalVariableName")
-  @SuppressFBWarnings(value = "UC_USELESS_OBJECT", justification = "False positive with List.forEach")
   public void export(Recording recording, Path destination, ConversionSettings settings) throws IOException {
+    try (var outputStream = new FileOutputStream(destination.toFile());
+         var writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
+      writer.append(convertToCsv(recording, settings));
+    }
+  }
+
+  /**
+   * Converts recorded data to CSV text.
+   *
+   * @param recording the recording to convert
+   * @param settings  the conversion settings to use
+   *
+   * @return a CSV-formatted text string of the data in the recording
+   */
+  @SuppressFBWarnings(value = "UC_USELESS_OBJECT", justification = "False positive with List.forEach")
+  public String convertToCsv(Recording recording, ConversionSettings settings) {
     List<String> header = makeHeader(recording, settings);
     int headerSize = header.size();
     CSVFormat csvFormat = CSVFormat.DEFAULT.withHeader(header.toArray(new String[headerSize]));
 
-    try (Writer writer = new OutputStreamWriter(new FileOutputStream(destination.toFile()), "UTF-8");
-         CSVPrinter printer = new CSVPrinter(writer, csvFormat)) {
+    try (var writer = new StringWriter();
+         var csvPrinter = new CSVPrinter(writer, csvFormat)) {
+      var flattenedData = Converter.flatten(recording, settings, TIME_WINDOW);
 
-      List<TimestampedData> data = recording.getData();
-      boolean skipMetadata = !settings.isConvertMetadata();
+      var rows = flattenedData.entrySet()
+          .stream()
+          .map(e -> toRow(header, headerSize, e))
+          .filter(Objects::nonNull)
+          .collect(Collectors.toList());
 
-      for (int i = 0; i < data.size(); ) {
-        TimestampedData point = data.get(i);
-        if (skipMetadata && DataSourceUtils.isMetadata(point.getSourceId())) {
-          i++;
-          continue;
-        }
-        int j = i;
-        List<TimestampedData> row = new ArrayList<>();
-        // Collate data within a certain delta time to the same row, since there may be some time jitter
-        // for multiple recorded data points that were updated at the same time, but network latencies
-        // or CPU usage caused the timestamps to be slightly different
-        for (; j < data.size() && data.get(j).getTimestamp() <= point.getTimestamp() + TIME_WINDOW; j++) {
-          TimestampedData d = data.get(j);
-          if (!(skipMetadata && DataSourceUtils.isMetadata(d.getSourceId()))) {
-            row.add(d);
-          }
-        }
-        Object[] rowToSave = new Object[headerSize];
-        row.forEach(d -> rowToSave[header.indexOf(d.getSourceId())] = d.getData());
-        rowToSave[0] = point.getTimestamp();
-        printer.printRecord(rowToSave);
-        i = j;
+      for (Object[] row : rows) {
+        csvPrinter.printRecord(row);
       }
+
+      return writer.toString();
+    } catch (IOException e) {
+      throw new IllegalStateException("Could not convert recording to CSV", e);
     }
+  }
+
+  private Object[] toRow(List<String> header, int headerSize, Map.Entry<Long, List<RecordingEntry>> entry) {
+    final var entries = entry.getValue();
+    if (entries.isEmpty()) {
+      return null;
+    }
+    Object[] row = new Object[headerSize];
+    row[0] = entry.getKey();
+
+    int dataStart = 0;
+
+    if (entries.get(0) instanceof Marker) {
+      dataStart = 1;
+
+      var marker = (Marker) entries.get(0);
+      row[1] = marker.getName();
+      row[2] = marker.getDescription();
+      row[3] = marker.getImportance();
+    }
+
+    for (int i = dataStart; i < entries.size(); i++) {
+      if (!(entries.get(i) instanceof TimestampedData)) {
+        // Invariant was violated, log it and discard this row
+        log.warning(
+            String.format(
+                invariantViolatedMessageFormat,
+                entries.get(i),
+                i,
+                entries.size() - 1,
+                entry.getKey()
+            )
+        );
+        return null;
+      }
+      var point = (TimestampedData) entries.get(i);
+      row[header.indexOf(point.getSourceId())] = point.getData();
+    }
+
+    return row;
   }
 
   private List<String> makeHeader(Recording recording, ConversionSettings settings) {
@@ -90,7 +143,7 @@ public final class CsvConverter implements Converter {
       header.removeIf(DataSourceUtils::isMetadata);
     }
     header.sort(AlphanumComparator.INSTANCE);
-    header.add(0, "Timestamp");
+    header.addAll(0, List.of("Timestamp", "Event", "Event Description", "Event Severity"));
     return header;
   }
 

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverter.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverter.java
@@ -21,6 +21,7 @@ import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -83,6 +84,7 @@ public final class CsvConverter implements Converter {
 
       var rows = flattenedData.entrySet()
           .stream()
+          .sorted(Comparator.comparingLong(Map.Entry::getKey))
           .map(e -> toRow(header, headerSize, e))
           .filter(Objects::nonNull)
           .collect(Collectors.toList());

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverter.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverter.java
@@ -40,7 +40,7 @@ public final class CsvConverter implements Converter {
 
   private static final Logger log = Logger.getLogger(CsvConverter.class.getName());
   private static final String invariantViolatedMessageFormat =
-      "Invariant violated: multiple non-data points in data list (found: %s at index %d of %d), for timestamp %d";
+      "Invariant violated: multiple event markers for same timestamp (found: %s at entry %d of %d), for timestamp %d";
 
   private CsvConverter() {
   }
@@ -117,18 +117,18 @@ public final class CsvConverter implements Converter {
     }
 
     for (int i = dataStart; i < entries.size(); i++) {
-      if (!(entries.get(i) instanceof TimestampedData)) {
-        // Invariant was violated, log it and discard this row
+      if (entries.get(i) instanceof Marker) {
+        // Invariant was violated, log it and ignore the marker
         log.warning(
             String.format(
                 invariantViolatedMessageFormat,
                 entries.get(i),
-                i,
-                entries.size() - 1,
+                i + 1,
+                entries.size(),
                 entry.getKey()
             )
         );
-        return null;
+        continue;
       }
       var point = (TimestampedData) entries.get(i);
       row[header.indexOf(point.getSourceId())] = point.getData();

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverterTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverterTest.java
@@ -1,0 +1,64 @@
+package edu.wpi.first.shuffleboard.app.sources.recording;
+
+import edu.wpi.first.shuffleboard.api.data.DataTypes;
+import edu.wpi.first.shuffleboard.api.sources.recording.ConversionSettings;
+import edu.wpi.first.shuffleboard.api.sources.recording.Marker;
+import edu.wpi.first.shuffleboard.api.sources.recording.MarkerImportance;
+import edu.wpi.first.shuffleboard.api.sources.recording.Recording;
+import edu.wpi.first.shuffleboard.api.sources.recording.TimestampedData;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class CsvConverterTest {
+
+  private static final ConversionSettings WITHOUT_METADATA = new ConversionSettings(false);
+
+  private static final String EMPTY_HEADER = "Timestamp,Event,Event Description,Event Severity";
+
+  private CsvConverter converter;
+  private Recording recording;
+
+  @BeforeEach
+  public void setup() {
+    converter = CsvConverter.Instance;
+    recording = new Recording();
+  }
+
+  @Test
+  public void testDataAndMarkerInSameWindow() {
+    recording.append(new TimestampedData("foo", DataTypes.String, "bar", 0));
+    recording.addMarker(new Marker("Name", "Description", MarkerImportance.CRITICAL, 4L));
+
+    String csv = converter.convertToCsv(recording, WITHOUT_METADATA);
+    var lines = csv.lines().collect(Collectors.toList());
+
+    assertAll(
+        () -> assertEquals(EMPTY_HEADER + ",foo", lines.get(0)),
+        () -> assertEquals("0,Name,Description,CRITICAL,bar", lines.get(1))
+    );
+  }
+
+  @Test
+  public void testMultipleMarkersInSameWindow() {
+    // First two markers are in the same time window
+    // That row should be skipped, but the third marker should still be included
+    recording.addMarker(new Marker("First", "", MarkerImportance.LOW, 0L));
+    recording.addMarker(new Marker("Second", "", MarkerImportance.CRITICAL, 0L));
+    recording.addMarker(new Marker("Third", "", MarkerImportance.NORMAL, 255));
+
+    String csv = converter.convertToCsv(recording, WITHOUT_METADATA);
+    var lines = csv.lines().collect(Collectors.toList());
+
+    assertAll(
+        () -> assertEquals(EMPTY_HEADER, lines.get(0), "First line should be the header"),
+        () -> assertEquals("255,Third,,NORMAL", lines.get(1), "Second line should be the third marker")
+    );
+  }
+
+}

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverterTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverterTest.java
@@ -47,7 +47,7 @@ public class CsvConverterTest {
   @Test
   public void testMultipleMarkersInSameWindow() {
     // First two markers are in the same time window
-    // That row should be skipped, but the third marker should still be included
+    // The second marker should be skipped, but the first and third should still be present
     recording.addMarker(new Marker("First", "", MarkerImportance.LOW, 0L));
     recording.addMarker(new Marker("Second", "", MarkerImportance.CRITICAL, 0L));
     recording.addMarker(new Marker("Third", "", MarkerImportance.NORMAL, 255));
@@ -57,7 +57,8 @@ public class CsvConverterTest {
 
     assertAll(
         () -> assertEquals(EMPTY_HEADER, lines.get(0), "First line should be the header"),
-        () -> assertEquals("255,Third,,NORMAL", lines.get(1), "Second line should be the third marker")
+        () -> assertEquals("0,First,,LOW", lines.get(1), "Second line should be the first marker"),
+        () -> assertEquals("255,Third,,NORMAL", lines.get(2), "Third line should be the third marker")
     );
   }
 


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->
This adds event marker columns at the start of the table:

```
Timestamp,Event,Event Description,Event Severity,[Sources...]
0,First Event,This is the first event,CRITICAL,[...]
```

| Timestamp | Event | Event Description | Event Severity | [Sources...]
|---|---|---|---|---|
0 | "First Event" | "This is the first event" | CRITICAL | [...]


If multiple events were logged for the same (or similar) timestamp (i.e. within 7ms of each other), only the first event will be present in the generated CSV and successive markers will be ignored and have messages logged.

A convenience method has been added to the `Converter` interface to map all data within a certain window to the same timestamp