### PR TITLE
Remove the powerup plugin from the app

### DIFF
--- a/app/app.gradle.kts
+++ b/app/app.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
     nativeProject(path = ":plugins:base")
     nativeProject(path = ":plugins:cameraserver")
     nativeProject(path = ":plugins:networktables")
-    nativeProject(path = ":plugins:powerup")
     compile(group = "de.huxhorn.lilith", name = "de.huxhorn.lilith.3rdparty.junique", version = "1.0.4")
     compile(group = "org.apache.commons", name = "commons-csv", version = "1.5")
     testCompile(project("test_plugins"))

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Shuffleboard.java
@@ -12,7 +12,6 @@ import edu.wpi.first.shuffleboard.app.sources.recording.CsvConverter;
 import edu.wpi.first.shuffleboard.plugin.base.BasePlugin;
 import edu.wpi.first.shuffleboard.plugin.cameraserver.CameraServerPlugin;
 import edu.wpi.first.shuffleboard.plugin.networktables.NetworkTablesPlugin;
-import edu.wpi.first.shuffleboard.plugin.powerup.PowerUpPlugin;
 
 import com.google.common.base.Stopwatch;
 
@@ -83,8 +82,6 @@ public class Shuffleboard extends Application {
     PluginLoader.getDefault().load(new NetworkTablesPlugin());
     notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading CameraServer plugin", 0.375));
     PluginLoader.getDefault().load(new CameraServerPlugin());
-    notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading Powerup plugin", 0.5));
-    PluginLoader.getDefault().load(new PowerUpPlugin());
     notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading custom plugins", 0.625));
     PluginLoader.getDefault().loadAllJarsFromDir(Storage.getPluginPath());
     notifyPreloader(new ShuffleboardPreloader.StateNotification("Loading custom plugins", 0.75));

--- a/plugins/powerup/README.md
+++ b/plugins/powerup/README.md
@@ -1,0 +1,17 @@
+# POWER UP Plugin
+
+This plugin provides widgets for viewing the field state in the 2018 FRC game. This plugin is no
+longer bundled with the Shuffleboard app (since the 2018 season and offseason are both over), but
+releases will still be made to the WPILib Maven server so it can be used in future offseason events
+or on old robots and driverstations.
+
+Releases can be found [here](http://first.wpi.edu/FRC/roborio/maven/release/edu/wpi/first/shuffleboard/plugin/powerup).
+
+To use the releases, download the JAR file for the version you want to use and place it in the `Shuffleboard/plugins`
+directory in your user home
+
+| Operating System | Plugins Directory |
+|---|---|
+| Windows | `C:\Users\<username>\Shuffleboard\plugins` |
+| Mac | `/Users/<username>/Shuffleboard/plugins` |
+| Linux | `/home/<username>/Shuffleboard/plugins` |


### PR DESCRIPTION
Artifacts will still be published so the plugin can be used in offseason events or on old robots. Documentation for this is present in the README in the powerup plugin root directory.

Closes #467 