### PR TITLE
Only attempt to create a camera stream .mp4 if the file doesn't exist

### DIFF
--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/CameraStreamSaver.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/source/CameraStreamSaver.java
@@ -187,7 +187,10 @@ public final class CameraStreamSaver {
   private FFmpegFrameRecorder createRecorder(int fileIndex) {
     String file = CameraStreamAdapter.videoFilePath(rootRecordingFile, cameraName, fileIndex);
     try {
-      Files.createFile(Paths.get(file));
+      var path = Paths.get(file);
+      if (Files.notExists(path)) {
+        Files.createFile(path);
+      }
     } catch (IOException e) {
       throw new AssertionError("Could not create video file " + file, e);
     }


### PR DESCRIPTION
Fixes an error that sometimes gets thrown