### PR TITLE
Ultrasonic widget

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/PropertyParser.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/PropertyParser.java
@@ -43,7 +43,7 @@ public interface PropertyParser<T> {
         E[] values = type.getEnumConstants();
         if (input instanceof String) {
           for (E value : values) {
-            if (value.name().equals(input)) {
+            if (value.name().equalsIgnoreCase((String) input)) {
               return value;
             }
           }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoader.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoader.java
@@ -1,5 +1,6 @@
 package edu.wpi.first.shuffleboard.app.plugin;
 
+import edu.wpi.first.shuffleboard.api.PropertyParsers;
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
 import edu.wpi.first.shuffleboard.api.data.IncompatibleSourceException;
 import edu.wpi.first.shuffleboard.api.plugin.Description;
@@ -58,7 +59,8 @@ public class PluginLoader {
           Components.getDefault(),
           Themes.getDefault(),
           TabInfoRegistry.getDefault(),
-          Converters.getDefault());
+          Converters.getDefault(),
+          PropertyParsers.getDefault());
 
   private final ObservableSet<Plugin> loadedPlugins = FXCollections.observableSet(new LinkedHashSet<>());
   private final Set<Class<? extends Plugin>> knownPluginClasses = new HashSet<>();
@@ -69,6 +71,7 @@ public class PluginLoader {
   private final Themes themes;
   private final TabInfoRegistry tabInfoRegistry;
   private final Converters converters;
+  private final PropertyParsers propertyParsers;
 
   /**
    * Creates a new plugin loader object. For app use, use {@link #getDefault() the default instance}; this should only
@@ -80,6 +83,7 @@ public class PluginLoader {
    * @param themes          the theme registry to use for registering themes from plugins
    * @param tabInfoRegistry the registry for tab information provided by plugins
    * @param converters      the registry for custom recording file converters
+   * @param propertyParsers the registry for custom property parsers
    *
    * @throws NullPointerException if any of the parameters is {@code null}
    */
@@ -88,13 +92,15 @@ public class PluginLoader {
                       Components components,
                       Themes themes,
                       TabInfoRegistry tabInfoRegistry,
-                      Converters converters) {
+                      Converters converters,
+                      PropertyParsers propertyParsers) {
     this.dataTypes = Objects.requireNonNull(dataTypes, "dataTypes");
     this.sourceTypes = Objects.requireNonNull(sourceTypes, "sourceTypes");
     this.components = Objects.requireNonNull(components, "components");
     this.themes = Objects.requireNonNull(themes, "themes");
     this.tabInfoRegistry = Objects.requireNonNull(tabInfoRegistry, "tabInfoRegistry");
     this.converters = converters;
+    this.propertyParsers = propertyParsers;
   }
 
   /**
@@ -292,6 +298,7 @@ public class PluginLoader {
     plugin.getThemes().forEach(themes::register);
     tabInfoRegistry.registerAll(plugin.getDefaultTabInfo());
     converters.registerAll(plugin.getRecordingConverters());
+    propertyParsers.registerAll(plugin.getPropertyParsers());
 
     plugin.onLoad();
     plugin.setLoaded(true);
@@ -423,6 +430,7 @@ public class PluginLoader {
     themes.unregisterAll(plugin.getThemes());
     tabInfoRegistry.unregisterAll(plugin.getDefaultTabInfo());
     converters.unregisterAll(plugin.getRecordingConverters());
+    propertyParsers.unregisterAll(plugin.getPropertyParsers());
 
     plugin.onUnload();
     plugin.setLoaded(false);

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoaderTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/plugin/PluginLoaderTest.java
@@ -1,5 +1,6 @@
 package edu.wpi.first.shuffleboard.app.plugin;
 
+import edu.wpi.first.shuffleboard.api.PropertyParsers;
 import edu.wpi.first.shuffleboard.api.data.DataType;
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
 import edu.wpi.first.shuffleboard.api.plugin.Description;
@@ -58,7 +59,9 @@ public class PluginLoaderTest {
     components = new Components();
     themes = new Themes();
     tabInfoRegistry = new TabInfoRegistry();
-    loader = new PluginLoader(dataTypes, sourceTypes, components, themes, tabInfoRegistry, new Converters());
+    var converters = new Converters();
+    var propertyParsers = new PropertyParsers();
+    loader = new PluginLoader(dataTypes, sourceTypes, components, themes, tabInfoRegistry, converters, propertyParsers);
   }
 
   @Test

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -29,6 +29,7 @@ import edu.wpi.first.shuffleboard.plugin.base.data.types.SendableChooserType;
 import edu.wpi.first.shuffleboard.plugin.base.data.types.SpeedControllerType;
 import edu.wpi.first.shuffleboard.plugin.base.data.types.SubsystemType;
 import edu.wpi.first.shuffleboard.plugin.base.data.types.ThreeAxisAccelerometerType;
+import edu.wpi.first.shuffleboard.plugin.base.data.types.UltrasonicType;
 import edu.wpi.first.shuffleboard.plugin.base.layout.GridLayout;
 import edu.wpi.first.shuffleboard.plugin.base.layout.GridLayoutSaver;
 import edu.wpi.first.shuffleboard.plugin.base.layout.ListLayout;
@@ -58,6 +59,7 @@ import edu.wpi.first.shuffleboard.plugin.base.widget.TextViewWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.ThreeAxisAccelerometerWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.ToggleButtonWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.ToggleSwitchWidget;
+import edu.wpi.first.shuffleboard.plugin.base.widget.UltrasonicWidget;
 import edu.wpi.first.shuffleboard.plugin.base.widget.VoltageViewWidget;
 
 import com.google.common.collect.ImmutableList;
@@ -71,7 +73,7 @@ import java.util.Set;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "Base",
-    version = "1.1.2",
+    version = "1.1.3",
     summary = "Defines all the WPILib data types and stock widgets"
 )
 @SuppressWarnings("PMD.CouplingBetweenObjects")
@@ -98,7 +100,8 @@ public class BasePlugin extends Plugin {
         RelayType.Instance,
         MecanumDriveType.Instance,
         DifferentialDriveType.Instance,
-        FmsInfoType.Instance
+        FmsInfoType.Instance,
+        UltrasonicType.Instance
     );
   }
 
@@ -131,6 +134,7 @@ public class BasePlugin extends Plugin {
         WidgetType.forAnnotatedWidget(DifferentialDriveWidget.class),
         WidgetType.forAnnotatedWidget(MecanumDriveWidget.class),
         WidgetType.forAnnotatedWidget(BasicFmsInfoWidget.class),
+        WidgetType.forAnnotatedWidget(UltrasonicWidget.class),
         new LayoutClass<>("List Layout", ListLayout.class),
         new LayoutClass<>("Grid Layout", GridLayout.class),
         createSubsystemLayoutType()
@@ -160,6 +164,7 @@ public class BasePlugin extends Plugin {
         .put(DifferentialDriveType.Instance, WidgetType.forAnnotatedWidget(DifferentialDriveWidget.class))
         .put(MecanumDriveType.Instance, WidgetType.forAnnotatedWidget(MecanumDriveWidget.class))
         .put(FmsInfoType.Instance, WidgetType.forAnnotatedWidget(BasicFmsInfoWidget.class))
+        .put(UltrasonicType.Instance, WidgetType.forAnnotatedWidget(UltrasonicWidget.class))
         .put(BasicSubsystemType.Instance, WidgetType.forAnnotatedWidget(BasicSubsystemWidget.class))
         .put(SubsystemType.Instance, createSubsystemLayoutType())
         .build();
@@ -168,7 +173,8 @@ public class BasePlugin extends Plugin {
   @Override
   public Set<PropertyParser<?>> getPropertyParsers() {
     return Set.of(
-        PropertyParser.forEnum(ThreeAxisAccelerometerWidget.Range.class)
+        PropertyParser.forEnum(ThreeAxisAccelerometerWidget.Range.class),
+        PropertyParser.forEnum(UltrasonicWidget.Unit.class)
     );
   }
 

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/UltrasonicData.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/UltrasonicData.java
@@ -1,0 +1,51 @@
+package edu.wpi.first.shuffleboard.plugin.base.data;
+
+import edu.wpi.first.shuffleboard.api.data.ComplexData;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class UltrasonicData extends ComplexData<UltrasonicData> {
+
+  private final double rangeInches;
+
+  public UltrasonicData(double rangeInches) {
+    this.rangeInches = rangeInches;
+  }
+
+  public double getRangeInches() {
+    return rangeInches;
+  }
+
+  @Override
+  public Map<String, Object> asMap() {
+    return Map.of("Value", rangeInches);
+  }
+
+  @Override
+  public String toHumanReadableString() {
+    return String.format("%.3f Inches", rangeInches);
+  }
+
+  @Override
+  public String toString() {
+    return "UltrasonicData(range=" + rangeInches + " inches)";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    UltrasonicData that = (UltrasonicData) o;
+    return Double.compare(that.rangeInches, rangeInches) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(rangeInches);
+  }
+}

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/types/UltrasonicType.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/types/UltrasonicType.java
@@ -1,0 +1,29 @@
+package edu.wpi.first.shuffleboard.plugin.base.data.types;
+
+import edu.wpi.first.shuffleboard.api.data.ComplexDataType;
+import edu.wpi.first.shuffleboard.api.util.Maps;
+import edu.wpi.first.shuffleboard.plugin.base.data.UltrasonicData;
+
+import java.util.Map;
+import java.util.function.Function;
+
+public final class UltrasonicType extends ComplexDataType<UltrasonicData> {
+
+  public static final UltrasonicType Instance = new UltrasonicType();
+
+  private UltrasonicType() {
+    super("Ultrasonic", UltrasonicData.class);
+  }
+
+  @Override
+  public Function<Map<String, Object>, UltrasonicData> fromMap() {
+    return map -> new UltrasonicData(
+        Maps.getOrDefault(map, "Value", 0.0)
+    );
+  }
+
+  @Override
+  public UltrasonicData getDefaultValue() {
+    return new UltrasonicData(0);
+  }
+}

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/UltrasonicWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/UltrasonicWidget.java
@@ -1,0 +1,78 @@
+package edu.wpi.first.shuffleboard.plugin.base.widget;
+
+import edu.wpi.first.shuffleboard.api.prefs.Group;
+import edu.wpi.first.shuffleboard.api.prefs.Setting;
+import edu.wpi.first.shuffleboard.api.widget.Description;
+import edu.wpi.first.shuffleboard.api.widget.ParametrizedController;
+import edu.wpi.first.shuffleboard.api.widget.SimpleAnnotatedWidget;
+import edu.wpi.first.shuffleboard.plugin.base.data.UltrasonicData;
+
+import java.util.List;
+
+import javafx.beans.property.Property;
+import javafx.beans.property.SimpleObjectProperty;
+import javafx.fxml.FXML;
+import javafx.scene.control.TextField;
+import javafx.scene.layout.Pane;
+
+@Description(name = "Ultrasonic", dataTypes = UltrasonicData.class)
+@ParametrizedController("UltrasonicWidget.fxml")
+public final class UltrasonicWidget extends SimpleAnnotatedWidget<UltrasonicData> {
+
+  @FXML
+  private Pane root;
+  @FXML
+  private TextField data;
+
+  private final Property<Unit> unit = new SimpleObjectProperty<>(this, "unit", Unit.INCH);
+
+  private static final String FORMAT = "%.3f %s";
+
+  @FXML
+  private void initialize() {
+    data.textProperty().bind(
+        dataOrDefault.map(UltrasonicData::getRangeInches)
+            .map(d -> Unit.INCH.as(d, getUnit()))
+            .map(v -> String.format(FORMAT, v, getUnit().abbreviation)));
+  }
+
+  public Unit getUnit() {
+    return unit.getValue();
+  }
+
+  @Override
+  public List<Group> getSettings() {
+    return List.of(
+        Group.of(
+            "Unit",
+            Setting.of("Unit", "The unit to display the measured distance as", unit, Unit.class)
+        )
+    );
+  }
+
+  @Override
+  public Pane getView() {
+    return root;
+  }
+
+  public enum Unit {
+    INCH(39.3701, "in"),
+    FOOT(3.28084, "ft"),
+    METER(1, "m"),
+    MM(1000, "mm"),
+    CM(100, "cm");
+
+    private final double baseUnitEquivalent;
+    public final String abbreviation;
+
+    Unit(double baseUnitEquivalent, String abbreviation) {
+      this.baseUnitEquivalent = baseUnitEquivalent;
+      this.abbreviation = abbreviation;
+    }
+
+    public double as(double value, Unit unit) {
+      return value * (unit.baseUnitEquivalent / this.baseUnitEquivalent);
+    }
+  }
+
+}

--- a/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/UltrasonicWidget.fxml
+++ b/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/UltrasonicWidget.fxml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.control.Label?>
+<BorderPane xmlns="http://javafx.com/javafx"
+            xmlns:fx="http://javafx.com/fxml"
+            fx:controller="edu.wpi.first.shuffleboard.plugin.base.widget.UltrasonicWidget"
+            fx:id="root">
+    <left>
+        <Label text="Range: " BorderPane.alignment="CENTER"/>
+    </left>
+    <center>
+        <TextField fx:id="data" editable="false" BorderPane.alignment="CENTER_LEFT"/>
+    </center>
+</BorderPane>

--- a/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/UltrasonicWidget.fxml
+++ b/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/UltrasonicWidget.fxml
@@ -3,10 +3,14 @@
 <?import javafx.scene.control.TextField?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.control.Label?>
+<?import javafx.geometry.Insets?>
 <BorderPane xmlns="http://javafx.com/javafx"
             xmlns:fx="http://javafx.com/fxml"
             fx:controller="edu.wpi.first.shuffleboard.plugin.base.widget.UltrasonicWidget"
             fx:id="root">
+    <padding>
+        <Insets topRightBottomLeft="4"/>
+    </padding>
     <left>
         <Label text="Range: " BorderPane.alignment="CENTER"/>
     </left>


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
- Adds a new widget for displaying ultrasonic sensors
Assumes the given input is in inches (that's what the WPILib objects give)
The display unit can be changed to inches, feet, meters, centimeters, or millimeters, and will convert the input value from inches to the selected unit

- Fixes the plugin loader not applying custom property parsers



# Screenshots
### Ultrasonic widgets generated from a robot program
![image](https://user-images.githubusercontent.com/6320992/50574804-c9f88c00-0dbd-11e9-97a9-bf4da18bd88e.png)

