### PR TITLE
Fix uncaught exceptions not ending up in the log file

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/Main.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/Main.java
@@ -2,6 +2,9 @@ package edu.wpi.first.shuffleboard.app;
 
 import com.sun.javafx.application.LauncherImpl;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * The true main class.  This bypasses module boot layer introspection by the Java launcher that attempts to
  * reflectively access the JavaFX application launcher classes - this will fail because there is no module path;
@@ -10,11 +13,22 @@ import com.sun.javafx.application.LauncherImpl;
  */
 @SuppressWarnings("PMD.UseUtilityClass") // Nope.
 public final class Main {
+  private static final Logger logger = Logger.getLogger(Main.class.getName());
+
   @SuppressWarnings("JavadocMethod")
   public static void main(String[] args) {
     // JavaFX 11+ uses GTK3 by default, and has problems on some display servers
     // This flag forces JavaFX to use GTK2
     System.setProperty("jdk.gtk.version", "2");
+
+    Thread
+        .setDefaultUncaughtExceptionHandler((thread, throwable) -> {
+          logger.log(
+              Level.SEVERE,
+              "Uncaught exception on thread `" + thread.getName() + "`.",
+              throwable
+          );
+        });
     LauncherImpl.launchApplication(Shuffleboard.class, ShuffleboardPreloader.class, args);
   }
 }


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
Makes it so that errors that are caused at launch also end up in the log file. Eg. The issue @bradamiller had this evening.
