### PR TITLE
Improve Camera Widget

### DIFF
--- a/api/api.gradle.kts
+++ b/api/api.gradle.kts
@@ -13,5 +13,6 @@ dependencies {
     api(group = "org.controlsfx", name = "controlsfx", version = "9.0.0")
     api(group = "de.codecentric.centerdevice", name = "javafxsvg", version = "1.2.1")
     api(group = "eu.hansolo", name = "Medusa", version = "7.9") // Note the capital 'M' -- lowercase is a much older version!
+    api(group = "com.jfoenix", name = "jfoenix", version = "9.0.8")
     api(group = "com.github.zafarkhaja", name = "java-semver", version = "0.9.0")
 }

--- a/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
+++ b/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
@@ -279,6 +279,15 @@
     -fx-background-color: -swatch-300;
 }
 
+.jfx-slider {
+    -jfx-default-thumb: -swatch-300;
+    -jfx-default-track: -swatch-gray;
+}
+
+.jfx-slider .track {
+    -fx-pref-height: 4px;
+}
+
 /*******************************************************************************
  *                                                                             *
  * Linear indicator                                                            *

--- a/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
+++ b/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
@@ -279,6 +279,18 @@
     -fx-background-color: -swatch-300;
 }
 
+.slider {
+    -fx-cursor: default;
+}
+
+.slider .thumb {
+    -fx-cursor: hand;
+}
+
+.slider:pressed .thumb {
+    -fx-cursor: move;
+}
+
 .jfx-slider {
     -jfx-default-thumb: -swatch-300;
     -jfx-default-track: -swatch-gray;

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/light.css
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/light.css
@@ -40,3 +40,9 @@
 .text-area, .text-field {
     -underline-color: #eee;
 }
+
+.jfx-slider .slider-value {
+    -fx-fill: #222;
+    -fx-stroke: #222;
+    -fx-stroke-width: 1;
+}

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/CameraServerPlugin.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/CameraServerPlugin.java
@@ -30,7 +30,7 @@ import java.util.logging.Logger;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "CameraServer",
-    version = "2.0.2",
+    version = "2.0.3",
     summary = "Provides sources and widgets for viewing CameraServer MJPEG streams"
 )
 @Requires(group = "edu.wpi.first.shuffleboard", name = "NetworkTables", minVersion = "2.0.0")

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.java
@@ -162,9 +162,9 @@ public class CameraServerWidget extends SimpleAnnotatedWidget<CameraServerData> 
     if (getSource() instanceof CameraServerSource) {
       CameraServerSource source = (CameraServerSource) getSource();
       int compression = (int) compressionSlider.getValue();
-      int fps = frameRateField.getNumber();
-      int width = this.width.getNumber();
-      int height = this.height.getNumber();
+      int fps = ((Number) frameRateField.getNumber()).intValue();
+      int width = ((Number) this.width.getNumber()).intValue();
+      int height = ((Number) this.height.getNumber()).intValue();
       boolean change = source.getTargetCompression() != compression
           || source.getTargetFps() != fps
           || source.getTargetResolution().isNotEqual(width, height);

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.java
@@ -13,11 +13,13 @@ import edu.wpi.first.shuffleboard.plugin.cameraserver.recording.serialization.Im
 import edu.wpi.first.shuffleboard.plugin.cameraserver.source.CameraServerSource;
 
 import com.google.common.collect.ImmutableList;
+import com.jfoenix.controls.JFXSlider;
 
-import java.util.List;
 import org.fxmisc.easybind.EasyBind;
 import org.opencv.core.Core;
 import org.opencv.core.Mat;
+
+import java.util.List;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.Property;
@@ -27,7 +29,6 @@ import javafx.beans.value.ChangeListener;
 import javafx.fxml.FXML;
 import javafx.scene.Node;
 import javafx.scene.control.Label;
-import javafx.scene.control.Slider;
 import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.Pane;
@@ -54,7 +55,7 @@ public class CameraServerWidget extends SimpleAnnotatedWidget<CameraServerData> 
   private Pane controls;
   @FXML
   @SavePropertyFrom(propertyName = "value", savedName = "compression")
-  private Slider compressionSlider;
+  private JFXSlider compressionSlider;
   @FXML
   @SavePropertyFrom(propertyName = "number", savedName = "fps")
   private IntegerField frameRateField;

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.java
@@ -162,9 +162,9 @@ public class CameraServerWidget extends SimpleAnnotatedWidget<CameraServerData> 
     if (getSource() instanceof CameraServerSource) {
       CameraServerSource source = (CameraServerSource) getSource();
       int compression = (int) compressionSlider.getValue();
-      int fps = ((Number) frameRateField.getNumber()).intValue();
-      int width = ((Number) this.width.getNumber()).intValue();
-      int height = ((Number) this.height.getNumber()).intValue();
+      int fps = frameRateField.getNumber();
+      int width = this.width.getNumber();
+      int height = this.height.getNumber();
       boolean change = source.getTargetCompression() != compression
           || source.getTargetFps() != fps
           || source.getTargetResolution().isNotEqual(width, height);

--- a/plugins/cameraserver/src/main/resources/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.fxml
+++ b/plugins/cameraserver/src/main/resources/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.fxml
@@ -14,6 +14,7 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.Pane?>
 <?import javafx.scene.control.Button?>
+<?import com.jfoenix.controls.JFXSlider?>
 <VBox xmlns="http://javafx.com/javafx"
       xmlns:fx="http://javafx.com/fxml"
       fx:controller="edu.wpi.first.shuffleboard.plugin.cameraserver.widget.CameraServerWidget"
@@ -36,7 +37,7 @@
         </Pane>
     </StackPane>
     <GridPane fx:id="controls" alignment="CENTER" visible="${controller.showControls}" managed="${controller.showControls}" hgap="16" styleClass="camera-controls">
-        <Slider fx:id="compressionSlider" min="0" max="100" value="-1" GridPane.columnIndex="0" GridPane.rowIndex="0"/>
+        <JFXSlider fx:id="compressionSlider" min="0" max="100" value="80" GridPane.columnIndex="0" GridPane.rowIndex="0"/>
         <Label text="Compression" minWidth="-Infinity" labelFor="${compressionSlider}" GridPane.columnIndex="0" GridPane.rowIndex="1" GridPane.halignment="CENTER"/>
         <IntegerField fx:id="frameRateField" number="-1" minWidth="50" maxWidth="50" GridPane.columnIndex="1" GridPane.rowIndex="0"/>
         <Label text="FPS" minWidth="-Infinity" labelFor="${frameRateField}" GridPane.columnIndex="1" GridPane.rowIndex="1" GridPane.halignment="CENTER"/>

--- a/plugins/cameraserver/src/main/resources/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.fxml
+++ b/plugins/cameraserver/src/main/resources/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.fxml
@@ -2,19 +2,18 @@
 
 <?import edu.wpi.first.shuffleboard.api.components.IntegerField?>
 <?import edu.wpi.first.shuffleboard.api.components.ResizableImageView?>
+<?import com.jfoenix.controls.JFXSlider?>
 <?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.control.Slider?>
 <?import javafx.scene.image.Image?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.Pane?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.shape.Line?>
-<?import javafx.scene.layout.AnchorPane?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.Pane?>
-<?import javafx.scene.control.Button?>
-<?import com.jfoenix.controls.JFXSlider?>
 <VBox xmlns="http://javafx.com/javafx"
       xmlns:fx="http://javafx.com/fxml"
       fx:controller="edu.wpi.first.shuffleboard.plugin.cameraserver.widget.CameraServerWidget"

--- a/plugins/cameraserver/src/main/resources/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.fxml
+++ b/plugins/cameraserver/src/main/resources/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.fxml
@@ -37,7 +37,7 @@
         </Pane>
     </StackPane>
     <GridPane fx:id="controls" alignment="CENTER" visible="${controller.showControls}" managed="${controller.showControls}" hgap="16" styleClass="camera-controls">
-        <JFXSlider fx:id="compressionSlider" min="0" max="100" value="80" GridPane.columnIndex="0" GridPane.rowIndex="0"/>
+        <JFXSlider fx:id="compressionSlider" min="-1" max="100" value="-1" GridPane.columnIndex="0" GridPane.rowIndex="0"/>
         <Label text="Compression" minWidth="-Infinity" labelFor="${compressionSlider}" GridPane.columnIndex="0" GridPane.rowIndex="1" GridPane.halignment="CENTER"/>
         <IntegerField fx:id="frameRateField" number="-1" minWidth="50" maxWidth="50" GridPane.columnIndex="1" GridPane.rowIndex="0"/>
         <Label text="FPS" minWidth="-Infinity" labelFor="${frameRateField}" GridPane.columnIndex="1" GridPane.rowIndex="1" GridPane.halignment="CENTER"/>


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->
Some minor improvements for camera widgets:
- Use a [JFoenix](https://github.com/jfoenixadmin/JFoenix) slider for compression to show the actual value (instead of an inscrutable slider)
- Fix loading of camera widget properties from save file
- Allow compression to not be set with a value of `-1` (slider in the farthest left position) to reduce CPU usage on the stream host

# Screenshots
<!-- Add screenshots of the new or fixed features, if you modified widgets or the UI -->
![screen record from 2019-01-08 13 36 08](https://user-images.githubusercontent.com/6320992/50851568-32f67b80-134b-11e9-8386-2df27d9b9d38.gif)

