### PR TITLE
Fix remotely-assigned number settings not being applied

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/PropertyParsers.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/PropertyParsers.java
@@ -67,7 +67,7 @@ public final class PropertyParsers extends Registry<PropertyParser<?>> {
   public <T> Optional<T> parse(Object input, Class<T> outputType) {
     Set<T> possibilities = getItems()
         .stream()
-        .filter(p -> outputType.isAssignableFrom(p.outputType()))
+        .filter(p -> p.outputType().isAssignableFrom(outputType))
         .filter(p -> p.canParse(input))
         .map(p -> (PropertyParser<T>) p)
         .map(p -> p.parse(input))

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/PropertyParsersTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/PropertyParsersTest.java
@@ -24,6 +24,22 @@ public class PropertyParsersTest {
   }
 
   @ParameterizedTest
+  @CsvSource({"1.0,1.0", "-2,-2", "3.141592653589,3.141592653589"})
+  public void testParseDouble(double input, double expectedOutput) {
+    Optional<Double> result = parsers.parse(input, Double.class);
+    assertTrue(result.isPresent(), "No result");
+    assertEquals(expectedOutput, result.get().doubleValue(), "Unexpected parse result");
+  }
+
+  @ParameterizedTest
+  @CsvSource({"1,1", "0,0", "65536,65536"})
+  public void testParseInteger(int input, int expectedOutput) {
+    Optional<Integer> result = parsers.parse(input, Integer.class);
+    assertTrue(result.isPresent(), "No result");
+    assertEquals(expectedOutput, result.get().intValue(), "Unexpected parse result");
+  }
+
+  @ParameterizedTest
   @CsvSource({"1,1", "12.34,12.34", "abc,abc"})
   public void testStringParse(Object input, String expectedOutput) {
     Optional<String> result = parsers.parse(input, String.class);


### PR DESCRIPTION
Add tests for double, int parsing

Caused by, essentially, a backwards `instanceof` check