### PR TITLE
Allow users to manually specify upper and lower bounds on graph Y-axis

### DIFF
--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -73,7 +73,7 @@ import java.util.Set;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "Base",
-    version = "1.1.4",
+    version = "1.1.5",
     summary = "Defines all the WPILib data types and stock widgets"
 )
 @SuppressWarnings("PMD.CouplingBetweenObjects")


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->
Adds three new settings to the graph widget's Y-axis:

### Automatic bounds
Use the default JavaFX graph behavior of determining the upper and lower bounds for a graph' Y-axis

### Upper bound
Sets the upper bound of the Y-axis. Defaults to `1`. Can only be used if `Automatic bounds` is disabled

### Lower bound
Sets the lower bound of the Y-axis. Defaults to `-1`. Can only be used if `Automatic bounds` is disabled

Closes #589 
# Screenshots
<!-- Add screenshots of the new or fixed features, if you modified widgets or the UI -->

![screenshot from 2019-02-27 23 15 59](https://user-images.githubusercontent.com/6320992/53541074-1aeadf00-3ae6-11e9-8f43-16a4dd5af80c.png)

