### PR TITLE
Allow remote grid layout definition

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/prefs/Setting.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/prefs/Setting.java
@@ -94,15 +94,38 @@ public final class Setting<T> {
   /**
    * Sets the value of this setting.
    *
+   * <p>If this setting's {@link #getType() type} is a boxed numeric type, then any numeric input is
+   * accepted and cast appropriately.
+   *
    * @param value the new value
    *
    * @throws IllegalArgumentException if the given value is incompatible with the {@link #getType() type} of this
    *                                  setting
    */
   public void setValue(T value) {
+    if (type != null
+        && Number.class.isAssignableFrom(type)
+        && value instanceof Number
+        && !type.isInstance(value)) {
+      // Do some workarounds for numeric input of a different type,
+      // since boxed values cannot be widened like primitives can
+      Number num = (Number) value;
+      if (type == Integer.class) {
+        property.setValue((T) (Integer) num.intValue());
+      } else if (type == Double.class) {
+        property.setValue((T) (Double) num.doubleValue());
+      } else if (type == Long.class) {
+        property.setValue((T) (Long) num.longValue());
+      } else if (type == Byte.class) {
+        property.setValue((T) (Byte) num.byteValue());
+      } else if (type == Short.class) {
+        property.setValue((T) (Short) num.shortValue());
+      }
+      return;
+    }
     if (type != null && !type.isInstance(value)) {
       throw new IllegalArgumentException(
-          String.format("Value is not a %s: '%s' (is: %s)", type.getName(), value, value.getClass().getName()));
+          String.format("Value must be of type %s, but is %s (%s)", type.getName(), value.getClass().getName(), value));
     }
     property.setValue(value);
   }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/ComponentContainer.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/ComponentContainer.java
@@ -1,5 +1,6 @@
 package edu.wpi.first.shuffleboard.api.widget;
 
+import edu.wpi.first.shuffleboard.api.tab.model.ComponentModel;
 import edu.wpi.first.shuffleboard.api.util.TypeUtils;
 
 import java.util.stream.Stream;
@@ -15,6 +16,16 @@ public interface ComponentContainer {
    * @param component the component to add
    */
   void addComponent(Component component);
+
+  /**
+   * Adds a component to this container from a model object. The model may specify position and size, which
+   * implementations must respect if those properties are supported.
+   *
+   * @param model the model for the component to add
+   *
+   * @return the component object that was added to this container, or null if no component was added
+   */
+  Component addComponent(ComponentModel model);
 
   /**
    * Removes a component from this container.

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Layout.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Layout.java
@@ -1,5 +1,8 @@
 package edu.wpi.first.shuffleboard.api.widget;
 
+import edu.wpi.first.shuffleboard.api.tab.model.ComponentModel;
+import edu.wpi.first.shuffleboard.api.tab.model.WidgetModel;
+
 import java.util.Collection;
 import java.util.stream.Stream;
 
@@ -48,6 +51,21 @@ public interface Layout extends Component, ComponentContainer {
   @Override
   default void addComponent(Component component) {
     addChild(component);
+  }
+
+  @Override
+  default Component addComponent(ComponentModel model) {
+    var optionalComponent = Components.getDefault().createComponent(model.getDisplayType());
+    if (model instanceof WidgetModel) {
+      optionalComponent
+          .ifPresent(c -> {
+            ((Widget) c).addSource(((WidgetModel) model).getDataSource());
+            addComponent(c);
+          });
+    } else {
+      optionalComponent.ifPresent(this::addComponent);
+    }
+    return optionalComponent.orElse(null);
   }
 
   @Override

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/ProcedurallyDefinedTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/ProcedurallyDefinedTab.java
@@ -12,7 +12,6 @@ import edu.wpi.first.shuffleboard.api.util.Debouncer;
 import edu.wpi.first.shuffleboard.api.util.FxUtils;
 import edu.wpi.first.shuffleboard.api.widget.Component;
 import edu.wpi.first.shuffleboard.api.widget.ComponentContainer;
-import edu.wpi.first.shuffleboard.api.widget.Components;
 import edu.wpi.first.shuffleboard.api.widget.Widget;
 
 import java.time.Duration;
@@ -114,10 +113,6 @@ public class ProcedurallyDefinedTab extends DashboardTab {
         populateLayout((LayoutModel) componentModel, (ComponentContainer) proceduralComponents.get(componentModel));
       }
     }
-  }
-
-  private Component componentFor(ComponentModel model) {
-    return Components.getDefault().createComponent(model.getDisplayType()).orElse(null);
   }
 
   private void applySettings(Component component, Map<String, Object> properties) {

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/ProcedurallyDefinedTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/ProcedurallyDefinedTab.java
@@ -10,11 +10,9 @@ import edu.wpi.first.shuffleboard.api.tab.model.TabModel;
 import edu.wpi.first.shuffleboard.api.tab.model.WidgetModel;
 import edu.wpi.first.shuffleboard.api.util.Debouncer;
 import edu.wpi.first.shuffleboard.api.util.FxUtils;
-import edu.wpi.first.shuffleboard.api.util.GridPoint;
 import edu.wpi.first.shuffleboard.api.widget.Component;
 import edu.wpi.first.shuffleboard.api.widget.ComponentContainer;
 import edu.wpi.first.shuffleboard.api.widget.Components;
-import edu.wpi.first.shuffleboard.api.widget.TileSize;
 import edu.wpi.first.shuffleboard.api.widget.Widget;
 
 import java.time.Duration;
@@ -100,7 +98,7 @@ public class ProcedurallyDefinedTab extends DashboardTab {
     for (ComponentModel componentModel : parent.getChildren().values()) {
       Component component = proceduralComponents.get(componentModel);
       if (component == null) {
-        component = componentFor(componentModel);
+        component = container.addComponent(componentModel);
         if (component == null) {
           log.warning("No registered component with name '" + componentModel.getDisplayType() + "'");
           continue;
@@ -109,34 +107,12 @@ public class ProcedurallyDefinedTab extends DashboardTab {
         if (componentModel instanceof WidgetModel) {
           ((Widget) component).addSource(((WidgetModel) componentModel).getDataSource());
         }
-        if (container instanceof WidgetPane) {
-          // Set the size and position in the widget pane
-          // Does not apply to layouts, since they do not necessarily support this behavior
-          addToWidgetPane((WidgetPane) container, componentModel, component);
-        } else {
-          container.addComponent(component);
-        }
         proceduralComponents.put(componentModel, component);
       }
       applySettings(component, componentModel.getProperties());
       if (componentModel instanceof LayoutModel) {
         populateLayout((LayoutModel) componentModel, (ComponentContainer) proceduralComponents.get(componentModel));
       }
-    }
-  }
-
-  @SuppressWarnings("PMD.ConfusingTernary")
-  private void addToWidgetPane(WidgetPane widgetPane, ComponentModel componentModel, Component component) {
-    GridPoint position = componentModel.getPreferredPosition();
-    if (position != null) {
-      TileSize size = componentModel.getPreferredSize();
-      if (size != null) {
-        widgetPane.addComponent(component, position, size);
-      } else {
-        widgetPane.addComponent(component, position);
-      }
-    } else {
-      widgetPane.addComponent(component);
     }
   }
 

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/WidgetPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/WidgetPane.java
@@ -274,15 +274,15 @@ public class WidgetPane extends TilePane implements ComponentContainer {
     }
     var component = optionalComponent.get();
     GridPoint position = componentModel.getPreferredPosition();
-    if (position != null) {
-      TileSize size = componentModel.getPreferredSize();
-      if (size != null) {
-        addComponent(component, position, size);
-      } else {
-        addComponent(component, position);
-      }
-    } else {
+    if (position == null) {
       addComponent(component);
+    } else {
+      TileSize size = componentModel.getPreferredSize();
+      if (size == null) {
+        addComponent(component, position);
+      } else {
+        addComponent(component, position, size);
+      }
     }
     return component;
   }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/WidgetPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/WidgetPane.java
@@ -2,12 +2,14 @@ package edu.wpi.first.shuffleboard.app.components;
 
 import edu.wpi.first.shuffleboard.api.css.SimpleColorCssMetaData;
 import edu.wpi.first.shuffleboard.api.css.SimpleCssMetaData;
+import edu.wpi.first.shuffleboard.api.tab.model.ComponentModel;
 import edu.wpi.first.shuffleboard.api.util.GridImage;
 import edu.wpi.first.shuffleboard.api.util.GridPoint;
 import edu.wpi.first.shuffleboard.api.util.RoundingMode;
 import edu.wpi.first.shuffleboard.api.util.TypeUtils;
 import edu.wpi.first.shuffleboard.api.widget.Component;
 import edu.wpi.first.shuffleboard.api.widget.ComponentContainer;
+import edu.wpi.first.shuffleboard.api.widget.Components;
 import edu.wpi.first.shuffleboard.api.widget.TileSize;
 import edu.wpi.first.shuffleboard.api.widget.Widget;
 import edu.wpi.first.shuffleboard.app.dnd.DragUtils;
@@ -261,6 +263,28 @@ public class WidgetPane extends TilePane implements ComponentContainer {
         setSize(tile, size);
       }
     }
+  }
+
+  @Override
+  public Component addComponent(ComponentModel componentModel) {
+    var optionalComponent = Components.getDefault().createComponent(componentModel.getDisplayType());
+    if (optionalComponent.isEmpty()) {
+      // Given component type is not available, bail
+      return null;
+    }
+    var component = optionalComponent.get();
+    GridPoint position = componentModel.getPreferredPosition();
+    if (position != null) {
+      TileSize size = componentModel.getPreferredSize();
+      if (size != null) {
+        addComponent(component, position, size);
+      } else {
+        addComponent(component, position);
+      }
+    } else {
+      addComponent(component);
+    }
+    return component;
   }
 
   /**

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/GridLayout.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/layout/GridLayout.java
@@ -3,12 +3,16 @@ package edu.wpi.first.shuffleboard.plugin.base.layout;
 import edu.wpi.first.shuffleboard.api.components.ActionList;
 import edu.wpi.first.shuffleboard.api.prefs.Group;
 import edu.wpi.first.shuffleboard.api.prefs.Setting;
+import edu.wpi.first.shuffleboard.api.tab.model.ComponentModel;
+import edu.wpi.first.shuffleboard.api.tab.model.WidgetModel;
 import edu.wpi.first.shuffleboard.api.util.GridPoint;
 import edu.wpi.first.shuffleboard.api.util.ListUtils;
 import edu.wpi.first.shuffleboard.api.util.TypeUtils;
 import edu.wpi.first.shuffleboard.api.widget.Component;
+import edu.wpi.first.shuffleboard.api.widget.Components;
 import edu.wpi.first.shuffleboard.api.widget.LayoutBase;
 import edu.wpi.first.shuffleboard.api.widget.ParametrizedController;
+import edu.wpi.first.shuffleboard.api.widget.Sourced;
 
 import com.google.common.collect.ImmutableList;
 
@@ -261,6 +265,21 @@ public final class GridLayout extends LayoutBase {
     ActionList.registerSupplier(pane, () -> actionsForComponent(component));
     panes.put(component, pane);
     return pane;
+  }
+
+  @Override
+  public Component addComponent(ComponentModel model) {
+    var optionalComponent = Components.getDefault().createComponent(model.getDisplayType());
+    if (optionalComponent.isEmpty()) {
+      return null;
+    }
+    var component = optionalComponent.get();
+    if (component instanceof Sourced && model instanceof WidgetModel) {
+      ((Sourced) component).addSource(((WidgetModel) model).getDataSource());
+    }
+    addChild(component, model.getPreferredPosition());
+    // TODO maybe handle sizing?
+    return component;
   }
 
   @Override


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->

Allows children in a grid layout to be laid out using the existing size property (usable with `withSize` in the WPILib API). Children are still forced to be 1x1.

Adds type widening to boxed numeric types in settings (eg to allow an `Integer` setting to have its value set to a `Double`).
