### PR TITLE
Add settings to recording converters

### DIFF
--- a/api-test-util/api-test-util.gradle.kts
+++ b/api-test-util/api-test-util.gradle.kts
@@ -1,0 +1,9 @@
+description = "Shared test utilities for the API and app projects."
+
+plugins {
+    `java`
+}
+
+dependencies {
+    compile(project(":api"))
+}

--- a/api-test-util/src/main/java/edu/wpi/first/shuffleboard/api/testutil/MockPreferences.java
+++ b/api-test-util/src/main/java/edu/wpi/first/shuffleboard/api/testutil/MockPreferences.java
@@ -1,0 +1,64 @@
+package edu.wpi.first.shuffleboard.api.testutil;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.prefs.AbstractPreferences;
+import java.util.prefs.BackingStoreException;
+
+/**
+ * A mock preferences class that stores values in a {@link Map Map&lt;String, String&gt;}.
+ * This cannot have child preference nodes.
+ */
+public class MockPreferences extends AbstractPreferences {
+
+  private final Map<String, String> map = new HashMap<>();
+
+  public MockPreferences() {
+    super(null, "");
+  }
+
+  @Override
+  protected void putSpi(String key, String value) {
+    map.put(key, value);
+  }
+
+  @Override
+  protected String getSpi(String key) {
+    return map.get(key);
+  }
+
+  @Override
+  protected void removeSpi(String key) {
+    map.remove(key);
+  }
+
+  @Override
+  protected void removeNodeSpi() throws BackingStoreException {
+    // no child nodes
+  }
+
+  @Override
+  protected String[] keysSpi() throws BackingStoreException {
+    return map.keySet().toArray(new String[map.keySet().size()]);
+  }
+
+  @Override
+  protected String[] childrenNamesSpi() throws BackingStoreException {
+    return new String[0]; // no children
+  }
+
+  @Override
+  protected AbstractPreferences childSpi(String name) {
+    return null;
+  }
+
+  @Override
+  protected void syncSpi() throws BackingStoreException {
+    // nothing to sync with
+  }
+
+  @Override
+  protected void flushSpi() throws BackingStoreException {
+    // nothing to flush to
+  }
+}

--- a/api/api.gradle.kts
+++ b/api/api.gradle.kts
@@ -15,4 +15,5 @@ dependencies {
     api(group = "eu.hansolo", name = "Medusa", version = "7.9") // Note the capital 'M' -- lowercase is a much older version!
     api(group = "com.jfoenix", name = "jfoenix", version = "9.0.8")
     api(group = "com.github.zafarkhaja", name = "java-semver", version = "0.9.0")
+    testCompile(project(":api-test-util"))
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/ExtendedPropertySheet.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/ExtendedPropertySheet.java
@@ -318,7 +318,7 @@ public class ExtendedPropertySheet extends PropertySheet {
   /**
    * An item wrapping a single {@link Setting}.
    */
-  private static class SettingsItem implements Item {
+  public static class SettingsItem implements Item {
     private final Setting<?> setting;
     private final Group group;
 

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/util/PreferencesUtilsTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/util/PreferencesUtilsTest.java
@@ -1,14 +1,12 @@
 package edu.wpi.first.shuffleboard.api.util;
 
+import edu.wpi.first.shuffleboard.api.testutil.MockPreferences;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.prefs.AbstractPreferences;
-import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 
 import javafx.beans.property.BooleanProperty;
@@ -233,61 +231,4 @@ public class PreferencesUtilsTest {
     assertEquals(initialValue, property.getValue().doubleValue());
   }
 
-  /**
-   * A mock preferences class that stores values in a {@link Map Map&lt;String, String&gt;}.
-   * This cannot have child preference nodes.
-   */
-  public static class MockPreferences extends AbstractPreferences {
-
-    private final Map<String, String> map = new HashMap<>();
-
-    public MockPreferences() {
-      super(null, "");
-    }
-
-    @Override
-    protected void putSpi(String key, String value) {
-      map.put(key, value);
-    }
-
-    @Override
-    protected String getSpi(String key) {
-      return map.get(key);
-    }
-
-    @Override
-    protected void removeSpi(String key) {
-      map.remove(key);
-    }
-
-    @Override
-    protected void removeNodeSpi() throws BackingStoreException {
-      // no child nodes
-    }
-
-    @Override
-    protected String[] keysSpi() throws BackingStoreException {
-      return map.keySet().toArray(new String[map.keySet().size()]);
-    }
-
-    @Override
-    protected String[] childrenNamesSpi() throws BackingStoreException {
-      return new String[0]; // no children
-    }
-
-    @Override
-    protected AbstractPreferences childSpi(String name) {
-      return null;
-    }
-
-    @Override
-    protected void syncSpi() throws BackingStoreException {
-      // nothing to sync with
-    }
-
-    @Override
-    protected void flushSpi() throws BackingStoreException {
-      // nothing to flush to
-    }
-  }
 }

--- a/app/app.gradle.kts
+++ b/app/app.gradle.kts
@@ -31,9 +31,7 @@ dependencies {
     compile(group = "de.huxhorn.lilith", name = "de.huxhorn.lilith.3rdparty.junique", version = "1.0.4")
     compile(group = "org.apache.commons", name = "commons-csv", version = "1.5")
     testCompile(project("test_plugins"))
-    val apiTestOutput = project(":api").dependencyProject.sourceSets["test"].output
-    testCompile(files(apiTestOutput))
-    testCompile(files(apiTestOutput.resourcesDir))
+    testCompile(project(":api-test-util"))
 }
 
 val theMainClassName = "edu.wpi.first.shuffleboard.app.Main"

--- a/app/app.gradle.kts
+++ b/app/app.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
     compile(group = "de.huxhorn.lilith", name = "de.huxhorn.lilith.3rdparty.junique", version = "1.0.4")
     compile(group = "org.apache.commons", name = "commons-csv", version = "1.5")
     testCompile(project("test_plugins"))
+    val apiTestOutput = project(":api").dependencyProject.sourceSets["test"].output
+    testCompile(files(apiTestOutput))
+    testCompile(files(apiTestOutput.resourcesDir))
 }
 
 val theMainClassName = "edu.wpi.first.shuffleboard.app.Main"

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/ExportRecordingDialog.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/ExportRecordingDialog.java
@@ -1,9 +1,15 @@
 package edu.wpi.first.shuffleboard.app.dialogs;
 
+import edu.wpi.first.shuffleboard.api.theme.Theme;
 import edu.wpi.first.shuffleboard.api.util.FxUtils;
 import edu.wpi.first.shuffleboard.api.util.LazyInit;
 import edu.wpi.first.shuffleboard.app.ConvertRecordingPaneController;
 import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
+
+import com.google.common.collect.ImmutableList;
+
+import org.fxmisc.easybind.EasyBind;
+import org.fxmisc.easybind.monadic.MonadicBinding;
 
 import javafx.scene.Scene;
 import javafx.scene.layout.Pane;
@@ -18,13 +24,15 @@ public final class ExportRecordingDialog {
   private boolean initialized = false;
   private final LazyInit<Pane> pane = LazyInit.of(() -> FxUtils.load(ConvertRecordingPaneController.class));
   private Stage stage;
+  private MonadicBinding<ImmutableList<String>> styleSheets; // NOPMD can be local field
 
   private void setup() {
+    styleSheets = EasyBind.map(AppPreferences.getInstance().themeProperty(), Theme::getStyleSheets);
     stage = new Stage();
     stage.setTitle("Export Recording Files");
     stage.setScene(new Scene(pane.get()));
     stage.setResizable(false);
-    pane.get().getStylesheets().setAll(AppPreferences.getInstance().getTheme().getStyleSheets());
+    FxUtils.bind(stage.getScene().getStylesheets(), styleSheets);
     stage.initModality(Modality.APPLICATION_MODAL);
     initialized = true;
   }

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverter.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverter.java
@@ -1,8 +1,9 @@
 package edu.wpi.first.shuffleboard.app.sources.recording;
 
 import edu.wpi.first.shuffleboard.api.data.ComplexData;
+import edu.wpi.first.shuffleboard.api.prefs.Group;
+import edu.wpi.first.shuffleboard.api.prefs.Setting;
 import edu.wpi.first.shuffleboard.api.sources.DataSourceUtils;
-import edu.wpi.first.shuffleboard.api.sources.recording.ConversionSettings;
 import edu.wpi.first.shuffleboard.api.sources.recording.Converter;
 import edu.wpi.first.shuffleboard.api.sources.recording.Marker;
 import edu.wpi.first.shuffleboard.api.sources.recording.Recording;
@@ -10,6 +11,8 @@ import edu.wpi.first.shuffleboard.api.sources.recording.RecordingEntry;
 import edu.wpi.first.shuffleboard.api.sources.recording.TimestampedData;
 import edu.wpi.first.shuffleboard.api.util.AlphanumComparator;
 import edu.wpi.first.shuffleboard.api.util.StringUtils;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
@@ -30,20 +33,30 @@ import java.util.Objects;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.IntegerProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+
+import static java.util.function.Predicate.not;
+
 public final class CsvConverter implements Converter {
 
   public static final CsvConverter Instance = new CsvConverter();
+
+  private static final Logger log = Logger.getLogger(CsvConverter.class.getName());
+  private static final String invariantViolatedMessageFormat =
+      "Invariant violated: multiple event markers for same timestamp (found: %s at entry %d of %d), for timestamp %d";
+
+  private final BooleanProperty includeMetadata = new SimpleBooleanProperty(false);
+  private final BooleanProperty fillEmpty = new SimpleBooleanProperty(false);
 
   // How far apart data points can be (in milliseconds) to group them all into a single row
   // We do this because data may be sent at the same time from the source, but high CPU usage
   // or network issues can cause them to arrive over the course of several milliseconds.
   // This value is set to be able to collate data that gets updated 100 times per second without
   // pulling data from two separate update events into a single row
-  private static final int TIME_WINDOW = 7; // milliseconds
-
-  private static final Logger log = Logger.getLogger(CsvConverter.class.getName());
-  private static final String invariantViolatedMessageFormat =
-      "Invariant violated: multiple event markers for same timestamp (found: %s at entry %d of %d), for timestamp %d";
+  private final IntegerProperty windowSize = new SimpleIntegerProperty(7);
 
   private CsvConverter() {
   }
@@ -59,30 +72,55 @@ public final class CsvConverter implements Converter {
   }
 
   @Override
-  public void export(Recording recording, Path destination, ConversionSettings settings) throws IOException {
+  public void export(Recording recording, Path destination) throws IOException {
     try (var outputStream = new FileOutputStream(destination.toFile());
          var writer = new OutputStreamWriter(outputStream, StandardCharsets.UTF_8)) {
-      writer.append(convertToCsv(recording, settings));
+      writer.append(convertToCsv(recording));
     }
+  }
+
+  @Override
+  public List<Group> getSettings() {
+    return List.of(
+        Group.of("Behavior",
+            Setting.of(
+                "Include metadata",
+                "Include metadata in the converted CSV",
+                includeMetadata,
+                Boolean.class
+            ),
+            Setting.of(
+                "Fill empty cells",
+                "Fill empty cells with the most recent data point",
+                fillEmpty,
+                Boolean.class
+            ),
+            Setting.of(
+                "Merge window",
+                "How far apart data points should be (in milliseconds) to merge into a single row",
+                windowSize,
+                Integer.class
+            )
+        )
+    );
   }
 
   /**
    * Converts recorded data to CSV text.
    *
    * @param recording the recording to convert
-   * @param settings  the conversion settings to use
    *
    * @return a CSV-formatted text string of the data in the recording
    */
   @SuppressFBWarnings(value = "UC_USELESS_OBJECT", justification = "False positive with List.forEach")
-  public String convertToCsv(Recording recording, ConversionSettings settings) {
-    List<String> header = makeHeader(recording, settings);
+  public String convertToCsv(Recording recording) {
+    List<String> header = makeHeader(recording);
     int headerSize = header.size();
     CSVFormat csvFormat = CSVFormat.DEFAULT.withHeader(header.toArray(new String[headerSize]));
 
     try (var writer = new StringWriter();
          var csvPrinter = new CSVPrinter(writer, csvFormat)) {
-      var flattenedData = Converter.flatten(recording, settings, TIME_WINDOW);
+      var flattenedData = Converter.flatten(recording, not(Converter::isMetadata), windowSize.get());
 
       var rows = flattenedData.entrySet()
           .stream()
@@ -91,6 +129,10 @@ public final class CsvConverter implements Converter {
           .filter(Objects::nonNull)
           .collect(Collectors.toList());
 
+      if (fillEmpty.get()) {
+        fillEmptyCells(rows);
+      }
+
       for (Object[] row : rows) {
         csvPrinter.printRecord(row);
       }
@@ -98,6 +140,29 @@ public final class CsvConverter implements Converter {
       return writer.toString();
     } catch (IOException e) {
       throw new IllegalStateException("Could not convert recording to CSV", e);
+    }
+  }
+
+  /**
+   * Fills in empty cells using the most recent value for the column.
+   *
+   * @param rows the rows to fill in
+   */
+  @VisibleForTesting
+  static void fillEmptyCells(List<Object[]> rows) {
+    if (rows.size() < 2) {
+      // Either empty (so no data) or only 1 row (so no data to use to fill empty cells)
+      return;
+    }
+    Object[] lastData = rows.get(0).clone();
+    for (Object[] row : rows) {
+      for (int i = 0; i < row.length; i++) {
+        if (row[i] == null) {
+          row[i] = lastData[i];
+        } else {
+          lastData[i] = row[i];
+        }
+      }
     }
   }
 
@@ -147,9 +212,9 @@ public final class CsvConverter implements Converter {
     return row;
   }
 
-  private List<String> makeHeader(Recording recording, ConversionSettings settings) {
+  private List<String> makeHeader(Recording recording) {
     List<String> header = new ArrayList<>(recording.getSourceIds());
-    if (!settings.isConvertMetadata()) {
+    if (!includeMetadata.get()) {
       header.removeIf(DataSourceUtils::isMetadata);
     }
     header.sort(AlphanumComparator.INSTANCE);

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverter.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverter.java
@@ -10,6 +10,7 @@ import edu.wpi.first.shuffleboard.api.sources.recording.Recording;
 import edu.wpi.first.shuffleboard.api.sources.recording.RecordingEntry;
 import edu.wpi.first.shuffleboard.api.sources.recording.TimestampedData;
 import edu.wpi.first.shuffleboard.api.util.AlphanumComparator;
+import edu.wpi.first.shuffleboard.api.util.PreferencesUtils;
 import edu.wpi.first.shuffleboard.api.util.StringUtils;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -31,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.logging.Logger;
+import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
 
 import javafx.beans.property.BooleanProperty;
@@ -42,7 +44,7 @@ import static java.util.function.Predicate.not;
 
 public final class CsvConverter implements Converter {
 
-  public static final CsvConverter Instance = new CsvConverter();
+  public static final CsvConverter Instance = new CsvConverter(Preferences.userNodeForPackage(CsvConverter.class));
 
   private static final Logger log = Logger.getLogger(CsvConverter.class.getName());
   private static final String invariantViolatedMessageFormat =
@@ -58,7 +60,21 @@ public final class CsvConverter implements Converter {
   // pulling data from two separate update events into a single row
   private final IntegerProperty windowSize = new SimpleIntegerProperty(7);
 
-  private CsvConverter() {
+  /**
+   * Creates a new CSV converter. This constructor is package-private for testing only; use {@link #Instance} to get
+   * a app-wide converter object.
+   *
+   * @param prefs the preferences object with which to save the converter settings
+   */
+  @VisibleForTesting
+  CsvConverter(Preferences prefs) {
+    PreferencesUtils.read(includeMetadata, prefs);
+    PreferencesUtils.read(fillEmpty, prefs);
+    PreferencesUtils.read(windowSize, prefs);
+
+    includeMetadata.addListener(__ -> PreferencesUtils.save(includeMetadata, prefs));
+    fillEmpty.addListener(__ -> PreferencesUtils.save(fillEmpty, prefs));
+    windowSize.addListener(__ -> PreferencesUtils.save(windowSize, prefs));
   }
 
   @Override

--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/ConvertRecordingPane.fxml
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/ConvertRecordingPane.fxml
@@ -13,6 +13,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 <?import org.controlsfx.control.ToggleSwitch?>
+<?import edu.wpi.first.shuffleboard.api.components.ExtendedPropertySheet?>
 <HBox xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="edu.wpi.first.shuffleboard.app.ConvertRecordingPaneController"
       fx:id="root"
@@ -56,7 +57,7 @@
                     <Label text="Convert to"/>
                     <ComboBox fx:id="formatDropdown" prefWidth="150.0" promptText="Choose format"/>
                 </HBox>
-                <ToggleSwitch text="Include metadata" fx:id="includeMetadata" selected="false"/>
+                <ExtendedPropertySheet fx:id="propertySheet" mode="CATEGORY"/>
             </VBox>
         </top>
         <center>

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverterTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverterTest.java
@@ -1,11 +1,11 @@
 package edu.wpi.first.shuffleboard.app.sources.recording;
 
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
-import edu.wpi.first.shuffleboard.api.sources.recording.ConversionSettings;
 import edu.wpi.first.shuffleboard.api.sources.recording.Marker;
 import edu.wpi.first.shuffleboard.api.sources.recording.MarkerImportance;
 import edu.wpi.first.shuffleboard.api.sources.recording.Recording;
 import edu.wpi.first.shuffleboard.api.sources.recording.TimestampedData;
+import edu.wpi.first.shuffleboard.api.util.PreferencesUtilsTest;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ public class CsvConverterTest {
 
   @BeforeEach
   public void setup() {
-    converter = CsvConverter.Instance;
+    converter = new CsvConverter(new PreferencesUtilsTest.MockPreferences());
     recording = new Recording();
   }
 

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverterTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverterTest.java
@@ -5,7 +5,7 @@ import edu.wpi.first.shuffleboard.api.sources.recording.Marker;
 import edu.wpi.first.shuffleboard.api.sources.recording.MarkerImportance;
 import edu.wpi.first.shuffleboard.api.sources.recording.Recording;
 import edu.wpi.first.shuffleboard.api.sources.recording.TimestampedData;
-import edu.wpi.first.shuffleboard.api.util.PreferencesUtilsTest;
+import edu.wpi.first.shuffleboard.api.testutil.MockPreferences;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ public class CsvConverterTest {
 
   @BeforeEach
   public void setup() {
-    converter = new CsvConverter(new PreferencesUtilsTest.MockPreferences());
+    converter = new CsvConverter(new MockPreferences());
     recording = new Recording();
   }
 

--- a/app/src/test/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverterTest.java
+++ b/app/src/test/java/edu/wpi/first/shuffleboard/app/sources/recording/CsvConverterTest.java
@@ -10,14 +10,15 @@ import edu.wpi.first.shuffleboard.api.sources.recording.TimestampedData;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CsvConverterTest {
-
-  private static final ConversionSettings WITHOUT_METADATA = new ConversionSettings(false);
 
   private static final String EMPTY_HEADER = "Timestamp,Event,Event Description,Event Severity";
 
@@ -35,7 +36,7 @@ public class CsvConverterTest {
     recording.append(new TimestampedData("foo", DataTypes.String, "bar", 0));
     recording.addMarker(new Marker("Name", "Description", MarkerImportance.CRITICAL, 4L));
 
-    String csv = converter.convertToCsv(recording, WITHOUT_METADATA);
+    String csv = converter.convertToCsv(recording);
     var lines = csv.lines().collect(Collectors.toList());
 
     assertAll(
@@ -52,13 +53,32 @@ public class CsvConverterTest {
     recording.addMarker(new Marker("Second", "", MarkerImportance.CRITICAL, 0L));
     recording.addMarker(new Marker("Third", "", MarkerImportance.NORMAL, 255));
 
-    String csv = converter.convertToCsv(recording, WITHOUT_METADATA);
+    String csv = converter.convertToCsv(recording);
     var lines = csv.lines().collect(Collectors.toList());
 
     assertAll(
         () -> assertEquals(EMPTY_HEADER, lines.get(0), "First line should be the header"),
         () -> assertEquals("0,First,,LOW", lines.get(1), "Second line should be the first marker"),
         () -> assertEquals("255,Third,,NORMAL", lines.get(2), "Third line should be the third marker")
+    );
+  }
+
+  @Test
+  public void testFillEmptyCells() {
+    var rows = List.of(
+        new Object[]{"a", "b"},
+        new Object[]{null, "b1"},
+        new Object[]{"a1", null}
+    );
+    var expected =  List.of(
+        new Object[]{"a", "b"},
+        new Object[]{"a", "b1"},
+        new Object[]{"a1", "b1"}
+    );
+    CsvConverter.fillEmptyCells(rows);
+    assertAll(
+        IntStream.range(0, 3)
+            .mapToObj(i -> () -> assertArrayEquals(expected.get(i), rows.get(i), "Row " + i))
     );
   }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 include ":api"
+include ":api-test-util"
 include ":app"
 include ":app:test_plugins"
 include "example-plugins"


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->

- Allow converters to define their own settings
- Add a CSV converter setting to fill in empty cells with the most recent value

This is a breaking change. Custom recording converters will need to be updated

Fixes #594 

