### PR TITLE
Allow widget titles to be hidden

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/PropertyParsers.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/PropertyParsers.java
@@ -25,11 +25,13 @@ public final class PropertyParsers extends Registry<PropertyParser<?>> {
   private static final PropertyParser<Number> NUMBER = new NumberPropertyParser();
   private static final PropertyParser<Boolean> BOOLEAN = new BooleanPropertyParser();
   private static final PropertyParser<Color> COLOR = new ColorPropertyParser();
+  private static final PropertyParser<TileTitleDisplayMode> TILE_DISPLAY_MODE =
+      PropertyParser.forEnum(TileTitleDisplayMode.class);
 
   private static final PropertyParsers defaultInstance = new PropertyParsers();
 
   public PropertyParsers() {
-    registerAll(BOOLEAN, COLOR, NUMBER, STRING, ORIENTATION, LABEL_POSITION);
+    registerAll(BOOLEAN, COLOR, NUMBER, STRING, ORIENTATION, LABEL_POSITION, TILE_DISPLAY_MODE);
   }
 
   public static PropertyParsers getDefault() {

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/TileTitleDisplayMode.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/TileTitleDisplayMode.java
@@ -1,0 +1,27 @@
+package edu.wpi.first.shuffleboard.api;
+
+public enum TileTitleDisplayMode {
+  /**
+   * The default tile view type - large title ad header bar.
+   */
+  DEFAULT("Default"),
+  /**
+   * Minimal tiles with smaller header bars and titles.
+   */
+  MINIMAL("Minimal"),
+  /**
+   * No header bars at all.
+   */
+  HIDDEN("Hidden");
+
+  private final String humanReadable;
+
+  TileTitleDisplayMode(String humanReadable) {
+    this.humanReadable = humanReadable;
+  }
+
+  @Override
+  public String toString() {
+    return humanReadable;
+  }
+}

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Component.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Component.java
@@ -17,7 +17,7 @@ import javafx.scene.layout.Pane;
  * an {@link ParametrizedController @ParametrizedController} annotation so that shuffleboard can know where the FXML
  * file is located.
  */
-public interface Component {
+public interface Component extends SettingsHolder {
 
   /**
    * Gets a JavaFX pane that displays this component.
@@ -48,20 +48,5 @@ public interface Component {
    * class-intrinsic.
    */
   String getName();
-
-  /**
-   * Gets the settings for this component. Settings are defined in groups. There may be arbitrarily many groups or
-   * settings per group.
-   *
-   * <p>General structure:
-   * <pre>{@code
-   * ImmutableList.of(
-   *   Group.of("Group Name",
-   *     Setting.of("Setting name", settingProperty)
-   *   )
-   * );
-   * }</pre>
-   */
-  List<Group> getSettings();
 
 }

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Component.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/Component.java
@@ -1,8 +1,5 @@
 package edu.wpi.first.shuffleboard.api.widget;
 
-import edu.wpi.first.shuffleboard.api.prefs.Group;
-
-import java.util.List;
 import java.util.stream.Stream;
 
 import javafx.beans.property.Property;

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/SettingsHolder.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/widget/SettingsHolder.java
@@ -1,0 +1,24 @@
+package edu.wpi.first.shuffleboard.api.widget;
+
+import edu.wpi.first.shuffleboard.api.prefs.Group;
+
+import java.util.List;
+
+public interface SettingsHolder {
+
+  /**
+   * Gets the settings for this component. Settings are defined in groups. There may be arbitrarily many groups or
+   * settings per group.
+   *
+   * <p>General structure:
+   * <pre>{@code
+   * List.of(
+   *   Group.of("Group Name",
+   *     Setting.of("Setting name", "Setting description", settingProperty, TypeOfSetting.class)
+   *   )
+   * );
+   * }</pre>
+   */
+  List<Group> getSettings();
+
+}

--- a/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
+++ b/api/src/main/resources/edu/wpi/first/shuffleboard/api/base.css
@@ -188,6 +188,20 @@
     -fx-background-color: -swatch-500;
 }
 
+.widget-pane:minimal-tile-titles .tile .tile-title-bar {
+    -fx-padding: -2px;
+    -fx-font-weight: none;
+    -fx-font-size: 10pt;
+}
+
+.widget-pane:no-tile-titles .tile .tile-title-bar,
+.widget-pane:no-tile-titles .tile .tile-title-bar * {
+    -fx-max-height: 0;
+    -fx-pref-height: 0;
+    -fx-min-height: 0;
+    -fx-managed: false;
+}
+
 .tile-title-bar {
     -fx-padding: 4px;
     -fx-background-color: -swatch-200;

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/MainWindowController.java
@@ -292,7 +292,7 @@ public class MainWindowController {
   private void showTabPrefs() {
     List<Category> categories = dashboard.getTabs().stream()
         .flatMap(TypeUtils.castStream(DashboardTab.class))
-        .map(DashboardTab::getSettings)
+        .map(DashboardTab::getSettingsCategory)
         .collect(Collectors.toList());
     SettingsDialog dialog = new SettingsDialog(categories);
     dialog.getDialogPane().getStylesheets().setAll(stylesheets.getValue());

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
@@ -235,8 +235,18 @@ public class DashboardTab extends Tab implements HandledTab, Populatable, Settin
         ),
         Group.of("Layout",
             Setting.of("Tile size", "The size of tiles in this tab", flushableTileSize, Double.class),
-            Setting.of("Horizontal spacing", "How far apart tiles should be, horizontally", widgetPane.hgapProperty(), Double.class),
-            Setting.of("Vertical spacing", "How far apart tiles should be, vertically", widgetPane.vgapProperty(), Double.class)
+            Setting.of(
+                "Horizontal spacing",
+                "How far apart tiles should be, horizontally",
+                widgetPane.hgapProperty(),
+                Double.class
+            ),
+            Setting.of(
+                "Vertical spacing",
+                "How far apart tiles should be, vertically",
+                widgetPane.vgapProperty(),
+                Double.class
+            )
         ),
         Group.of("Visual",
             Setting.of("Show grid", "Show the alignment grid", widgetPane.showGridProperty(), Boolean.class),

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTab.java
@@ -1,6 +1,7 @@
 package edu.wpi.first.shuffleboard.app.components;
 
 import edu.wpi.first.shuffleboard.api.Populatable;
+import edu.wpi.first.shuffleboard.api.TileTitleDisplayMode;
 import edu.wpi.first.shuffleboard.api.data.DataTypes;
 import edu.wpi.first.shuffleboard.api.prefs.Category;
 import edu.wpi.first.shuffleboard.api.prefs.FlushableProperty;
@@ -17,6 +18,7 @@ import edu.wpi.first.shuffleboard.api.util.TypeUtils;
 import edu.wpi.first.shuffleboard.api.widget.Component;
 import edu.wpi.first.shuffleboard.api.widget.ComponentContainer;
 import edu.wpi.first.shuffleboard.api.widget.Components;
+import edu.wpi.first.shuffleboard.api.widget.SettingsHolder;
 import edu.wpi.first.shuffleboard.api.widget.Sourced;
 import edu.wpi.first.shuffleboard.app.Autopopulator;
 import edu.wpi.first.shuffleboard.app.prefs.AppPreferences;
@@ -33,6 +35,7 @@ import java.util.stream.Collectors;
 
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.Property;
 import javafx.beans.property.SimpleBooleanProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.property.SimpleStringProperty;
@@ -48,42 +51,16 @@ import javafx.scene.control.Tab;
 import javafx.scene.control.TabPane;
 import javafx.scene.layout.StackPane;
 
-public class DashboardTab extends Tab implements HandledTab, Populatable {
+public class DashboardTab extends Tab implements HandledTab, Populatable, SettingsHolder {
 
   private final ObjectProperty<WidgetPane> widgetPane = new SimpleObjectProperty<>(this, "widgetPane");
   private final StringProperty title = new SimpleStringProperty(this, "title", "");
   private final BooleanProperty autoPopulate = new SimpleBooleanProperty(this, "autoPopulate", false);
   private final StringProperty sourcePrefix = new SimpleStringProperty(this, "sourcePrefix", "");
-  private final ObjectProperty<TileType> tileType = new SimpleObjectProperty<>(TileType.DEFAULT);
+  private final Property<TileTitleDisplayMode> tileType = new SimpleObjectProperty<>(TileTitleDisplayMode.DEFAULT);
 
   private static final PseudoClass MINIMAL_TITLES = PseudoClass.getPseudoClass("minimal-tile-titles");
   private static final PseudoClass HIDDEN_TITLES = PseudoClass.getPseudoClass("no-tile-titles");
-
-  public enum TileType {
-    /**
-     * The default tile view type - large title ad header bar.
-     */
-    DEFAULT("Default"),
-    /**
-     * Minimal tiles with smaller header bars and titles.
-     */
-    MINIMAL("Minimal"),
-    /**
-     * No header bars at all.
-     */
-    NO_TITLE("Hidden");
-
-    private final String humanReadable;
-
-    TileType(String humanReadable) {
-      this.humanReadable = humanReadable;
-    }
-
-    @Override
-    public String toString() {
-      return humanReadable;
-    }
-  }
 
   /**
    * Debounces populate() calls so we don't freeze the app while a source type is doing its initial discovery of
@@ -159,7 +136,7 @@ public class DashboardTab extends Tab implements HandledTab, Populatable {
           widgetPane.pseudoClassStateChanged(MINIMAL_TITLES, true);
           widgetPane.pseudoClassStateChanged(HIDDEN_TITLES, false);
           break;
-        case NO_TITLE:
+        case HIDDEN:
           widgetPane.pseudoClassStateChanged(MINIMAL_TITLES, false);
           widgetPane.pseudoClassStateChanged(HIDDEN_TITLES, true);
           break;
@@ -226,47 +203,57 @@ public class DashboardTab extends Tab implements HandledTab, Populatable {
    * Shows a dialog for editing the properties of this tab.
    */
   public void showPrefsDialog() {
-    Category category = getSettings();
-    SettingsDialog dialog = new SettingsDialog(category);
+    SettingsDialog dialog = new SettingsDialog(getSettingsCategory());
     dialog.getDialogPane().getStylesheets().setAll(AppPreferences.getInstance().getTheme().getStyleSheets());
     dialog.titleProperty().bind(EasyBind.map(this.title, t -> t + " Preferences"));
     dialog.showAndWait();
   }
 
   /**
-   * Gets the category of settings for this tab. This contains autopopulation settings, layout settings, and the tite.
+   * Gets the settings for this tab. This contains autopopulation and layout settings, as well as the title of the tab.
    */
-  public Category getSettings() {
+  @Override
+  public List<Group> getSettings() {
     // Use a flushable property here to prevent a call to populate() on every keystroke in the editor (!)
     FlushableProperty<String> flushableSourcePrefix = new FlushableProperty<>(sourcePrefix);
     WidgetPane widgetPane = getWidgetPane();
     FlushableProperty<Number> flushableTileSize = new FlushableProperty<>(widgetPane.tileSizeProperty());
-    return Category.of(getTitle(),
+    return List.of(
         Group.of("Autopopulation",
             Setting.of(
                 "Autopopulate",
                 "Sets this tab to automatically populate with widgets",
-                autoPopulate
+                autoPopulate,
+                Boolean.class
             ),
             Setting.of(
                 "Autopopulation Prefix",
                 "The prefix for data sources to autopopulate into the tab",
-                flushableSourcePrefix
+                flushableSourcePrefix,
+                String.class
             )
         ),
         Group.of("Layout",
-            Setting.of("Tile size", "The size of tiles in this tab", flushableTileSize),
-            Setting.of("Horizontal spacing", "How far apart tiles should be, horizontally", widgetPane.hgapProperty()),
-            Setting.of("Vertical spacing", "How far apart tiles should be, vertically", widgetPane.vgapProperty())
+            Setting.of("Tile size", "The size of tiles in this tab", flushableTileSize, Double.class),
+            Setting.of("Horizontal spacing", "How far apart tiles should be, horizontally", widgetPane.hgapProperty(), Double.class),
+            Setting.of("Vertical spacing", "How far apart tiles should be, vertically", widgetPane.vgapProperty(), Double.class)
         ),
         Group.of("Visual",
-            Setting.of("Show grid", "Show the alignment grid", widgetPane.showGridProperty()),
-            Setting.of("Widget titles", "How to display title bars on widgets", tileType, TileType.class)
+            Setting.of("Show grid", "Show the alignment grid", widgetPane.showGridProperty(), Boolean.class),
+            Setting.of("Widget titles", "How to display title bars on widgets", tileType, TileTitleDisplayMode.class)
         ),
         Group.of("Miscellaneous",
             Setting.of("Title", "The title of this tab", title)
         )
     );
+  }
+
+  /**
+   * Gets a category containing the settings of this tab. The category's name will be the same as the title of this
+   * tab.
+   */
+  public Category getSettingsCategory() {
+    return Category.of(getTitle(), getSettings());
   }
 
   /**
@@ -353,6 +340,18 @@ public class DashboardTab extends Tab implements HandledTab, Populatable {
 
   public void setSourcePrefix(String sourceRegex) {
     this.sourcePrefix.set(sourceRegex);
+  }
+
+  public TileTitleDisplayMode getTileType() {
+    return tileType.getValue();
+  }
+
+  public Property<TileTitleDisplayMode> tileTypeProperty() {
+    return tileType;
+  }
+
+  public void setTileType(TileTitleDisplayMode tileType) {
+    this.tileType.setValue(tileType);
   }
 
   @Override

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/PrefsDialog.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/dialogs/PrefsDialog.java
@@ -56,7 +56,7 @@ public final class PrefsDialog {
     Category tabs = Category.of("Tabs",
         tabPane.getTabs().stream()
             .flatMap(TypeUtils.castStream(DashboardTab.class))
-            .map(DashboardTab::getSettings)
+            .map(DashboardTab::getSettingsCategory)
             .collect(Collectors.toList()),
         ImmutableList.of(
             Group.of("Default Settings",


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->

Add two more title display modes: 'minimal' and 'hidden'. Minimal display reduces the size of the title bars and font, while hidden will remove title bars entirely.

Widget titles are hidden on a per-tab basis. Individual widgets have no control. This follows the existing behavior of widget titles inside layouts.

Title display modes can be modified in CSS using `.widget-pane:minimal-tile-titles` and `.widget-pane:no-tile-titles`

Closes #400
Closes #586 

Alternative to #520 

# Screenshots

### Default title display (current)
![Screenshot from 2019-04-02 17 47 15](https://user-images.githubusercontent.com/6320992/55438410-8275cd80-556f-11e9-95cd-4f41bef46416.png)

### Minimal title display
![Screenshot from 2019-04-02 17 47 27](https://user-images.githubusercontent.com/6320992/55438411-8275cd80-556f-11e9-85d3-fc1fa6317ef0.png)

### Hidden title display
![Screenshot from 2019-04-02 17 47 40](https://user-images.githubusercontent.com/6320992/55438412-8275cd80-556f-11e9-90c3-74d7b24ff161.png)
