### PR TITLE
Ignore whitespace and capitalization for remotely defined settings

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/StringUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/StringUtils.java
@@ -53,4 +53,18 @@ public final class StringUtils {
     }
   }
 
+  /**
+   * Checks if two strings are equal, ignoring capitalization and spaces. For example,
+   * {@code equalsIgnoreCaseAndWhitespace("A B C", "abc")} will return true since the only differences are in
+   * whitespace and capitalization.
+   *
+   * @param first  the first string
+   * @param second the second string
+   *
+   * @return true if the inputs are textually equal except for whitespace and capitalization
+   */
+  public static boolean equalsIgnoreCaseAndWhitespace(String first, String second) {
+    return first.replace(" ", "").equalsIgnoreCase(second.replace(" ", ""));
+  }
+
 }

--- a/api/src/test/java/edu/wpi/first/shuffleboard/api/util/StringUtilsTest.java
+++ b/api/src/test/java/edu/wpi/first/shuffleboard/api/util/StringUtilsTest.java
@@ -1,5 +1,6 @@
 package edu.wpi.first.shuffleboard.api.util;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -7,6 +8,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class StringUtilsTest {
 
@@ -33,6 +35,11 @@ public class StringUtilsTest {
   @MethodSource("containsArgs")
   public void testContainsIgnoreCase(String base, String test, boolean expectedResult) {
     assertEquals(expectedResult, StringUtils.containsIgnoreCase(base, test));
+  }
+
+  @Test
+  public void testEqualsIgnoreCaseAndWhitespace() {
+    assertTrue(StringUtils.equalsIgnoreCaseAndWhitespace("A B C", "abc"));
   }
 
   public static Stream<Arguments> containsArgs() {

--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/ProcedurallyDefinedTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/ProcedurallyDefinedTab.java
@@ -2,6 +2,7 @@ package edu.wpi.first.shuffleboard.app.components;
 
 import edu.wpi.first.shuffleboard.api.PropertyParsers;
 import edu.wpi.first.shuffleboard.api.prefs.Category;
+import edu.wpi.first.shuffleboard.api.prefs.Group;
 import edu.wpi.first.shuffleboard.api.prefs.Setting;
 import edu.wpi.first.shuffleboard.api.tab.model.ComponentModel;
 import edu.wpi.first.shuffleboard.api.tab.model.LayoutModel;
@@ -10,11 +11,13 @@ import edu.wpi.first.shuffleboard.api.tab.model.TabModel;
 import edu.wpi.first.shuffleboard.api.tab.model.WidgetModel;
 import edu.wpi.first.shuffleboard.api.util.Debouncer;
 import edu.wpi.first.shuffleboard.api.util.FxUtils;
+import edu.wpi.first.shuffleboard.api.util.StringUtils;
 import edu.wpi.first.shuffleboard.api.widget.Component;
 import edu.wpi.first.shuffleboard.api.widget.ComponentContainer;
 import edu.wpi.first.shuffleboard.api.widget.Widget;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Map;
 import java.util.WeakHashMap;
 import java.util.logging.Logger;
@@ -118,11 +121,11 @@ public class ProcedurallyDefinedTab extends DashboardTab {
   private void applySettings(Component component, Map<String, Object> properties) {
     properties.forEach((name, value) -> {
       component.getSettings().stream()
-          .map(g -> g.getSettings())
-          .flatMap(l -> l.stream())
+          .map(Group::getSettings)
+          .flatMap(Collection::stream)
           .filter(s -> s.getType() != null)
           .forEach(s -> {
-            if (s.getName().equalsIgnoreCase(name)) {
+            if (StringUtils.equalsIgnoreCaseAndWhitespace(name, s.getName())) {
               parsers.parse(value, s.getType())
                   .ifPresent(v -> ((Setting) s).setValue(v));
             }


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->
Allows component settings to be set, ignoring whitespace and capitalization. Old behavior only ignored capitalization, not whitespace. Settings can now be specified with `"Setting name"` or `"settingName"` 
