### PR TITLE
Do not cache plugins manually loaded from the default plugins directory

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/PluginPaneController.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/PluginPaneController.java
@@ -144,8 +144,11 @@ public class PluginPaneController {
     }
     files.forEach(f -> {
       try {
-        PluginLoader.getDefault().loadPluginJar(f.toURI());
-        jarUris.add(f.toURI());
+        URI jarUri = f.toURI();
+        PluginLoader.getDefault().loadPluginJar(jarUri);
+        if (!f.getParentFile().toPath().equals(Storage.getPluginPath()) && !jarUris.contains(jarUri)) {
+          jarUris.add(jarUri);
+        }
       } catch (IOException | IllegalArgumentException e) {
         log.log(Level.WARNING, "Could not load jar", e);
         // TODO improve the dialog; use something like what GRIP has


### PR DESCRIPTION
Fixes an issue where a plugin could be attempted to be loaded multiple times