### PR TITLE
fix syntax error in build.gradle.kts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,13 +71,9 @@ allprojects {
             class TrimTrailingSpaces : FormatterStep {
                 override fun getName(): String = "trimTrailingSpaces"
 
-                override fun format(rawUnix: String, file: File): String? {
-                    if (rawUnix == null || file == null) {
-                        return null
-                    }
-                    return rawUnix.split('\n')
-                            .joinToString(separator = "\n", transform = this::formatLine)
-                }
+                override fun format(rawUnix: String, file: File) = rawUnix
+                        .split('\n')
+                        .joinToString(separator = "\n", transform = this::formatLine)
 
                 fun formatLine(line: String): String {
                     if (!line.endsWith(" ")) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -71,7 +71,7 @@ allprojects {
             class TrimTrailingSpaces : FormatterStep {
                 override fun getName(): String = "trimTrailingSpaces"
 
-                override fun format(rawUnix: String?, file: File?): String? {
+                override fun format(rawUnix: String, file: File): String? {
                     if (rawUnix == null || file == null) {
                         return null
                     }


### PR DESCRIPTION
nullable rawUnix string and file were used when the signature has them
as non-nullable. Although it still compiles before, IntelliJ highlights
it as a critical error.


<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->

# Screenshots
<!-- Add screenshots of the new or fixed features, if you modified widgets or the UI -->