### PR TITLE
Fix small number handling in number fields

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/AbstractNumberField.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/AbstractNumberField.java
@@ -44,7 +44,7 @@ public abstract class AbstractNumberField<N extends Number> extends TextField {
         textProperty(),
         number,
         text -> isCompleteNumber(text) ? getNumberFromText(text) : getNumber(),
-        num -> Objects.equals(num, getNumberFromText(getText())) ? getText() : num.toString());
+        num -> Objects.equals(num, getNumberFromText(getText())) ? getText() : getTextFromNumber(num));
   }
 
   protected AbstractNumberField(N initialValue) {
@@ -71,6 +71,15 @@ public abstract class AbstractNumberField<N extends Number> extends TextField {
    * @param text the text to parse
    */
   protected abstract N getNumberFromText(String text);
+
+  /**
+   * Converts number to its text representation.
+   *
+   * @param num the number to convert
+   */
+  protected String getTextFromNumber(N num) {
+    return num.toString();
+  }
 
   public final N getNumber() {
     return number.getValue();

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/NumberField.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/NumberField.java
@@ -32,6 +32,11 @@ public class NumberField extends AbstractNumberField<Double> {
   }
 
   @Override
+  protected String getTextFromNumber(Double num) {
+    return String.format("%f", num);
+  }
+
+  @Override
   protected boolean isCompleteNumber(String text) {
     return completeFloatingPointNumber.matcher(text).matches();
   }


### PR DESCRIPTION
Double.toString() formats in scientific notation by default, which was
causing the regex to not recognize it as a valid number and thus stop updating.

Fixes #630.