### PR TITLE
Fix Number Bar properties dialog not showing (#634)

### DIFF
--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -73,7 +73,7 @@ import java.util.Set;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "Base",
-    version = "1.1.5",
+    version = "1.1.6",
     summary = "Defines all the WPILib data types and stock widgets"
 )
 @SuppressWarnings("PMD.CouplingBetweenObjects")

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/NumberBarWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/NumberBarWidget.java
@@ -15,9 +15,9 @@ import org.fxmisc.easybind.EasyBind;
 import java.util.List;
 
 import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.DoubleProperty;
+import javafx.beans.property.IntegerProperty;
 import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleDoubleProperty;
+import javafx.beans.property.SimpleIntegerProperty;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
@@ -33,7 +33,7 @@ public class NumberBarWidget extends SimpleAnnotatedWidget<Number> {
   @FXML
   private Label text;
 
-  private final DoubleProperty numTicks = new SimpleDoubleProperty(this, "numTickMarks", 5);
+  private final IntegerProperty numTicks = new SimpleIntegerProperty(this, "numTickMarks", 5);
   private final BooleanProperty showText = new SimpleBooleanProperty(this, "showText", true);
 
   @FXML


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->
Fix Number Bar properties dialog not showing when "Edit properties" is
selected in the context menu (#634). This is caused by `NumberBarWidget`
incorrectly using a `DoubleProperty` instead of an `IntegerProperty` for the
`numTickMarks` property, causing a `ClassCastException` when trying to cast
from Number to Integer when displaying the property in a dialog.

Increase the version of the base plugin from 1.1.5 to 1.1.6 as requested in the PR template.

# Screenshots
<!-- Add screenshots of the new or fixed features, if you modified widgets or the UI -->
![image](https://user-images.githubusercontent.com/32781310/69118164-653f3200-0a60-11ea-91e1-5547f4aec056.png)
