### PR TITLE
Added "Counter clockwise" option to gyro widget

### DIFF
--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -73,7 +73,7 @@ import java.util.Set;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "Base",
-    version = "1.1.6",
+    version = "1.1.7",
     summary = "Defines all the WPILib data types and stock widgets"
 )
 @SuppressWarnings("PMD.CouplingBetweenObjects")

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/GyroWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/GyroWidget.java
@@ -13,6 +13,8 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
+import javafx.beans.property.BooleanPropertyBase;
+import javafx.beans.property.Property;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
@@ -40,7 +42,8 @@ public class GyroWidget extends SimpleAnnotatedWidget<GyroData> {
         Group.of("Visuals",
             Setting.of("Major tick spacing", gauge.majorTickSpaceProperty(), Double.class),
             Setting.of("Starting angle", gauge.startAngleProperty(), Double.class),
-            Setting.of("Show tick mark ring", gauge.tickMarkRingVisibleProperty(), Boolean.class)
+            Setting.of("Show tick mark ring", gauge.tickMarkRingVisibleProperty(), Boolean.class),
+            Setting.of("Counter clockwise", createCounterClockwiseProperty(), Boolean.class)
         )
     );
   }
@@ -48,6 +51,32 @@ public class GyroWidget extends SimpleAnnotatedWidget<GyroData> {
   @Override
   public Pane getView() {
     return root;
+  }
+
+  private Property<Boolean> createCounterClockwiseProperty() {
+    return new BooleanPropertyBase() {
+      @Override
+      public boolean get() {
+        set(gauge.getScaleDirection() == Gauge.ScaleDirection.COUNTER_CLOCKWISE);
+        return super.get();
+      }
+
+      @Override
+      public void set(boolean newValue) {
+        super.set(newValue);
+        gauge.setScaleDirection(newValue ? Gauge.ScaleDirection.COUNTER_CLOCKWISE : Gauge.ScaleDirection.CLOCKWISE);
+      }
+
+      @Override
+      public Object getBean() {
+        return gauge;
+      }
+
+      @Override
+      public String getName() {
+        return "counterClockwise";
+      }
+    };
   }
 
 }


### PR DESCRIPTION
# Overview
This adds a counter-clockwise option to the GyroWidget allowing users to switch the ScaleDirection of the Gauge from CLOCKWISE to COUNTER_CLOCKWISE. I've tested that this is editable through properties sent over network tables and editable through the edit properties dialog shown below.

Our team prefers to use counter-clockwise angles to more accurately show orientation relative to the field and counter-clockwise angles better represent polar angles. With this change, it will still default to clockwise angles, but will give teams the option to choose which one they prefer best. This will especially be useful when implementing custom gyros where clockwise angles aren't natural.

# Screenshots
![image](https://user-images.githubusercontent.com/13205600/69590647-c06baa00-0fb5-11ea-9f6a-34c020f9533a.png)
![image](https://user-images.githubusercontent.com/13205600/69590783-396b0180-0fb6-11ea-8643-3a2fdda2b7de.png)


