### PR TITLE
Make SendableChooser widgets default to the Chooser's default value if no selection has been made

### DIFF
--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -73,7 +73,7 @@ import java.util.Set;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "Base",
-    version = "1.1.7",
+    version = "1.1.8",
     summary = "Defines all the WPILib data types and stock widgets"
 )
 @SuppressWarnings("PMD.CouplingBetweenObjects")

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/SendableChooserData.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/SendableChooserData.java
@@ -30,7 +30,7 @@ public final class SendableChooserData extends ComplexData<SendableChooserData> 
   public SendableChooserData(Map<String, Object> map) {
     this((String[]) map.getOrDefault(OPTIONS_KEY, new String[0]),
         (String) map.getOrDefault(DEFAULT_OPTION_KEY, ""),
-        (String) map.getOrDefault(SELECTED_OPTION_KEY, ""),
+        (String) map.getOrDefault(SELECTED_OPTION_KEY, map.getOrDefault(DEFAULT_OPTION_KEY, "")),
         (String) map.getOrDefault(ACTIVE_OPTION_KEY, ""));
   }
 


### PR DESCRIPTION
# Overview
Fix #639 by making SendableChooser widget selection default to its default value instead of empty if a selection hasn't been made. If no default is specified, it will do the old behavior of showing an empty combo/split box.

# Screenshots
[Imgur Link](https://imgur.com/a/iEUBr09)
