### PR TITLE
Use wpilib/tools/shuffleboard for config storage

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/Storage.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/Storage.java
@@ -22,7 +22,10 @@ public final class Storage {
   /**
    * The root dashboard storage directory.
    */
-  private static final String STORAGE_DIR = SystemProperties.USER_HOME + "/Shuffleboard";
+  private static final String WPILIB_VERSION = Storage.class.getPackage().getImplementationVersion().split("\\.")[0];
+  private static final String WPILIB_DIR = SystemProperties.USER_HOME + "/wpilib/" + WPILIB_VERSION;
+
+  private static final String STORAGE_DIR = WPILIB_DIR + "/tools/Shuffleboard";
 
   private static final String RECORDING_DIR = STORAGE_DIR + "/recordings";
 


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->
Make Shuffleboard store settings in `~/wpilib/<build-year>/tools/Shuffleboard` rather than in `~/Shuffleboard`.

# Screenshots
<!-- Add screenshots of the new or fixed features, if you modified widgets or the UI -->
