### PR TITLE
Fix Numeric value displayed as zero with a French environment #649

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/NumberField.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/NumberField.java
@@ -1,6 +1,9 @@
 package edu.wpi.first.shuffleboard.api.components;
 
 import java.util.regex.Pattern;
+import java.util.Locale;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 
 /**
  * A type of text field that only accepts valid floating-point decimal numbers.
@@ -9,6 +12,11 @@ public class NumberField extends AbstractNumberField<Double> {
 
   private static final Pattern startOfFloatingPointNumber = Pattern.compile("^[-+]?\\d*\\.?\\d*$");
   private static final Pattern completeFloatingPointNumber = Pattern.compile("^[-+]?\\d*\\.?\\d+$");
+  private static final DecimalFormat textFromNumberFormat = new DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+
+  static {
+    textFromNumberFormat.setMaximumFractionDigits(340);
+  }
 
   /**
    * Creates a new number field with no value.
@@ -33,7 +41,7 @@ public class NumberField extends AbstractNumberField<Double> {
 
   @Override
   protected String getTextFromNumber(Double num) {
-    return String.format("%f", num);
+    return textFromNumberFormat.format(num);
   }
 
   @Override

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/NumberField.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/NumberField.java
@@ -12,7 +12,8 @@ public class NumberField extends AbstractNumberField<Double> {
 
   private static final Pattern startOfFloatingPointNumber = Pattern.compile("^[-+]?\\d*\\.?\\d*$");
   private static final Pattern completeFloatingPointNumber = Pattern.compile("^[-+]?\\d*\\.?\\d+$");
-  private static final DecimalFormat textFromNumberFormat = new DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+  private static final DecimalFormat textFromNumberFormat =
+      new DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
   static {
     textFromNumberFormat.setMaximumFractionDigits(340);


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
Fixes the bug reported in #649. I used DecimalFormat to force the use of the English locale. The maximum fraction digits of 340 was taken from the [DecimalFormat Javadocs](https://docs.oracle.com/javase/7/docs/api/java/text/DecimalFormat.html#setMaximumFractionDigits(int)), which is the maximum allowed for double values. This allows to show only the number of digits required, instead of the default 6 that were show by `String.format()`.