### PR TITLE
Number slider with text

### DIFF
--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -73,7 +73,7 @@ import java.util.Set;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "Base",
-    version = "1.1.8",
+    version = "1.2.0",
     summary = "Defines all the WPILib data types and stock widgets"
 )
 @SuppressWarnings("PMD.CouplingBetweenObjects")

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/NumberSliderWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/NumberSliderWidget.java
@@ -10,8 +10,13 @@ import com.google.common.collect.ImmutableList;
 
 import java.util.List;
 
+import org.fxmisc.easybind.EasyBind;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+
 import javafx.fxml.FXML;
 import javafx.scene.control.Slider;
+import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
 
 @Description(
@@ -24,6 +29,10 @@ public class NumberSliderWidget extends SimpleAnnotatedWidget<Number> {
   private Pane root;
   @FXML
   private Slider slider;
+  @FXML
+  private Label text;
+
+  private final BooleanProperty showText = new SimpleBooleanProperty(this, "showText", true);
 
   @FXML
   private void initialize() {
@@ -33,6 +42,7 @@ public class NumberSliderWidget extends SimpleAnnotatedWidget<Number> {
               .subtract(slider.minProperty())
               .divide(4));
     slider.valueProperty().bindBidirectional(dataProperty());
+    text.textProperty().bind(EasyBind.map(dataOrDefault, n -> String.format("%.2f", n.doubleValue())));
   }
 
   @Override
@@ -47,7 +57,22 @@ public class NumberSliderWidget extends SimpleAnnotatedWidget<Number> {
             Setting.of("Min", slider.minProperty(), Double.class),
             Setting.of("Max", slider.maxProperty(), Double.class),
             Setting.of("Block increment", slider.blockIncrementProperty(), Double.class)
+        ),
+        Group.of("Visuals",
+            Setting.of("Display value", showText, Boolean.class)
         )
     );
+  }
+
+  public boolean isShowText() {
+    return showText.get();
+  }
+
+  public BooleanProperty showTextProperty() {
+    return showText;
+  }
+
+  public void setShowText(boolean showText) {
+    this.showText.set(showText);
   }
 }

--- a/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/NumberSliderWidget.fxml
+++ b/plugins/base/src/main/resources/edu/wpi/first/shuffleboard/plugin/base/widget/NumberSliderWidget.fxml
@@ -3,6 +3,9 @@
 <?import javafx.scene.control.Slider?>
 <?import javafx.scene.layout.BorderPane?>
 <?import javafx.scene.layout.StackPane?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.layout.VBox?>
+<?import javafx.scene.control.Label?>
 <BorderPane xmlns="http://javafx.com/javafx"
             xmlns:fx="http://javafx.com/fxml"
             fx:controller="edu.wpi.first.shuffleboard.plugin.base.widget.NumberSliderWidget"
@@ -11,7 +14,13 @@
             prefHeight="128" prefWidth="256">
     <center>
         <StackPane>
-            <Slider fx:id="slider" showTickLabels="true" min="-1" max="1" blockIncrement="0.0625"/>
+            <padding>
+                <Insets topRightBottomLeft="8"/>
+            </padding>
+            <VBox alignment="CENTER" spacing="4">
+                <Slider fx:id="slider" showTickLabels="true" min="-1" max="1" blockIncrement="0.0625"/>
+                <Label fx:id="text" visible="${controller.showText}"/>
+            </VBox>
         </StackPane>
     </center>
 </BorderPane>


### PR DESCRIPTION
# Overview
This PR allows the NumberSlider widget to display the value being specified by the slider. My team regularly uses this widget to tweak values in test mode and it's awkward to need to add an additional widget to display the value they're modifying. This by default shows the value and allows the display to be turned off via edit. Happy to swap the default if desired.

# Screenshots

<img width="831" alt="Screen Shot 2020-03-02 at 5 01 04 PM" src="https://user-images.githubusercontent.com/20/75732802-652e0f80-5ca8-11ea-96a1-69a4a455ad4b.png">


