### PR TITLE
Add encoding to javadoc task so it doesn't crash on utf-8 chars

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,7 +155,9 @@ stages:
 
     - task: PublishPipelineArtifact@0
       inputs:
+        artifactName: 'API'
         targetPath: 'api/build/libs'
     - task: PublishPipelineArtifact@0
       inputs:
+        artifactName: 'APP'
         targetPath: 'app/build/libs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -152,3 +152,10 @@ stages:
         RUN_AZURE_ARTIFACTORY_RELEASE: 'TRUE'
         ARTIFACTORY_PUBLISH_USERNAME: $(PublishUserName)
         ARTIFACTORY_PUBLISH_PASSWORD: $(PublishPassword)
+
+    - task: PublishPipelineArtifact@0
+      inputs:
+        targetPath: 'api/build/libs'
+    - task: PublishPipelineArtifact@0
+      inputs:
+        targetPath: 'app/build/libs'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -247,6 +247,7 @@ allprojects {
 
     tasks.withType<Javadoc> {
         isFailOnError = false
+        options.encoding = "UTF-8"
     }
 }
 


### PR DESCRIPTION
Closes #658 

<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->

# Screenshots
<!-- Add screenshots of the new or fixed features, if you modified widgets or the UI -->
