### PR TITLE
Increase max decimal digits in NumberField

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/components/NumberField.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/components/NumberField.java
@@ -14,6 +14,10 @@ public class NumberField extends AbstractNumberField<Double> {
   private static final Pattern completeFloatingPointNumber = Pattern.compile("^[-+]?\\d*\\.?\\d+$");
   private static final DecimalFormat textFromNumberFormat =
           new DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+  
+  static {
+    textFromNumberFormat.setMaximumFractionDigits(15);
+  }
 
   /**
    * Creates a new number field with no value.


### PR DESCRIPTION
(As discussed in #649, #650 and #671) Numbers smaller than 0.001 should be able to be displayed correctly. I believe 15 is a good compromise between 3 and 340, which could accommodate most teams' use cases.
