### PR TITLE
Bump JDK to 11.0.8

### DIFF
--- a/azure-templates/job-build-win32.yml
+++ b/azure-templates/job-build-win32.yml
@@ -19,7 +19,7 @@ jobs:
     - powershell: |
         mkdir build
         $ProgressPreference = 'SilentlyContinue'
-        wget "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.4%2B11/OpenJDK11U-jdk_x86-32_windows_hotspot_11.0.4_11.zip" -O "build\jdk.zip"
+        wget "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.8%2B10/OpenJDK11U-jdk_x86-32_windows_hotspot_11.0.8_10.zip" -O "build\jdk.zip"
       displayName: 'Download JDK'
     - task: JavaToolInstaller@0
       inputs:


### PR DESCRIPTION
Needed to fix Javadoc build errors

<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->

# Screenshots
<!-- Add screenshots of the new or fixed features, if you modified widgets or the UI -->
