### PR TITLE
Allow Analog Input to be used with TextView Widget

### DIFF
--- a/plugins/base/README.md
+++ b/plugins/base/README.md
@@ -6,7 +6,7 @@ This includes, but is not limited to:
 
 | Data type | Compatible widgets | Default widget |
 |---|---|---|
-| Analog Input | Voltage View |
+| Analog Input | Voltage View, Text View | Voltage View
 | Boolean | Boolean Box, Toggle Button, Toggle Switch, Text View | Boolean Box
 | Command | Command |
 | Number | Number Slider, Linear Indicator, Slider, Text View, Graph | Linear Indicator

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/TextViewWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/TextViewWidget.java
@@ -4,6 +4,8 @@ import edu.wpi.first.shuffleboard.api.components.NumberField;
 import edu.wpi.first.shuffleboard.api.widget.Description;
 import edu.wpi.first.shuffleboard.api.widget.ParametrizedController;
 import edu.wpi.first.shuffleboard.api.widget.SimpleAnnotatedWidget;
+import edu.wpi.first.shuffleboard.plugin.base.data.AnalogInputData;
+import edu.wpi.first.shuffleboard.plugin.base.data.types.AnalogInputType;
 
 import org.fxmisc.easybind.EasyBind;
 
@@ -18,7 +20,7 @@ import javafx.scene.layout.Pane;
     name = "Text View",
     summary = "Display a value as text",
     dataTypes = {
-        String.class, Number.class, Boolean.class
+        String.class, Number.class, Boolean.class, AnalogInputType.class
     })
 @ParametrizedController("TextViewWidget.fxml")
 public class TextViewWidget extends SimpleAnnotatedWidget<Object> {
@@ -38,12 +40,15 @@ public class TextViewWidget extends SimpleAnnotatedWidget<Object> {
           numberField.setNumber(((Number) cur).doubleValue());
         } else if (cur instanceof String || cur instanceof Boolean) {
           textField.setText(cur.toString());
+        } else if (cur instanceof AnalogInputData) {
+          numberField.setNumber(((AnalogInputData) cur).getValue());
         } else {
           throw new UnsupportedOperationException("Unsupported type: " + cur.getClass().getName());
         }
       }
     });
-    numberField.visibleProperty().bind(EasyBind.map(dataProperty(), d -> d instanceof Number).orElse(false));
+    numberField.visibleProperty().bind(EasyBind.map(dataProperty(), d -> d instanceof Number
+            || d instanceof AnalogInputData).orElse(false));
     textField.visibleProperty().bind(numberField.visibleProperty().not());
 
     textField.textProperty().addListener((__, oldText, newText) -> {
@@ -55,7 +60,17 @@ public class TextViewWidget extends SimpleAnnotatedWidget<Object> {
         setData(newText);
       }
     });
-    numberField.numberProperty().addListener((__, oldNumber, newNumber) -> setData(newNumber));
+    numberField.numberProperty().addListener((__, oldNumber, newNumber) -> {
+      if (newNumber != null) {
+        if (getData() instanceof Number || getData() instanceof String || getData() instanceof Boolean) {
+          setData(newNumber);
+        } else if (getData() instanceof AnalogInputData) {
+          //Analog inputs can't accept data
+        } else {
+          throw new UnsupportedOperationException("Unsupported type: " + getData().getClass().getName());
+        }
+      }
+    });
   }
 
   @Override


### PR DESCRIPTION


<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
Allow an Analog Input to be changed to the TextView Widget. This is better for Potentiometers, that have scaled values outside the range of 0-5.

# Screenshots
<!-- Add screenshots of the new or fixed features, if you modified widgets or the UI -->
![image](https://user-images.githubusercontent.com/4885091/97812706-fab6e000-1c37-11eb-93f0-89e2b6a609db.png)
![image](https://user-images.githubusercontent.com/4885091/97812721-1d48f900-1c38-11eb-9926-6d60d0fd9965.png)


