### PR TITLE
Move artifact from 'shuffleboard:shuffleboard' to 'tools:Shuffleboard'

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,8 +99,8 @@ allprojects {
                     } else {
                         artifact(project.shadowJar)
                     }
-                    groupId 'edu.wpi.first.shuffleboard'
-                    artifactId = 'shuffleboard'
+                    groupId 'edu.wpi.first.tools'
+                    artifactId = 'Shuffleboard'
                     version project.version
                     }
                 }


### PR DESCRIPTION
Part one of wpilibsuite/GradleRIO#390.

Where do we want the API artifact to be? Currently it's here:
https://github.com/wpilibsuite/shuffleboard/blob/71fa3489dcba6d3baff9ef7019a9b4429066d750/build.gradle#L326-L327

Is there anything else that needs to be changed?

Requesting review from @ThadHouse.