### PR TITLE
Fix isUpToDate check

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/SaveFileHandler.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/SaveFileHandler.java
@@ -139,7 +139,7 @@ public final class SaveFileHandler {
   public boolean isUpToDate(DashboardData data) {
     try {
       return JsonBuilder.forSaveFile().toJson(data).equals(Files.toString(currentFile, Charset.forName("UTF-8")));
-    } catch (IOException e) {
+    } catch (IOException | NullPointerException e) {
       return false;
     }
   }


### PR DESCRIPTION
# Overview

If there is no save file, currently the isUpToDate check throws an uncaught NullPointerException which in turn doesn't allow the user to close the app.