### PR TITLE
Handle plugins failing to load, properly handle cscore load failure

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/plugin/Plugin.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/plugin/Plugin.java
@@ -156,7 +156,7 @@ public class Plugin {
    * Called when a plugin is loaded. Defaults to do nothing; plugins that require logic to be performed when they're
    * loaded (for example, connecting to a server) should be run here.
    */
-  public void onLoad() {
+  public void onLoad() throws Exception {
     // Default to NOP
   }
 

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/CameraServerPlugin.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/CameraServerPlugin.java
@@ -58,7 +58,8 @@ public class CameraServerPlugin extends Plugin {
     } catch (IOException | UnsatisfiedLinkError ex) {
       log.log(Level.SEVERE, "Failed to load CV Libraries", ex);
       if (OsDetector.isWindows()) {
-        log.log(Level.SEVERE, "This failure is likely caused by running an N version of windows. Camera support will not work");
+        log.log(Level.SEVERE, "This failure is likely caused by running an N version of windows."
+            + " Camera support will not work");
       }
       throw ex;
     }

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/CameraServerPlugin.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/CameraServerPlugin.java
@@ -8,6 +8,7 @@ import edu.wpi.first.shuffleboard.api.plugin.Plugin;
 import edu.wpi.first.shuffleboard.api.plugin.Requires;
 import edu.wpi.first.shuffleboard.api.sources.SourceType;
 import edu.wpi.first.shuffleboard.api.sources.recording.serialization.TypeAdapter;
+import edu.wpi.first.shuffleboard.api.util.OsDetector;
 import edu.wpi.first.shuffleboard.api.widget.ComponentType;
 import edu.wpi.first.shuffleboard.api.widget.WidgetType;
 import edu.wpi.first.shuffleboard.plugin.cameraserver.data.type.CameraServerDataType;
@@ -45,18 +46,21 @@ public class CameraServerPlugin extends Plugin {
   private static final PropertyParser<Rotation> CAMERA_ROTATION = PropertyParser.forEnum(Rotation.class);
 
   @Override
-  public void onLoad() {
-    // Make sure the JNI is loaded. If it's not, this plugin can't work!
-    Loader.load(opencv_java.class);
-
+  public void onLoad() throws Exception {
     CameraServerJNI.Helper.setExtractOnStaticLoad(false);
     try {
+      // Make sure the JNI is loaded. If it's not, this plugin can't work!
+      Loader.load(opencv_java.class);
       var files = CombinedRuntimeLoader.extractLibraries(CameraServerPlugin.class,
           "/ResourceInformation-CameraServer.json");
       CombinedRuntimeLoader.loadLibrary("cscorejnicvstatic", files);
       CameraServerJNI.setTelemetryPeriod(1.0);
-    } catch (IOException ex) {
+    } catch (IOException | UnsatisfiedLinkError ex) {
       log.log(Level.SEVERE, "Failed to load CV Libraries", ex);
+      if (OsDetector.isWindows()) {
+        log.log(Level.SEVERE, "This failure is likely caused by running an N version of windows. Camera support will not work");
+      }
+      throw ex;
     }
   }
 


### PR DESCRIPTION
On N versions of windows, cscore will fail to load. Previously this would have just crashed shuffleboard. However, this doesn't always have to be the case. We can make plugin loading not hard crash, and instead just log, and let the program work as normal.
