### PR TITLE
Update example plugins to use project dependencies

### DIFF
--- a/example-plugins/custom-data-and-widget/custom-data-and-widget.gradle
+++ b/example-plugins/custom-data-and-widget/custom-data-and-widget.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly group: "edu.wpi.first.shuffleboard", name: "api", version: "2020.3.2"
+    compileOnly project(":api")
 }
 
 tasks.register("installPlugin", Copy) {

--- a/example-plugins/custom-theme/custom-theme.gradle
+++ b/example-plugins/custom-theme/custom-theme.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly group: "edu.wpi.first.shuffleboard", name: "api", version: "2020.3.2"
+    compileOnly project(":api")
 }
 
 tasks.register("installPlugin", Copy) {


### PR DESCRIPTION
Avoids the problem that NT and CS plugins aren't published (#696)
