### PR TITLE
Add all known topics on networktables client connect

### DIFF
--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
@@ -42,7 +42,7 @@ import javafx.beans.value.ChangeListener;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "NetworkTables",
-    version = "2.3.0",
+    version = "2.3.1",
     summary = "Provides sources and widgets for NetworkTables"
 )
 public class NetworkTablesPlugin extends Plugin {

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSourceType.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSourceType.java
@@ -50,14 +50,14 @@ public final class NetworkTableSourceType extends SourceType {
           availableSourceIds.clear();
           NetworkTableSource.removeAllCachedSources();
         });
-      } else if(event.is(NetworkTableEvent.Kind.kConnected)) {
+      } else if (event.is(NetworkTableEvent.Kind.kConnected)) {
         FxUtils.runOnFxThread(() -> {
-          for(Topic topic : event.getInstance().getTopics()) {
+          for (Topic topic : event.getInstance().getTopics()) {
             String uri = toUri(topic.getName());
-            if(!availableSources.containsKey(uri)) {
+            if (!availableSources.containsKey(uri)) {
               availableSources.put(uri, topic.genericSubscribe().get().getValue());
             }
-            if(!availableSourceIds.contains(uri)) {
+            if (!availableSourceIds.contains(uri)) {
               availableSourceIds.add(uri);
             }
           }

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSourceType.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSourceType.java
@@ -16,6 +16,7 @@ import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableEvent;
 import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.Topic;
 
 import java.util.EnumSet;
 import java.util.List;
@@ -48,6 +49,18 @@ public final class NetworkTableSourceType extends SourceType {
           availableSources.clear();
           availableSourceIds.clear();
           NetworkTableSource.removeAllCachedSources();
+        });
+      } else if(event.is(NetworkTableEvent.Kind.kConnected)) {
+        FxUtils.runOnFxThread(() -> {
+          for(Topic topic : event.getInstance().getTopics()) {
+            String uri = toUri(topic.getName());
+            if(!availableSources.containsKey(uri)) {
+              availableSources.put(uri, topic.genericSubscribe().get().getValue());
+            }
+            if(!availableSourceIds.contains(uri)) {
+              availableSourceIds.add(uri);
+            }
+          }
         });
       }
     });


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
<!-- What does this pull request do? -->
Fixes issue #751 by re-adding all known topics when reconnecting to the networktables server.

# Screenshots
N/A
