### PR TITLE
Create tabs for root tables

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/ProcedurallyDefinedTab.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/ProcedurallyDefinedTab.java
@@ -108,7 +108,7 @@ public class ProcedurallyDefinedTab extends DashboardTab {
           continue;
         }
         component.setTitle(componentModel.getTitle());
-        if (componentModel instanceof WidgetModel) {
+        if (component instanceof Widget && componentModel instanceof WidgetModel) {
           ((Widget) component).addSource(((WidgetModel) componentModel).getDataSource());
         }
         proceduralComponents.put(componentModel, component);

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -81,7 +81,7 @@ import java.util.prefs.Preferences;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "Base",
-    version = "1.3.6",
+    version = "1.3.7",
     summary = "Defines all the WPILib data types and stock widgets"
 )
 @SuppressWarnings("PMD.CouplingBetweenObjects")
@@ -221,10 +221,7 @@ public class BasePlugin extends Plugin {
 
   @Override
   public List<TabInfo> getDefaultTabInfo() {
-    return ImmutableList.of(
-        TabInfo.builder().name("SmartDashboard").autoPopulate().sourcePrefix("SmartDashboard/").build(),
-        TabInfo.builder().name("LiveWindow").autoPopulate().sourcePrefix("LiveWindow/").build()
-    );
+    return ImmutableList.of();
   }
 
   @Override

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -81,7 +81,7 @@ import java.util.prefs.Preferences;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "Base",
-    version = "1.3.5",
+    version = "1.3.6",
     summary = "Defines all the WPILib data types and stock widgets"
 )
 @SuppressWarnings("PMD.CouplingBetweenObjects")

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/fms/FmsInfo.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/fms/FmsInfo.java
@@ -64,14 +64,14 @@ public final class FmsInfo extends ComplexData<FmsInfo> {
    */
   public FmsInfo(Map<String, Object> map) {
     this(
-        Maps.get(map, GAME_SPECIFIC_MESSAGE),
-        Maps.get(map, EVENT_NAME),
-        Maps.<String, Number>get(map, MATCH_NUMBER).intValue(),
-        Maps.<String, Number>get(map, REPLAY_NUMBER).intValue(),
-        MatchType.fromOrdinal(Maps.<String, Number>get(map, MATCH_TYPE).intValue()),
-        Maps.<String, Boolean>get(map, IS_RED_ALLIANCE) ? Alliance.RED : Alliance.BLUE,
-        Maps.<String, Number>get(map, STATION_NUMBER).intValue(),
-        ControlWord.fromBits(Maps.<String, Number>get(map, FMS_CONTROL_DATA).intValue())
+        Maps.getOrDefault(map, GAME_SPECIFIC_MESSAGE, ""),
+        Maps.getOrDefault(map, EVENT_NAME, ""),
+        Maps.<String, Object, Number>getOrDefault(map, MATCH_NUMBER, 0).intValue(),
+        Maps.<String, Object, Number>getOrDefault(map, REPLAY_NUMBER, 0).intValue(),
+        MatchType.fromOrdinal(Maps.<String, Object, Number>getOrDefault(map, MATCH_TYPE, MatchType.NONE.ordinal()).intValue()),
+        Maps.<String, Object, Boolean>getOrDefault(map, IS_RED_ALLIANCE, true) ? Alliance.RED : Alliance.BLUE,
+        Maps.<String, Object, Number>getOrDefault(map, STATION_NUMBER, 1).intValue(),
+        ControlWord.fromBits(Maps.<String, Object, Number>getOrDefault(map, FMS_CONTROL_DATA, 0).intValue())
     );
   }
 

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/fms/FmsInfo.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/fms/FmsInfo.java
@@ -68,7 +68,8 @@ public final class FmsInfo extends ComplexData<FmsInfo> {
         Maps.getOrDefault(map, EVENT_NAME, ""),
         Maps.<String, Object, Number>getOrDefault(map, MATCH_NUMBER, 0).intValue(),
         Maps.<String, Object, Number>getOrDefault(map, REPLAY_NUMBER, 0).intValue(),
-        MatchType.fromOrdinal(Maps.<String, Object, Number>getOrDefault(map, MATCH_TYPE, MatchType.NONE.ordinal()).intValue()),
+        MatchType.fromOrdinal(Maps.<String, Object, Number>getOrDefault(map, MATCH_TYPE,
+                        MatchType.NONE.ordinal()).intValue()),
         Maps.<String, Object, Boolean>getOrDefault(map, IS_RED_ALLIANCE, true) ? Alliance.RED : Alliance.BLUE,
         Maps.<String, Object, Number>getOrDefault(map, STATION_NUMBER, 1).intValue(),
         ControlWord.fromBits(Maps.<String, Object, Number>getOrDefault(map, FMS_CONTROL_DATA, 0).intValue())

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
@@ -42,7 +42,7 @@ import javafx.beans.value.ChangeListener;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "NetworkTables",
-    version = "2.3.1",
+    version = "2.4.1",
     summary = "Provides sources and widgets for NetworkTables"
 )
 public class NetworkTablesPlugin extends Plugin {


### PR DESCRIPTION
Create tabs based on root tables, not only those inside `/Shuffleboard/`. This is a prerequisite for #760, and is already rebased on #766.
Also removed the default LiveWindow and SmartDashboard tables; these will be created from their NT tables if those exist. (Though an empty LW tab appears to always be created due to the always-present `.status/` "hidden" subtable.)