### PR TITLE
Don't switch to selected tab on value change

### DIFF
--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
@@ -42,7 +42,7 @@ import javafx.beans.value.ChangeListener;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "NetworkTables",
-    version = "2.3.1",
+    version = "2.3.2",
     summary = "Provides sources and widgets for NetworkTables"
 )
 public class NetworkTablesPlugin extends Plugin {

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGenerator.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGenerator.java
@@ -206,16 +206,12 @@ final class TabGenerator {
           .takeWhile(s -> !s.contains("/."))
           .collect(Collectors.toList());
       if (tables.size() >= 3) {
-        updateFrom(tables);
+        updateStructure(tables);
+        tabs.dirty();
       }
       return;
     }
-    updateFrom(hierarchy);
-  }
-
-  private void updateFrom(List<String> tables) {
-    updateStructure(tables);
-    tabs.dirty();
+    updateStructure(hierarchy);
   }
 
   private void updateStructure(List<String> hierarchy) {


### PR DESCRIPTION
Fixes #745

For some reason, the tab structure listeners were called also on value changes (and not just metadata changes). I've done some testing to ensure this doesn't break functionality, but I may have missed something.