### PR TITLE
Fix IndexOutOfBoundsException in tab setup

### DIFF
--- a/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
+++ b/app/src/main/java/edu/wpi/first/shuffleboard/app/components/DashboardTabPane.java
@@ -45,7 +45,7 @@ public class DashboardTabPane extends TabPane {
       for (TabModel model : tabs.getTabs().values()) {
         var tab = realTabs.computeIfAbsent(model, m -> new ProcedurallyDefinedTab(m, PropertyParsers.getDefault()));
         if (!getTabs().contains(tab)) {
-          getTabs().add(getTabs().size() - 1, tab);
+          getTabs().add(tab);
         }
         tab.populate();
       }


### PR DESCRIPTION
This would occasionally throw exceptions when `getTabs().size() == 0`.