### PR TITLE
Use ConcurrentHashMap for static collection of NT sources

### DIFF
--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/NetworkTablesPlugin.java
@@ -42,7 +42,7 @@ import javafx.beans.value.ChangeListener;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "NetworkTables",
-    version = "2.3.1",
+    version = "2.3.2",
     summary = "Provides sources and widgets for NetworkTables"
 )
 public class NetworkTablesPlugin extends Plugin {

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSource.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSource.java
@@ -14,9 +14,9 @@ import edu.wpi.first.networktables.NetworkTableEvent;
 import edu.wpi.first.networktables.NetworkTableInstance;
 
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A source for data in network tables. Data can be a single value or a map of keys to values.
@@ -28,7 +28,7 @@ import java.util.Optional;
  */
 public abstract class NetworkTableSource<T> extends AbstractDataSource<T> {
 
-  private static final Map<String, NetworkTableSource> sources = new HashMap<>();
+  private static final Map<String, NetworkTableSource> sources = new ConcurrentHashMap<>();
 
   protected final String fullTableKey;
   private int listenerUid = -1;


### PR DESCRIPTION
Might fix #770?
Seems like a very small/simple fix, but on the other hand this may be what's happening: the relevant exception in the log [here](https://github.com/wpilibsuite/shuffleboard/issues/770#issuecomment-1485491710) is a ConcurrentModificationException on this collection.

Not sure why this would break all sources, though. Maybe the CME is interrupting an iteration?