### PR TITLE
CameraServerWidget: Explicitly unbox Number objects

### DIFF
--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/CameraServerPlugin.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/CameraServerPlugin.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "CameraServer",
-    version = "3.1.0",
+    version = "3.1.1",
     summary = "Provides sources and widgets for viewing CameraServer MJPEG streams"
 )
 @Requires(group = "edu.wpi.first.shuffleboard", name = "NetworkTables", minVersion = "2.0.0")

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.java
@@ -157,14 +157,16 @@ public class CameraServerWidget extends SimpleAnnotatedWidget<CameraServerData> 
     return root;
   }
 
+  @SuppressWarnings("UnnecessaryUnboxing")
   @FXML
   private void applySettings() {
     if (getSource() instanceof CameraServerSource) {
       CameraServerSource source = (CameraServerSource) getSource();
       int compression = (int) compressionSlider.getValue();
-      int fps = frameRateField.getNumber();
-      int width = this.width.getNumber();
-      int height = this.height.getNumber();
+      // Gson uses an internal subclass of Number that can't be implicitly cast to Integer
+      int fps = frameRateField.getNumber().intValue();
+      int width = this.width.getNumber().intValue();
+      int height = this.height.getNumber().intValue();
       boolean change = source.getTargetCompression() != compression
           || source.getTargetFps() != fps
           || source.getTargetResolution().isNotEqual(width, height);

--- a/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.java
+++ b/plugins/cameraserver/src/main/java/edu/wpi/first/shuffleboard/plugin/cameraserver/widget/CameraServerWidget.java
@@ -157,16 +157,17 @@ public class CameraServerWidget extends SimpleAnnotatedWidget<CameraServerData> 
     return root;
   }
 
-  @SuppressWarnings("UnnecessaryUnboxing")
   @FXML
   private void applySettings() {
     if (getSource() instanceof CameraServerSource) {
       CameraServerSource source = (CameraServerSource) getSource();
       int compression = (int) compressionSlider.getValue();
-      // Gson uses an internal subclass of Number that can't be implicitly cast to Integer
-      int fps = frameRateField.getNumber().intValue();
-      int width = this.width.getNumber().intValue();
-      int height = this.height.getNumber().intValue();
+      // Gson uses an internal subclass of Number that can't be implicitly cast to Integer,
+      // and Java *really* likes implicitly casting to Integer,
+      // so we need to explcitly cast to Number.
+      int fps = ((Number) frameRateField.getNumber()).intValue();
+      int width = ((Number) this.width.getNumber()).intValue();
+      int height = ((Number) this.height.getNumber()).intValue();
       boolean change = source.getTargetCompression() != compression
           || source.getTargetFps() != fps
           || source.getTargetResolution().isNotEqual(width, height);


### PR DESCRIPTION
Fixes #773.
This fixes a CCE caused by trying to implicitly cast a Gson internal subclass of Number to an `int`.