### PR TITLE
Correct FieldData de/serialization

### DIFF
--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/FieldData.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/FieldData.java
@@ -65,7 +65,7 @@ public class FieldData extends ComplexData<FieldData> {
       if (value instanceof double[]) {
         // Intended flow
         doubles = (double[]) value;
-      } else if (entry.getValue() instanceof byte[]) {
+      } else if (value instanceof byte[]) {
         // double[] encoded as byte[] is supported too (for some reason)
         byte[] data = (byte[]) value;
         doubles = new double[data.length / Double.BYTES];

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/FieldData.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/data/FieldData.java
@@ -104,6 +104,8 @@ public class FieldData extends ComplexData<FieldData> {
 
   @Override
   public Map<String, Object> asMap() {
-    return ImmutableMap.of("Robot", robot);
+    HashMap<String, SimplePose2d[]> tmp = new HashMap<>(getObjects());
+    tmp.put("Robot", new SimplePose2d[]{getRobot()});
+    return ImmutableMap.copyOf(tmp);
   }
 }


### PR DESCRIPTION
The first commit fixes #797
The second commit is a bug I saw and decided to fix on the way

--- 

The fix here is to explicitly check for the type being `double[]` and warning+dropping if not, rather than unsafely casting which leads to CCEs like #797 in cases where there's unrelated data in that table.