### PR TITLE
Expose orientation property for NumberSlider

### DIFF
--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/BasePlugin.java
@@ -81,7 +81,7 @@ import java.util.prefs.Preferences;
 @Description(
     group = "edu.wpi.first.shuffleboard",
     name = "Base",
-    version = "1.3.6",
+    version = "1.3.7",
     summary = "Defines all the WPILib data types and stock widgets"
 )
 @SuppressWarnings("PMD.CouplingBetweenObjects")

--- a/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/NumberSliderWidget.java
+++ b/plugins/base/src/main/java/edu/wpi/first/shuffleboard/plugin/base/widget/NumberSliderWidget.java
@@ -11,13 +11,16 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 
 import org.fxmisc.easybind.EasyBind;
+import javafx.beans.property.Property;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleObjectProperty;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Slider;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Pane;
+import javafx.geometry.Orientation;
 
 @Description(
     name = "Number Slider",
@@ -33,6 +36,8 @@ public class NumberSliderWidget extends SimpleAnnotatedWidget<Number> {
   private Label text;
 
   private final BooleanProperty showText = new SimpleBooleanProperty(this, "showText", true);
+  private final Property<Orientation> orientation =
+      new SimpleObjectProperty<>(this, "orientation", Orientation.HORIZONTAL);
 
   @FXML
   private void initialize() {
@@ -43,6 +48,7 @@ public class NumberSliderWidget extends SimpleAnnotatedWidget<Number> {
               .divide(4));
     slider.valueProperty().bindBidirectional(dataProperty());
     text.textProperty().bind(EasyBind.map(dataOrDefault, n -> String.format("%.2f", n.doubleValue())));
+    slider.orientationProperty().bind(orientation);
   }
 
   @Override
@@ -59,7 +65,8 @@ public class NumberSliderWidget extends SimpleAnnotatedWidget<Number> {
             Setting.of("Block increment", slider.blockIncrementProperty(), Double.class)
         ),
         Group.of("Visuals",
-            Setting.of("Display value", showText, Boolean.class)
+            Setting.of("Display value", showText, Boolean.class),
+            Setting.of("Orientation", orientation, Orientation.class)
         )
     );
   }


### PR DESCRIPTION
<!--
If you have modified classes in a plugin (plugins/base, plugins/cameraserver, etc.),
make sure you have updated the version of the plugin in the @Description annotation on the plugin class
-->

# Overview
This exposes the Orientation option present in numberBar in the numberSlider widget.

# Screenshots
<img width="1240" alt="image" src="https://github.com/wpilibsuite/shuffleboard/assets/5223761/c5222166-f12f-408d-9058-0fad86b9fe56">

