### PR TITLE
Fix network tables

### DIFF
--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/FxUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/FxUtils.java
@@ -44,7 +44,7 @@ public final class FxUtils {
   private static final Object FX_CONTROLLER_KEY = new Object();
 
   private static final ScheduledExecutorService laterScheduler =
-          Executors.newSingleThreadScheduledExecutor((runnable) -> {
+          Executors.newSingleThreadScheduledExecutor(runnable -> {
             var thread = new Thread(runnable);
             thread.setDaemon(true);
             thread.setName("Shuffleboard Run Later Scheduler");

--- a/api/src/main/java/edu/wpi/first/shuffleboard/api/util/FxUtils.java
+++ b/api/src/main/java/edu/wpi/first/shuffleboard/api/util/FxUtils.java
@@ -4,9 +4,14 @@ import edu.wpi.first.shuffleboard.api.sources.DataSource;
 import edu.wpi.first.shuffleboard.api.widget.ParametrizedController;
 
 import java.io.IOException;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import javafx.application.Platform;
@@ -38,6 +43,14 @@ public final class FxUtils {
 
   private static final Object FX_CONTROLLER_KEY = new Object();
 
+  private static final ScheduledExecutorService laterScheduler =
+          Executors.newSingleThreadScheduledExecutor((runnable) -> {
+            var thread = new Thread(runnable);
+            thread.setDaemon(true);
+            thread.setName("Shuffleboard Run Later Scheduler");
+            return thread;
+          });
+
   private FxUtils() {
     throw new UnsupportedOperationException("This is a utility class!");
   }
@@ -66,6 +79,15 @@ public final class FxUtils {
       });
     }
     return future;
+  }
+
+  /**
+   * Runs a task on the platform thread at some point in the future.
+   * @param task the task to run
+   * @param delay how far in the future the task should run
+   */
+  public static void runLater(Runnable task, Duration delay) {
+    laterScheduler.schedule(() -> runOnFxThread(task), delay.get(ChronoUnit.NANOS), TimeUnit.NANOSECONDS);
   }
 
   /**

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGenerator.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGenerator.java
@@ -102,7 +102,7 @@ final class TabGenerator {
         });
 
     metadataSubscriber =
-        new MultiSubscriber(inst, new String[] {METADATA_TABLE_NAME + "/"}, PubSubOption.sendAll(true));
+        new MultiSubscriber(inst, new String[] {METADATA_TABLE_NAME + "/"});
     metadataListener = inst.addListener(
         metadataSubscriber,
         EnumSet.of(NetworkTableEvent.Kind.kValueAll, NetworkTableEvent.Kind.kImmediate),

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGenerator.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/TabGenerator.java
@@ -102,12 +102,12 @@ final class TabGenerator {
         });
 
     metadataSubscriber =
-        new MultiSubscriber(inst, new String[] {METADATA_TABLE_NAME + "/"}, PubSubOption.hidden(true));
+        new MultiSubscriber(inst, new String[] {METADATA_TABLE_NAME + "/"}, PubSubOption.sendAll(true));
     metadataListener = inst.addListener(
         metadataSubscriber,
         EnumSet.of(NetworkTableEvent.Kind.kValueAll, NetworkTableEvent.Kind.kImmediate),
         this::metadataChanged);
-    dataSubscriber = new MultiSubscriber(inst, new String[] {ROOT_TABLE_NAME + "/"}, PubSubOption.hidden(true));
+    dataSubscriber = new MultiSubscriber(inst, new String[] {ROOT_TABLE_NAME + "/"});
     dataListener = inst.addListener(
         dataSubscriber,
         EnumSet.of(NetworkTableEvent.Kind.kValueAll, NetworkTableEvent.Kind.kImmediate),

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/CompositeNetworkTableSource.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/CompositeNetworkTableSource.java
@@ -47,7 +47,7 @@ public class CompositeNetworkTableSource<D extends ComplexData<D>> extends Netwo
     setData(dataType.getDefaultValue());
 
     setTableListener((key, event) -> {
-      String relativeKey = NetworkTable.normalizeKey(key.substring(path.length() + 1), false);
+      String relativeKey = NetworkTable.basenameKey(key);
       if (event.is(NetworkTableEvent.Kind.kUnpublish)) {
         backingMap.remove(relativeKey);
       } else if (event.valueData != null) {

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSource.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSource.java
@@ -16,6 +16,7 @@ import edu.wpi.first.networktables.NetworkTableEvent;
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.PubSubOption;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.Map;
@@ -73,7 +74,19 @@ public abstract class NetworkTableSource<T> extends AbstractDataSource<T> {
     }
     setConnected(true);
     if (isSingular()) {
-      singleSub = inst.getTopic(fullTableKey).genericSubscribe(PubSubOption.hidden(false), PubSubOption.sendAll(true));
+      // Handle leading slashes. Topic names are exact and do no normalization
+      String topicName;
+      if (Arrays.stream(inst.getTopicInfo()).anyMatch(t -> t.name.equals(fullTableKey))) {
+        topicName = fullTableKey;
+      } else {
+        if (fullTableKey.startsWith("/")) {
+          topicName = NetworkTable.normalizeKey(fullTableKey, false);
+        } else {
+          topicName = NetworkTable.normalizeKey(fullTableKey, true);
+        }
+      }
+
+      singleSub = inst.getTopic(topicName).genericSubscribe(PubSubOption.hidden(false), PubSubOption.sendAll(true));
       listenerUid = inst.addListener(
         singleSub,
         EnumSet.of(
@@ -197,7 +210,7 @@ public abstract class NetworkTableSource<T> extends AbstractDataSource<T> {
    */
   @SuppressWarnings("unchecked")
   public static DataSource<?> forKey(String fullTableKey) {
-    String key = NetworkTable.normalizeKey(fullTableKey, false);
+    String key = fullTableKey;
     final String uri = NetworkTableSourceType.getInstance().toUri(key);
     return sources.computeIfAbsent(uri, __ -> {
       DataType<?> lookup = NetworkTableUtils.dataTypeForEntry(key);

--- a/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSource.java
+++ b/plugins/networktables/src/main/java/edu/wpi/first/shuffleboard/plugin/networktables/sources/NetworkTableSource.java
@@ -17,7 +17,6 @@ import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.PubSubOption;
 
 import java.util.Arrays;
-import java.util.Comparator;
 import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;


### PR DESCRIPTION
# Overview

Fixes several bugs related to networktables:

- NT-based tab generation not working, due to values in the metadata topics not being subscribed to (fixes #813)
- Complex widgets rendering as generic tables when the data type metadata arrives late (fixes #814)
- Sources unable to be added to a tab from the sources tree when their topics hadn't had their values loaded
- Data sources for topics without leading slashes never having data (this was due to assumptions based on NT3 table structuring that no longer hold with NT4)