### PR TITLE
Add deprecated message to footer

### DIFF
--- a/app/src/main/resources/edu/wpi/first/shuffleboard/app/MainWindow.fxml
+++ b/app/src/main/resources/edu/wpi/first/shuffleboard/app/MainWindow.fxml
@@ -9,6 +9,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.layout.BorderPane?>
+<?import javafx.scene.text.Text ?>
 <VBox fx:id="root" maxHeight="Infinity" maxWidth="Infinity"
       xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1"
       fx:controller="edu.wpi.first.shuffleboard.app.MainWindowController">
@@ -54,6 +55,7 @@
         <padding>
             <Insets topRightBottomLeft="4"/>
         </padding>
+        <left><Text text="Warning: Shuffleboard is deprecated" fill="red"/></left>
         <center>
             <fx:include source="PlaybackControls.fxml"/>
         </center>


### PR DESCRIPTION
Since dashboards are opened a lot more then Pathweaver or Robotbuilder, I didn't want to make a pop-up that had to be dismissed every time it was used.

# Screenshots
<img width="942" height="711" alt="image" src="https://github.com/user-attachments/assets/540807f0-5637-4d9a-9573-3841df1ac074" />
